### PR TITLE
Add Context Runtime layer: SessionState, TokenBudget, PromptBuilder, ContextManager

### DIFF
--- a/Desktop/HermesDesktop/HermesDesktop.csproj
+++ b/Desktop/HermesDesktop/HermesDesktop.csproj
@@ -8,7 +8,6 @@
     <Platform>x64</Platform>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <UseWinUI>true</UseWinUI>
-    <WinUISDKReferences>false</WinUISDKReferences>
     <EnableMsixTooling>true</EnableMsixTooling>
     <WindowsAppSdkDeploymentManagerInitialize>false</WindowsAppSdkDeploymentManagerInitialize>
     <Nullable>enable</Nullable>
@@ -33,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="*" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="*" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250401003" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Context/ContextManager.cs
+++ b/src/Context/ContextManager.cs
@@ -63,11 +63,12 @@ public sealed class ContextManager
         var recentTurns = _budget.TrimToRecentWindow(allMessages);
         var evictedMessages = _budget.GetEvictedMessages(allMessages);
 
-        // Estimate current token usage
+        // Estimate current token usage (all layers that will be sent)
+        var systemTokens = _budget.EstimateTokens(_promptBuilder.SystemPrompt);
         var stateTokens = state.EstimateTokens();
         var recentTokens = _budget.EstimateTokens(recentTurns);
         var userTokens = _budget.EstimateTokens(userMessage);
-        var totalTokens = stateTokens + recentTokens + userTokens;
+        var totalTokens = systemTokens + stateTokens + recentTokens + userTokens;
 
         var pressure = _budget.GetPressure(totalTokens);
 

--- a/src/Context/ContextManager.cs
+++ b/src/Context/ContextManager.cs
@@ -214,8 +214,7 @@ public sealed class ContextManager
     public void EvictState(string sessionId)
     {
         _sessionStates.TryRemove(sessionId, out _);
-        if (_sessionLocks.TryRemove(sessionId, out var semaphore))
-            semaphore.Dispose();
+        _sessionLocks.TryRemove(sessionId, out _);
     }
 
     /// <summary>

--- a/src/Context/ContextManager.cs
+++ b/src/Context/ContextManager.cs
@@ -212,7 +212,7 @@ public sealed class ContextManager
         {
             var summary = await _chatClient.CompleteAsync(summarizePrompt, ct);
             state.Summary.Content = summary.Trim();
-            state.Summary.CoveredThroughTurn = state.TurnCount - 1;
+            state.Summary.CoveredThroughTurn = Math.Max(0, state.TurnCount - 1);
 
             _logger.LogInformation(
                 "Summarized {Count} evicted messages into {Tokens} est. tokens",

--- a/src/Context/ContextManager.cs
+++ b/src/Context/ContextManager.cs
@@ -214,7 +214,6 @@ public sealed class ContextManager
     public void EvictState(string sessionId)
     {
         _sessionStates.TryRemove(sessionId, out _);
-        _sessionLocks.TryRemove(sessionId, out _);
     }
 
     /// <summary>

--- a/src/Context/ContextManager.cs
+++ b/src/Context/ContextManager.cs
@@ -90,17 +90,20 @@ public sealed class ContextManager
                 "Context budget: {Total}/{Max} tokens ({Pressure}), {Recent} recent, {Evicted} evicted",
                 totalTokens, _budget.MaxTokens, pressure, recentTurns.Count, evictedMessages.Count);
 
-            // Summarize evicted messages if we have any and need to
-            if (evictedMessages.Count > 0 && pressure >= BudgetPressure.High)
+            // Summarize evicted messages only when the summary is behind the current turn
+            var needsSummary = evictedMessages.Count > 0
+                && state.Summary.CoveredThroughTurn < state.TurnCount;
+
+            if (needsSummary && pressure >= BudgetPressure.High)
             {
                 await SummarizeEvictedAsync(state, evictedMessages, ct);
             }
-            else if (evictedMessages.Count > 0 && string.IsNullOrEmpty(state.Summary.Content))
+            else if (needsSummary && string.IsNullOrEmpty(state.Summary.Content))
             {
                 // First time we evict messages — create initial summary
                 await SummarizeEvictedAsync(state, evictedMessages, ct);
             }
-            else if (evictedMessages.Count > 0 && IsSummaryStaleBeyond(state, turnsStalenessThreshold: 10))
+            else if (needsSummary && IsSummaryStaleBeyond(state, turnsStalenessThreshold: 10))
             {
                 // Summary is stale — re-summarize to capture recent evictions
                 await SummarizeEvictedAsync(state, evictedMessages, ct);

--- a/src/Context/ContextManager.cs
+++ b/src/Context/ContextManager.cs
@@ -106,8 +106,13 @@ public sealed class ContextManager
                 await SummarizeEvictedAsync(state, evictedMessages, ct);
             }
 
+            // Recompute pressure after summarization may have grown state.Summary
+            var postSummarizeStateTokens = state.EstimateTokens();
+            var postTotalTokens = systemTokens + postSummarizeStateTokens + recentTokens + retrievedTokens + userTokens;
+            var postPressure = _budget.GetPressure(postTotalTokens);
+
             // Under critical pressure, compact the state itself
-            if (pressure == BudgetPressure.Critical)
+            if (postPressure == BudgetPressure.Critical)
             {
                 state.Compact(maxDecisions: 5, maxQuestions: 3, maxEntities: 10);
                 _logger.LogWarning("Critical budget pressure — compacted session state");

--- a/src/Context/ContextManager.cs
+++ b/src/Context/ContextManager.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Hermes.Agent.Core;
 using Hermes.Agent.LLM;
 using Hermes.Agent.Transcript;
@@ -20,7 +21,7 @@ public sealed class ContextManager
     private readonly PromptBuilder _promptBuilder;
     private readonly ILogger<ContextManager> _logger;
 
-    private readonly Dictionary<string, SessionState> _sessionStates = new();
+    private readonly ConcurrentDictionary<string, SessionState> _sessionStates = new();
 
     public ContextManager(
         TranscriptStore transcripts,
@@ -54,10 +55,13 @@ public sealed class ContextManager
         CancellationToken ct)
     {
         var state = GetOrCreateState(sessionId);
-        state.TurnCount++;
 
-        // Load full transcript from archive
-        var allMessages = await _transcripts.LoadSessionAsync(sessionId, ct);
+        // Load transcript from archive — empty list for brand-new sessions
+        List<Message> allMessages;
+        if (_transcripts.SessionExists(sessionId))
+            allMessages = await _transcripts.LoadSessionAsync(sessionId, ct);
+        else
+            allMessages = new List<Message>();
 
         // Split into recent window and evicted older messages
         var recentTurns = _budget.TrimToRecentWindow(allMessages);
@@ -67,8 +71,9 @@ public sealed class ContextManager
         var systemTokens = _budget.EstimateTokens(_promptBuilder.SystemPrompt);
         var stateTokens = state.EstimateTokens();
         var recentTokens = _budget.EstimateTokens(recentTurns);
+        var retrievedTokens = EstimateRetrievedContextTokens(retrievedContext);
         var userTokens = _budget.EstimateTokens(userMessage);
-        var totalTokens = systemTokens + stateTokens + recentTokens + userTokens;
+        var totalTokens = systemTokens + stateTokens + recentTokens + retrievedTokens + userTokens;
 
         var pressure = _budget.GetPressure(totalTokens);
 
@@ -93,6 +98,9 @@ public sealed class ContextManager
             state.Compact(maxDecisions: 5, maxQuestions: 3, maxEntities: 10);
             _logger.LogWarning("Critical budget pressure — compacted session state");
         }
+
+        // Increment turn count only after all async work succeeds
+        state.TurnCount++;
 
         // Build the prompt
         var packet = _promptBuilder.Build(new BuildRequest
@@ -146,12 +154,7 @@ public sealed class ContextManager
     /// </summary>
     public SessionState GetOrCreateState(string sessionId)
     {
-        if (!_sessionStates.TryGetValue(sessionId, out var state))
-        {
-            state = new SessionState();
-            _sessionStates[sessionId] = state;
-        }
-        return state;
+        return _sessionStates.GetOrAdd(sessionId, _ => new SessionState());
     }
 
     /// <summary>
@@ -159,7 +162,16 @@ public sealed class ContextManager
     /// </summary>
     public void EvictState(string sessionId)
     {
-        _sessionStates.Remove(sessionId);
+        _sessionStates.TryRemove(sessionId, out _);
+    }
+
+    private int EstimateRetrievedContextTokens(List<string>? retrievedContext)
+    {
+        if (retrievedContext is null or { Count: 0 }) return 0;
+        var totalChars = 0;
+        foreach (var chunk in retrievedContext)
+            totalChars += chunk.Length;
+        return totalChars / 4;
     }
 
     /// <summary>
@@ -173,9 +185,10 @@ public sealed class ContextManager
     {
         var transcript = string.Join("\n", evictedMessages.Select(m => $"{m.Role}: {m.Content}"));
 
-        // Truncate if the evicted block is huge — we don't want the summary call itself to be expensive
+        // Truncate if the evicted block is huge — keep the NEWEST messages (tail)
+        // since they're closest to the current context and most relevant to summarize
         if (transcript.Length > 4000)
-            transcript = transcript[..4000] + "\n[...truncated]";
+            transcript = "[...truncated]\n" + transcript[^4000..];
 
         var existingSummary = string.IsNullOrEmpty(state.Summary.Content)
             ? ""
@@ -205,6 +218,10 @@ public sealed class ContextManager
                 "Summarized {Count} evicted messages into {Tokens} est. tokens",
                 evictedMessages.Count,
                 _budget.EstimateTokens(summary));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/Context/ContextManager.cs
+++ b/src/Context/ContextManager.cs
@@ -22,7 +22,11 @@ public sealed class ContextManager
     private readonly ILogger<ContextManager> _logger;
 
     private readonly ConcurrentDictionary<string, SessionState> _sessionStates = new();
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _sessionLocks = new();
 
+    /// <summary>
+    /// Creates a new ContextManager wired to the given transcript store, LLM client, and budget.
+    /// </summary>
     public ContextManager(
         TranscriptStore transcripts,
         IChatClient chatClient,
@@ -55,63 +59,72 @@ public sealed class ContextManager
         CancellationToken ct)
     {
         var state = GetOrCreateState(sessionId);
+        var sessionLock = _sessionLocks.GetOrAdd(sessionId, _ => new SemaphoreSlim(1, 1));
 
-        // Load transcript from archive — empty list for brand-new sessions
-        List<Message> allMessages;
-        if (_transcripts.SessionExists(sessionId))
-            allMessages = await _transcripts.LoadSessionAsync(sessionId, ct);
-        else
-            allMessages = new List<Message>();
-
-        // Split into recent window and evicted older messages
-        var recentTurns = _budget.TrimToRecentWindow(allMessages);
-        var evictedMessages = _budget.GetEvictedMessages(allMessages);
-
-        // Estimate current token usage (all layers that will be sent)
-        var systemTokens = _budget.EstimateTokens(_promptBuilder.SystemPrompt);
-        var stateTokens = state.EstimateTokens();
-        var recentTokens = _budget.EstimateTokens(recentTurns);
-        var retrievedTokens = EstimateRetrievedContextTokens(retrievedContext);
-        var userTokens = _budget.EstimateTokens(userMessage);
-        var totalTokens = systemTokens + stateTokens + recentTokens + retrievedTokens + userTokens;
-
-        var pressure = _budget.GetPressure(totalTokens);
-
-        _logger.LogDebug(
-            "Context budget: {Total}/{Max} tokens ({Pressure}), {Recent} recent, {Evicted} evicted",
-            totalTokens, _budget.MaxTokens, pressure, recentTurns.Count, evictedMessages.Count);
-
-        // Summarize evicted messages if we have any and need to
-        if (evictedMessages.Count > 0 && pressure >= BudgetPressure.High)
+        await sessionLock.WaitAsync(ct);
+        try
         {
-            await SummarizeEvictedAsync(state, evictedMessages, ct);
+            // Load transcript from archive — empty list for brand-new sessions
+            List<Message> allMessages;
+            if (_transcripts.SessionExists(sessionId))
+                allMessages = await _transcripts.LoadSessionAsync(sessionId, ct);
+            else
+                allMessages = new List<Message>();
+
+            // Split into recent window and evicted older messages
+            var recentTurns = _budget.TrimToRecentWindow(allMessages);
+            var evictedMessages = _budget.GetEvictedMessages(allMessages);
+
+            // Estimate current token usage (all layers that will be sent)
+            var systemTokens = _budget.EstimateTokens(_promptBuilder.SystemPrompt);
+            var stateTokens = state.EstimateTokens();
+            var recentTokens = _budget.EstimateTokens(recentTurns);
+            var retrievedTokens = EstimateRetrievedContextTokens(retrievedContext);
+            var userTokens = _budget.EstimateTokens(userMessage);
+            var totalTokens = systemTokens + stateTokens + recentTokens + retrievedTokens + userTokens;
+
+            var pressure = _budget.GetPressure(totalTokens);
+
+            _logger.LogDebug(
+                "Context budget: {Total}/{Max} tokens ({Pressure}), {Recent} recent, {Evicted} evicted",
+                totalTokens, _budget.MaxTokens, pressure, recentTurns.Count, evictedMessages.Count);
+
+            // Summarize evicted messages if we have any and need to
+            if (evictedMessages.Count > 0 && pressure >= BudgetPressure.High)
+            {
+                await SummarizeEvictedAsync(state, evictedMessages, ct);
+            }
+            else if (evictedMessages.Count > 0 && string.IsNullOrEmpty(state.Summary.Content))
+            {
+                // First time we evict messages — create initial summary
+                await SummarizeEvictedAsync(state, evictedMessages, ct);
+            }
+
+            // Under critical pressure, compact the state itself
+            if (pressure == BudgetPressure.Critical)
+            {
+                state.Compact(maxDecisions: 5, maxQuestions: 3, maxEntities: 10);
+                _logger.LogWarning("Critical budget pressure — compacted session state");
+            }
+
+            // Increment turn count only after all async work succeeds
+            state.TurnCount++;
+
+            // Build the prompt
+            var packet = _promptBuilder.Build(new BuildRequest
+            {
+                State = state,
+                CurrentUserMessage = userMessage,
+                RecentTurns = recentTurns,
+                RetrievedContext = retrievedContext
+            });
+
+            return _promptBuilder.ToOpenAiMessages(packet);
         }
-        else if (evictedMessages.Count > 0 && string.IsNullOrEmpty(state.Summary.Content))
+        finally
         {
-            // First time we evict messages — create initial summary
-            await SummarizeEvictedAsync(state, evictedMessages, ct);
+            sessionLock.Release();
         }
-
-        // Under critical pressure, compact the state itself
-        if (pressure == BudgetPressure.Critical)
-        {
-            state.Compact(maxDecisions: 5, maxQuestions: 3, maxEntities: 10);
-            _logger.LogWarning("Critical budget pressure — compacted session state");
-        }
-
-        // Increment turn count only after all async work succeeds
-        state.TurnCount++;
-
-        // Build the prompt
-        var packet = _promptBuilder.Build(new BuildRequest
-        {
-            State = state,
-            CurrentUserMessage = userMessage,
-            RecentTurns = recentTurns,
-            RetrievedContext = retrievedContext
-        });
-
-        return _promptBuilder.ToOpenAiMessages(packet);
     }
 
     /// <summary>
@@ -165,6 +178,9 @@ public sealed class ContextManager
         _sessionStates.TryRemove(sessionId, out _);
     }
 
+    /// <summary>
+    /// Estimates token cost for retrieved context chunks (~4 chars per token).
+    /// </summary>
     private int EstimateRetrievedContextTokens(List<string>? retrievedContext)
     {
         if (retrievedContext is null or { Count: 0 }) return 0;

--- a/src/Context/ContextManager.cs
+++ b/src/Context/ContextManager.cs
@@ -90,22 +90,21 @@ public sealed class ContextManager
                 "Context budget: {Total}/{Max} tokens ({Pressure}), {Recent} recent, {Evicted} evicted",
                 totalTokens, _budget.MaxTokens, pressure, recentTurns.Count, evictedMessages.Count);
 
-            // Summarize evicted messages only when the summary is behind the current turn
-            var needsSummary = evictedMessages.Count > 0
-                && state.Summary.CoveredThroughTurn < state.TurnCount;
+            // Summarize only when the evicted set has actually grown since the last summary
+            var newEvictions = evictedMessages.Count > state.Summary.SummarizedMessageCount;
 
-            if (needsSummary && pressure >= BudgetPressure.High)
+            if (newEvictions && pressure >= BudgetPressure.High)
             {
                 await SummarizeEvictedAsync(state, evictedMessages, ct);
             }
-            else if (needsSummary && string.IsNullOrEmpty(state.Summary.Content))
+            else if (newEvictions && string.IsNullOrEmpty(state.Summary.Content))
             {
                 // First time we evict messages — create initial summary
                 await SummarizeEvictedAsync(state, evictedMessages, ct);
             }
-            else if (needsSummary && IsSummaryStaleBeyond(state, turnsStalenessThreshold: 10))
+            else if (evictedMessages.Count > 0 && IsSummaryStaleBeyond(state, turnsStalenessThreshold: 10))
             {
-                // Summary is stale — re-summarize to capture recent evictions
+                // Summary is stale — re-summarize even if eviction count hasn't changed
                 await SummarizeEvictedAsync(state, evictedMessages, ct);
             }
 
@@ -283,6 +282,7 @@ public sealed class ContextManager
             var summary = await _chatClient.CompleteAsync(summarizePrompt, ct);
             state.Summary.Content = summary.Trim();
             state.Summary.CoveredThroughTurn = state.TurnCount;
+            state.Summary.SummarizedMessageCount = evictedMessages.Count;
 
             _logger.LogInformation(
                 "Summarized {Count} evicted messages into {Tokens} est. tokens",

--- a/src/Context/ContextManager.cs
+++ b/src/Context/ContextManager.cs
@@ -76,11 +76,12 @@ public sealed class ContextManager
             var evictedMessages = _budget.GetEvictedMessages(allMessages);
 
             // Estimate current token usage (all layers that will be sent)
-            var systemTokens = _budget.EstimateTokens(_promptBuilder.SystemPrompt);
+            // Use EstimateMessageTokens for standalone text that PromptBuilder wraps in Message objects
+            var systemTokens = _budget.EstimateMessageTokens("system", _promptBuilder.SystemPrompt);
             var stateTokens = state.EstimateTokens();
             var recentTokens = _budget.EstimateTokens(recentTurns);
             var retrievedTokens = EstimateRetrievedContextTokens(retrievedContext);
-            var userTokens = _budget.EstimateTokens(userMessage);
+            var userTokens = _budget.EstimateMessageTokens("user", userMessage);
             var totalTokens = systemTokens + stateTokens + recentTokens + retrievedTokens + userTokens;
 
             var pressure = _budget.GetPressure(totalTokens);

--- a/src/Context/ContextManager.cs
+++ b/src/Context/ContextManager.cs
@@ -100,6 +100,11 @@ public sealed class ContextManager
                 // First time we evict messages — create initial summary
                 await SummarizeEvictedAsync(state, evictedMessages, ct);
             }
+            else if (evictedMessages.Count > 0 && IsSummaryStaleBeyond(state, turnsStalenessThreshold: 10))
+            {
+                // Summary is stale — re-summarize to capture recent evictions
+                await SummarizeEvictedAsync(state, evictedMessages, ct);
+            }
 
             // Under critical pressure, compact the state itself
             if (pressure == BudgetPressure.Critical)
@@ -132,35 +137,62 @@ public sealed class ContextManager
     /// Updates session state after receiving an LLM response.
     /// Call this after each successful LLM completion to keep state current.
     /// </summary>
-    public void UpdateAfterResponse(string sessionId, string? responseId = null)
+    public async Task UpdateAfterResponseAsync(string sessionId, string? responseId = null, CancellationToken ct = default)
     {
-        if (_sessionStates.TryGetValue(sessionId, out var state))
+        var sessionLock = _sessionLocks.GetOrAdd(sessionId, _ => new SemaphoreSlim(1, 1));
+        await sessionLock.WaitAsync(ct);
+        try
         {
-            state.PreviousResponseId = responseId;
+            if (_sessionStates.TryGetValue(sessionId, out var state))
+            {
+                state.PreviousResponseId = responseId;
+            }
+        }
+        finally
+        {
+            sessionLock.Release();
         }
     }
 
     /// <summary>
     /// Records a decision made during the conversation.
     /// </summary>
-    public void RecordDecision(string sessionId, string what, string why)
+    public async Task RecordDecisionAsync(string sessionId, string what, string why, CancellationToken ct = default)
     {
         var state = GetOrCreateState(sessionId);
-        state.Decisions.Add(new Decision
+        var sessionLock = _sessionLocks.GetOrAdd(sessionId, _ => new SemaphoreSlim(1, 1));
+        await sessionLock.WaitAsync(ct);
+        try
         {
-            What = what,
-            Why = why,
-            TurnNumber = state.TurnCount
-        });
+            state.Decisions.Add(new Decision
+            {
+                What = what,
+                Why = why,
+                TurnNumber = state.TurnCount
+            });
+        }
+        finally
+        {
+            sessionLock.Release();
+        }
     }
 
     /// <summary>
     /// Updates the active goal for a session.
     /// </summary>
-    public void SetActiveGoal(string sessionId, string goal)
+    public async Task SetActiveGoalAsync(string sessionId, string goal, CancellationToken ct = default)
     {
         var state = GetOrCreateState(sessionId);
-        state.ActiveGoal = goal;
+        var sessionLock = _sessionLocks.GetOrAdd(sessionId, _ => new SemaphoreSlim(1, 1));
+        await sessionLock.WaitAsync(ct);
+        try
+        {
+            state.ActiveGoal = goal;
+        }
+        finally
+        {
+            sessionLock.Release();
+        }
     }
 
     /// <summary>
@@ -177,6 +209,19 @@ public sealed class ContextManager
     public void EvictState(string sessionId)
     {
         _sessionStates.TryRemove(sessionId, out _);
+    }
+
+    /// <summary>
+    /// Returns true if the summary is stale — i.e. more than the given number of turns
+    /// have elapsed since the summary was last updated. Uses CoveredThroughTurn for gap detection.
+    /// </summary>
+    private static bool IsSummaryStaleBeyond(SessionState state, int turnsStalenessThreshold)
+    {
+        if (string.IsNullOrEmpty(state.Summary.Content))
+            return false;
+
+        var turnsSinceLastSummary = state.TurnCount - state.Summary.CoveredThroughTurn;
+        return turnsSinceLastSummary > turnsStalenessThreshold;
     }
 
     /// <summary>

--- a/src/Context/ContextManager.cs
+++ b/src/Context/ContextManager.cs
@@ -1,0 +1,213 @@
+using Hermes.Agent.Core;
+using Hermes.Agent.LLM;
+using Hermes.Agent.Transcript;
+using Microsoft.Extensions.Logging;
+
+namespace Hermes.Agent.Context;
+
+/// <summary>
+/// Main orchestrator for the Context Runtime.
+/// Replaces the naive "send all messages" pattern with:
+///   conversation history = archive (TranscriptStore)
+///   session state = active memory (SessionState)
+///   retrieval = selective recall (on-demand)
+/// </summary>
+public sealed class ContextManager
+{
+    private readonly TranscriptStore _transcripts;
+    private readonly IChatClient _chatClient;
+    private readonly TokenBudget _budget;
+    private readonly PromptBuilder _promptBuilder;
+    private readonly ILogger<ContextManager> _logger;
+
+    private readonly Dictionary<string, SessionState> _sessionStates = new();
+
+    public ContextManager(
+        TranscriptStore transcripts,
+        IChatClient chatClient,
+        TokenBudget budget,
+        PromptBuilder promptBuilder,
+        ILogger<ContextManager> logger)
+    {
+        _transcripts = transcripts;
+        _chatClient = chatClient;
+        _budget = budget;
+        _promptBuilder = promptBuilder;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Prepares an optimized context for the LLM call, replacing the naive full-history pattern.
+    ///
+    /// Flow:
+    /// 1. Load or create session state
+    /// 2. Get recent turns (last N only) from transcript
+    /// 3. Check token budget pressure
+    /// 4. If over threshold, summarize evicted turns
+    /// 5. Build cache-safe prompt packet
+    /// 6. Return OpenAI-compatible message list
+    /// </summary>
+    public async Task<List<Message>> PrepareContextAsync(
+        string sessionId,
+        string userMessage,
+        List<string>? retrievedContext,
+        CancellationToken ct)
+    {
+        var state = GetOrCreateState(sessionId);
+        state.TurnCount++;
+
+        // Load full transcript from archive
+        var allMessages = await _transcripts.LoadSessionAsync(sessionId, ct);
+
+        // Split into recent window and evicted older messages
+        var recentTurns = _budget.TrimToRecentWindow(allMessages);
+        var evictedMessages = _budget.GetEvictedMessages(allMessages);
+
+        // Estimate current token usage
+        var stateTokens = state.EstimateTokens();
+        var recentTokens = _budget.EstimateTokens(recentTurns);
+        var userTokens = _budget.EstimateTokens(userMessage);
+        var totalTokens = stateTokens + recentTokens + userTokens;
+
+        var pressure = _budget.GetPressure(totalTokens);
+
+        _logger.LogDebug(
+            "Context budget: {Total}/{Max} tokens ({Pressure}), {Recent} recent, {Evicted} evicted",
+            totalTokens, _budget.MaxTokens, pressure, recentTurns.Count, evictedMessages.Count);
+
+        // Summarize evicted messages if we have any and need to
+        if (evictedMessages.Count > 0 && pressure >= BudgetPressure.High)
+        {
+            await SummarizeEvictedAsync(state, evictedMessages, ct);
+        }
+        else if (evictedMessages.Count > 0 && string.IsNullOrEmpty(state.Summary.Content))
+        {
+            // First time we evict messages — create initial summary
+            await SummarizeEvictedAsync(state, evictedMessages, ct);
+        }
+
+        // Under critical pressure, compact the state itself
+        if (pressure == BudgetPressure.Critical)
+        {
+            state.Compact(maxDecisions: 5, maxQuestions: 3, maxEntities: 10);
+            _logger.LogWarning("Critical budget pressure — compacted session state");
+        }
+
+        // Build the prompt
+        var packet = _promptBuilder.Build(new BuildRequest
+        {
+            State = state,
+            CurrentUserMessage = userMessage,
+            RecentTurns = recentTurns,
+            RetrievedContext = retrievedContext
+        });
+
+        return _promptBuilder.ToOpenAiMessages(packet);
+    }
+
+    /// <summary>
+    /// Updates session state after receiving an LLM response.
+    /// Call this after each successful LLM completion to keep state current.
+    /// </summary>
+    public void UpdateAfterResponse(string sessionId, string? responseId = null)
+    {
+        if (_sessionStates.TryGetValue(sessionId, out var state))
+        {
+            state.PreviousResponseId = responseId;
+        }
+    }
+
+    /// <summary>
+    /// Records a decision made during the conversation.
+    /// </summary>
+    public void RecordDecision(string sessionId, string what, string why)
+    {
+        var state = GetOrCreateState(sessionId);
+        state.Decisions.Add(new Decision
+        {
+            What = what,
+            Why = why,
+            TurnNumber = state.TurnCount
+        });
+    }
+
+    /// <summary>
+    /// Updates the active goal for a session.
+    /// </summary>
+    public void SetActiveGoal(string sessionId, string goal)
+    {
+        var state = GetOrCreateState(sessionId);
+        state.ActiveGoal = goal;
+    }
+
+    /// <summary>
+    /// Gets or creates session state for a given session ID.
+    /// </summary>
+    public SessionState GetOrCreateState(string sessionId)
+    {
+        if (!_sessionStates.TryGetValue(sessionId, out var state))
+        {
+            state = new SessionState();
+            _sessionStates[sessionId] = state;
+        }
+        return state;
+    }
+
+    /// <summary>
+    /// Removes session state from memory (transcript stays on disk via TranscriptStore).
+    /// </summary>
+    public void EvictState(string sessionId)
+    {
+        _sessionStates.Remove(sessionId);
+    }
+
+    /// <summary>
+    /// Uses the LLM to compress evicted messages into a summary paragraph.
+    /// This summary becomes part of SessionState and survives across turns.
+    /// </summary>
+    private async Task SummarizeEvictedAsync(
+        SessionState state,
+        List<Message> evictedMessages,
+        CancellationToken ct)
+    {
+        var transcript = string.Join("\n", evictedMessages.Select(m => $"{m.Role}: {m.Content}"));
+
+        // Truncate if the evicted block is huge — we don't want the summary call itself to be expensive
+        if (transcript.Length > 4000)
+            transcript = transcript[..4000] + "\n[...truncated]";
+
+        var existingSummary = string.IsNullOrEmpty(state.Summary.Content)
+            ? ""
+            : $"Previous summary: {state.Summary.Content}\n\n";
+
+        var summarizePrompt = new List<Message>
+        {
+            new()
+            {
+                Role = "system",
+                Content = "You are a conversation summarizer. Produce a concise summary (2-4 sentences) of the key points, decisions, and outcomes. Preserve important names, paths, and technical details. Do not include pleasantries or filler."
+            },
+            new()
+            {
+                Role = "user",
+                Content = $"{existingSummary}Summarize this conversation segment:\n\n{transcript}"
+            }
+        };
+
+        try
+        {
+            var summary = await _chatClient.CompleteAsync(summarizePrompt, ct);
+            state.Summary.Content = summary.Trim();
+            state.Summary.CoveredThroughTurn = state.TurnCount - 1;
+
+            _logger.LogInformation(
+                "Summarized {Count} evicted messages into {Tokens} est. tokens",
+                evictedMessages.Count,
+                _budget.EstimateTokens(summary));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to summarize evicted messages — keeping stale summary");
+        }
+    }
+}

--- a/src/Context/ContextManager.cs
+++ b/src/Context/ContextManager.cs
@@ -214,6 +214,8 @@ public sealed class ContextManager
     public void EvictState(string sessionId)
     {
         _sessionStates.TryRemove(sessionId, out _);
+        if (_sessionLocks.TryRemove(sessionId, out var semaphore))
+            semaphore.Dispose();
     }
 
     /// <summary>
@@ -279,7 +281,7 @@ public sealed class ContextManager
         {
             var summary = await _chatClient.CompleteAsync(summarizePrompt, ct);
             state.Summary.Content = summary.Trim();
-            state.Summary.CoveredThroughTurn = Math.Max(0, state.TurnCount - 1);
+            state.Summary.CoveredThroughTurn = state.TurnCount;
 
             _logger.LogInformation(
                 "Summarized {Count} evicted messages into {Tokens} est. tokens",

--- a/src/Context/PromptBuilder.cs
+++ b/src/Context/PromptBuilder.cs
@@ -20,8 +20,12 @@ public sealed class PromptBuilder
 
     private readonly string _systemPrompt;
 
+    /// <summary>The stable system prompt used as the cache anchor.</summary>
     public string SystemPrompt => _systemPrompt;
 
+    /// <summary>
+    /// Creates a prompt builder with a fixed system prompt that serves as the cache anchor.
+    /// </summary>
     public PromptBuilder(string systemPrompt)
     {
         _systemPrompt = systemPrompt;
@@ -121,19 +125,37 @@ public sealed class PromptBuilder
     }
 }
 
+/// <summary>Input parameters for building a prompt packet.</summary>
 public sealed class BuildRequest
 {
+    /// <summary>Current session state to serialize into the prompt.</summary>
     public required SessionState State { get; init; }
+
+    /// <summary>The user's message for the current turn.</summary>
     public required string CurrentUserMessage { get; init; }
+
+    /// <summary>Recent conversation turns from the sliding window.</summary>
     public List<Message> RecentTurns { get; init; } = new();
+
+    /// <summary>Optional context chunks retrieved on demand (e.g. from memory or search).</summary>
     public List<string>? RetrievedContext { get; init; }
 }
 
+/// <summary>Assembled prompt ready for conversion to provider message format.</summary>
 public sealed class PromptPacket
 {
+    /// <summary>Stable system instructions (cache anchor layer).</summary>
     public required string SystemPrompt { get; init; }
+
+    /// <summary>Serialized session state JSON (slow-changing second cache layer).</summary>
     public string SessionStateJson { get; init; } = "{}";
+
+    /// <summary>Optional retrieved context chunks.</summary>
     public List<string>? RetrievedContext { get; init; }
+
+    /// <summary>Recent conversation turns from the sliding window.</summary>
     public List<Message> RecentTurns { get; init; } = new();
+
+    /// <summary>The user's message for the current turn.</summary>
     public required string CurrentUserMessage { get; init; }
 }

--- a/src/Context/PromptBuilder.cs
+++ b/src/Context/PromptBuilder.cs
@@ -20,6 +20,8 @@ public sealed class PromptBuilder
 
     private readonly string _systemPrompt;
 
+    public string SystemPrompt => _systemPrompt;
+
     public PromptBuilder(string systemPrompt)
     {
         _systemPrompt = systemPrompt;
@@ -34,10 +36,10 @@ public sealed class PromptBuilder
         var stateJson = JsonSerializer.Serialize(new
         {
             activeGoal = NullIfEmpty(request.State.ActiveGoal),
-            constraints = NullIfEmpty(request.State.Constraints),
-            decisions = NullIfEmpty(request.State.Decisions?.Select(d => new { d.What, d.Why })),
-            openQuestions = NullIfEmpty(request.State.OpenQuestions),
-            importantEntities = NullIfEmpty(request.State.ImportantEntities),
+            constraints = NullIfEmptyCollection(request.State.Constraints),
+            decisions = NullIfEmptyCollection(request.State.Decisions?.Select(d => new { d.What, d.Why })),
+            openQuestions = NullIfEmptyCollection(request.State.OpenQuestions),
+            importantEntities = NullIfEmptyCollection(request.State.ImportantEntities),
             summary = NullIfEmpty(request.State.Summary?.Content)
         }, JsonOpts);
 
@@ -112,16 +114,12 @@ public sealed class PromptBuilder
     private static string? NullIfEmpty(string? value)
         => string.IsNullOrWhiteSpace(value) ? null : value;
 
-    private static T? NullIfEmpty<T>(IEnumerable<T>? collection) where T : class
+    private static object? NullIfEmptyCollection<T>(IEnumerable<T>? collection)
     {
-        if (collection is null) return default;
-        // Materialize to check emptiness, but return null for JSON omission
+        if (collection is null) return null;
         var list = collection as IList<T> ?? collection.ToList();
-        return list.Count == 0 ? default : (T?)(object)list;
+        return list.Count == 0 ? null : list;
     }
-
-    private static List<T>? NullIfEmpty<T>(List<T>? list)
-        => list is null || list.Count == 0 ? null : list;
 }
 
 public sealed class BuildRequest

--- a/src/Context/PromptBuilder.cs
+++ b/src/Context/PromptBuilder.cs
@@ -49,8 +49,7 @@ public sealed class PromptBuilder
             SessionStateJson = stateJson,
             RetrievedContext = request.RetrievedContext,
             RecentTurns = request.RecentTurns,
-            CurrentUserMessage = request.CurrentUserMessage,
-            PreviousResponseId = request.State.PreviousResponseId
+            CurrentUserMessage = request.CurrentUserMessage
         };
     }
 
@@ -137,9 +136,4 @@ public sealed class PromptPacket
     public List<string>? RetrievedContext { get; init; }
     public List<Message> RecentTurns { get; init; } = new();
     public required string CurrentUserMessage { get; init; }
-
-    /// <summary>
-    /// OpenAI response_id from the previous turn, enabling cache chaining.
-    /// </summary>
-    public string? PreviousResponseId { get; init; }
 }

--- a/src/Context/PromptBuilder.cs
+++ b/src/Context/PromptBuilder.cs
@@ -1,0 +1,147 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Hermes.Agent.Core;
+
+namespace Hermes.Agent.Context;
+
+/// <summary>
+/// Assembles cache-safe prompts with a stable system prefix.
+/// The system prefix is byte-identical every turn — this is the cache anchor.
+/// OpenAI/Anthropic can reuse cached computation when the prefix doesn't change.
+/// </summary>
+public sealed class PromptBuilder
+{
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private readonly string _systemPrompt;
+
+    public PromptBuilder(string systemPrompt)
+    {
+        _systemPrompt = systemPrompt;
+    }
+
+    /// <summary>
+    /// Builds a cache-optimized prompt packet from session state, recent turns, and optional retrieved context.
+    /// The system prompt is stable (cache anchor), session state changes slowly, and recent turns change each turn.
+    /// </summary>
+    public PromptPacket Build(BuildRequest request)
+    {
+        var stateJson = JsonSerializer.Serialize(new
+        {
+            activeGoal = NullIfEmpty(request.State.ActiveGoal),
+            constraints = NullIfEmpty(request.State.Constraints),
+            decisions = NullIfEmpty(request.State.Decisions?.Select(d => new { d.What, d.Why })),
+            openQuestions = NullIfEmpty(request.State.OpenQuestions),
+            importantEntities = NullIfEmpty(request.State.ImportantEntities),
+            summary = NullIfEmpty(request.State.Summary?.Content)
+        }, JsonOpts);
+
+        return new PromptPacket
+        {
+            SystemPrompt = _systemPrompt,
+            SessionStateJson = stateJson,
+            RetrievedContext = request.RetrievedContext,
+            RecentTurns = request.RecentTurns,
+            CurrentUserMessage = request.CurrentUserMessage,
+            PreviousResponseId = request.State.PreviousResponseId
+        };
+    }
+
+    /// <summary>
+    /// Converts a PromptPacket into the OpenAI-compatible message list format.
+    /// Layout:
+    ///   [0] system: stable instructions (cache anchor)
+    ///   [1] system: session state JSON (slow-changing, second cache layer)
+    ///   [2..N] system: retrieved context (if any)
+    ///   [N+1..M] user/assistant: recent turns
+    ///   [M+1] user: current message
+    /// </summary>
+    public List<Message> ToOpenAiMessages(PromptPacket packet)
+    {
+        var messages = new List<Message>();
+
+        // Layer 1: Stable system prompt (cache anchor — never changes)
+        messages.Add(new Message
+        {
+            Role = "system",
+            Content = packet.SystemPrompt
+        });
+
+        // Layer 2: Session state (changes slowly — good for incremental caching)
+        if (!string.IsNullOrEmpty(packet.SessionStateJson) && packet.SessionStateJson != "{}")
+        {
+            messages.Add(new Message
+            {
+                Role = "system",
+                Content = $"[Session State]\n{packet.SessionStateJson}"
+            });
+        }
+
+        // Layer 3: Retrieved context (only present when relevant)
+        if (packet.RetrievedContext is { Count: > 0 })
+        {
+            var contextBlock = string.Join("\n---\n", packet.RetrievedContext);
+            messages.Add(new Message
+            {
+                Role = "system",
+                Content = $"[Retrieved Context]\n{contextBlock}"
+            });
+        }
+
+        // Layer 4: Recent conversation turns (sliding window)
+        if (packet.RecentTurns is { Count: > 0 })
+        {
+            messages.AddRange(packet.RecentTurns);
+        }
+
+        // Layer 5: Current user message
+        messages.Add(new Message
+        {
+            Role = "user",
+            Content = packet.CurrentUserMessage
+        });
+
+        return messages;
+    }
+
+    private static string? NullIfEmpty(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value;
+
+    private static T? NullIfEmpty<T>(IEnumerable<T>? collection) where T : class
+    {
+        if (collection is null) return default;
+        // Materialize to check emptiness, but return null for JSON omission
+        var list = collection as IList<T> ?? collection.ToList();
+        return list.Count == 0 ? default : (T?)(object)list;
+    }
+
+    private static List<T>? NullIfEmpty<T>(List<T>? list)
+        => list is null || list.Count == 0 ? null : list;
+}
+
+public sealed class BuildRequest
+{
+    public required SessionState State { get; init; }
+    public required string CurrentUserMessage { get; init; }
+    public List<Message> RecentTurns { get; init; } = new();
+    public List<string>? RetrievedContext { get; init; }
+}
+
+public sealed class PromptPacket
+{
+    public required string SystemPrompt { get; init; }
+    public string SessionStateJson { get; init; } = "{}";
+    public List<string>? RetrievedContext { get; init; }
+    public List<Message> RecentTurns { get; init; } = new();
+    public required string CurrentUserMessage { get; init; }
+
+    /// <summary>
+    /// OpenAI response_id from the previous turn, enabling cache chaining.
+    /// </summary>
+    public string? PreviousResponseId { get; init; }
+}

--- a/src/Context/SessionState.cs
+++ b/src/Context/SessionState.cs
@@ -22,7 +22,7 @@ public sealed class SessionState
     public List<string> ImportantEntities { get; set; } = new();
 
     /// <summary>Compressed summary of older turns evicted from the recent window.</summary>
-    public SessionSummary Summary { get; set; } = new();
+    public ContextSummary Summary { get; set; } = new();
 
     /// <summary>
     /// OpenAI response_id for cache chaining across turns.
@@ -94,7 +94,7 @@ public sealed class Decision
 }
 
 /// <summary>Rolling summary of conversation turns that have been evicted from the recent window.</summary>
-public sealed class SessionSummary
+public sealed class ContextSummary
 {
     /// <summary>
     /// Compressed representation of older turns that have been evicted from the recent window.

--- a/src/Context/SessionState.cs
+++ b/src/Context/SessionState.cs
@@ -106,4 +106,10 @@ public sealed class ContextSummary
     /// Turns after this number are still in the recent window.
     /// </summary>
     public int CoveredThroughTurn { get; set; }
+
+    /// <summary>
+    /// The number of evicted messages that were summarized.
+    /// Used to detect when new messages have been evicted and re-summarization is needed.
+    /// </summary>
+    public int SummarizedMessageCount { get; set; }
 }

--- a/src/Context/SessionState.cs
+++ b/src/Context/SessionState.cs
@@ -6,16 +6,22 @@ namespace Hermes.Agent.Context;
 /// </summary>
 public sealed class SessionState
 {
+    /// <summary>The current task or objective the conversation is working toward.</summary>
     public string ActiveGoal { get; set; } = string.Empty;
 
+    /// <summary>Rules, boundaries, or requirements that constrain how the goal is pursued.</summary>
     public List<string> Constraints { get; set; } = new();
 
+    /// <summary>Key decisions made during the conversation, with rationale.</summary>
     public List<Decision> Decisions { get; set; } = new();
 
+    /// <summary>Unresolved items that still need answers or investigation.</summary>
     public List<string> OpenQuestions { get; set; } = new();
 
+    /// <summary>Key names, file paths, or domain terms referenced in the conversation.</summary>
     public List<string> ImportantEntities { get; set; } = new();
 
+    /// <summary>Compressed summary of older turns evicted from the recent window.</summary>
     public SessionSummary Summary { get; set; } = new();
 
     /// <summary>
@@ -74,13 +80,20 @@ public sealed class SessionState
     }
 }
 
+/// <summary>A recorded decision with rationale, anchored to a specific turn.</summary>
 public sealed class Decision
 {
+    /// <summary>What was decided.</summary>
     public required string What { get; init; }
+
+    /// <summary>Why this choice was made.</summary>
     public required string Why { get; init; }
+
+    /// <summary>The turn number when this decision was recorded.</summary>
     public int TurnNumber { get; init; }
 }
 
+/// <summary>Rolling summary of conversation turns that have been evicted from the recent window.</summary>
 public sealed class SessionSummary
 {
     /// <summary>

--- a/src/Context/SessionState.cs
+++ b/src/Context/SessionState.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Hermes.Agent.Context;
 
 /// <summary>

--- a/src/Context/SessionState.cs
+++ b/src/Context/SessionState.cs
@@ -1,0 +1,98 @@
+using System.Text.Json.Serialization;
+
+namespace Hermes.Agent.Context;
+
+/// <summary>
+/// Structured rolling memory that replaces raw transcript as "what the model knows."
+/// Compact, structured, and stable — doesn't change wildly every turn so provider caching works.
+/// </summary>
+public sealed class SessionState
+{
+    public string ActiveGoal { get; set; } = string.Empty;
+
+    public List<string> Constraints { get; set; } = new();
+
+    public List<Decision> Decisions { get; set; } = new();
+
+    public List<string> OpenQuestions { get; set; } = new();
+
+    public List<string> ImportantEntities { get; set; } = new();
+
+    public SessionSummary Summary { get; set; } = new();
+
+    /// <summary>
+    /// OpenAI response_id for cache chaining across turns.
+    /// When set, subsequent requests can reference this to reuse cached KV computations.
+    /// </summary>
+    public string? PreviousResponseId { get; set; }
+
+    /// <summary>
+    /// Monotonically increasing turn counter for staleness detection.
+    /// </summary>
+    public int TurnCount { get; set; }
+
+    /// <summary>
+    /// Estimates the token footprint of this session state using a simple heuristic:
+    /// ~4 characters per token (conservative for English text + JSON overhead).
+    /// </summary>
+    public int EstimateTokens()
+    {
+        var chars = 0;
+
+        chars += ActiveGoal.Length;
+
+        foreach (var c in Constraints)
+            chars += c.Length;
+
+        foreach (var d in Decisions)
+            chars += d.What.Length + d.Why.Length;
+
+        foreach (var q in OpenQuestions)
+            chars += q.Length;
+
+        foreach (var e in ImportantEntities)
+            chars += e.Length;
+
+        chars += Summary.Content.Length;
+
+        // ~4 chars per token, plus JSON structure overhead (~20%)
+        return (int)((chars / 4.0) * 1.2);
+    }
+
+    /// <summary>
+    /// Trims the oldest decisions and resolved questions when state grows too large.
+    /// Keeps the most recent items which are most relevant to current work.
+    /// </summary>
+    public void Compact(int maxDecisions = 10, int maxQuestions = 5, int maxEntities = 20)
+    {
+        if (Decisions.Count > maxDecisions)
+            Decisions = Decisions.GetRange(Decisions.Count - maxDecisions, maxDecisions);
+
+        if (OpenQuestions.Count > maxQuestions)
+            OpenQuestions = OpenQuestions.GetRange(OpenQuestions.Count - maxQuestions, maxQuestions);
+
+        if (ImportantEntities.Count > maxEntities)
+            ImportantEntities = ImportantEntities.GetRange(ImportantEntities.Count - maxEntities, maxEntities);
+    }
+}
+
+public sealed class Decision
+{
+    public required string What { get; init; }
+    public required string Why { get; init; }
+    public int TurnNumber { get; init; }
+}
+
+public sealed class SessionSummary
+{
+    /// <summary>
+    /// Compressed representation of older turns that have been evicted from the recent window.
+    /// </summary>
+    public string Content { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The turn number up to which this summary covers.
+    /// Turns after this number are still in the recent window.
+    /// </summary>
+    public int CoveredThroughTurn { get; set; }
+}

--- a/src/Context/TokenBudget.cs
+++ b/src/Context/TokenBudget.cs
@@ -1,0 +1,104 @@
+using Hermes.Agent.Core;
+
+namespace Hermes.Agent.Context;
+
+/// <summary>
+/// Enforces hard limits on context size to prevent context explosion.
+/// When token usage crosses thresholds, triggers summarization and trimming.
+/// </summary>
+public sealed class TokenBudget
+{
+    public int MaxTokens { get; init; } = 8000;
+
+    /// <summary>75% of max — crossing this triggers summarization of older turns.</summary>
+    public int SummaryThreshold { get; init; } = 6000;
+
+    /// <summary>94% of max — crossing this triggers aggressive trimming.</summary>
+    public int CriticalThreshold { get; init; } = 7500;
+
+    /// <summary>Number of most recent turns to keep in the context window.</summary>
+    public int RecentTurnWindow { get; init; } = 6;
+
+    /// <summary>
+    /// Estimates the token count for a sequence of messages.
+    /// Uses ~4 chars/token heuristic with overhead for role tags and JSON framing.
+    /// </summary>
+    public int EstimateTokens(IEnumerable<Message> messages)
+    {
+        var totalChars = 0;
+        var messageCount = 0;
+
+        foreach (var msg in messages)
+        {
+            totalChars += msg.Content.Length;
+            totalChars += msg.Role.Length;
+            messageCount++;
+        }
+
+        // ~4 chars per token for content, plus ~4 tokens per message for framing
+        return (totalChars / 4) + (messageCount * 4);
+    }
+
+    /// <summary>
+    /// Estimates the token count for a single string (system prompt, JSON blob, etc).
+    /// </summary>
+    public int EstimateTokens(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return 0;
+        return text.Length / 4;
+    }
+
+    /// <summary>
+    /// Determines the current budget pressure level based on total token usage.
+    /// </summary>
+    public BudgetPressure GetPressure(int currentTokens)
+    {
+        if (currentTokens >= CriticalThreshold) return BudgetPressure.Critical;
+        if (currentTokens >= SummaryThreshold) return BudgetPressure.High;
+        return BudgetPressure.Normal;
+    }
+
+    /// <summary>
+    /// Returns the number of tokens remaining before hitting the hard ceiling.
+    /// </summary>
+    public int RemainingTokens(int currentTokens) => Math.Max(0, MaxTokens - currentTokens);
+
+    /// <summary>
+    /// Trims a message list to fit within the recent turn window.
+    /// Returns the most recent N turns (a turn = one user + one assistant message).
+    /// </summary>
+    public List<Message> TrimToRecentWindow(List<Message> messages)
+    {
+        if (messages.Count <= RecentTurnWindow * 2)
+            return messages;
+
+        // Keep last N*2 messages (each turn is user+assistant)
+        var startIndex = messages.Count - (RecentTurnWindow * 2);
+        return messages.GetRange(startIndex, messages.Count - startIndex);
+    }
+
+    /// <summary>
+    /// Returns the messages that would be evicted by trimming to the recent window.
+    /// These are candidates for summarization.
+    /// </summary>
+    public List<Message> GetEvictedMessages(List<Message> messages)
+    {
+        if (messages.Count <= RecentTurnWindow * 2)
+            return new List<Message>();
+
+        var evictCount = messages.Count - (RecentTurnWindow * 2);
+        return messages.GetRange(0, evictCount);
+    }
+}
+
+public enum BudgetPressure
+{
+    /// <summary>Under 75% — no action needed.</summary>
+    Normal,
+
+    /// <summary>75-94% — should summarize older turns.</summary>
+    High,
+
+    /// <summary>Over 94% — aggressive trimming required.</summary>
+    Critical
+}

--- a/src/Context/TokenBudget.cs
+++ b/src/Context/TokenBudget.cs
@@ -90,11 +90,6 @@ public sealed class TokenBudget
     }
 
     /// <summary>
-    /// Returns the number of tokens remaining before hitting the hard ceiling.
-    /// </summary>
-    public int RemainingTokens(int currentTokens) => Math.Max(0, MaxTokens - currentTokens);
-
-    /// <summary>
     /// Trims a message list to fit within the recent turn window.
     /// Scans from the end counting user messages as turn starts, so tool/system
     /// messages within a turn are kept together rather than split mid-turn.

--- a/src/Context/TokenBudget.cs
+++ b/src/Context/TokenBudget.cs
@@ -9,12 +9,22 @@ namespace Hermes.Agent.Context;
 public sealed class TokenBudget
 {
     private readonly int _maxTokens;
+    private readonly int _recentTurnWindow;
 
-    public TokenBudget(int maxTokens = 8000)
+    /// <summary>
+    /// Creates a token budget with the given ceiling. Thresholds scale proportionally.
+    /// </summary>
+    /// <param name="maxTokens">Hard token ceiling (must be greater than zero).</param>
+    /// <param name="recentTurnWindow">Number of recent turns to keep (must be non-negative).</param>
+    public TokenBudget(int maxTokens = 8000, int recentTurnWindow = 6)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(maxTokens, 0);
+        ArgumentOutOfRangeException.ThrowIfNegative(recentTurnWindow);
         _maxTokens = maxTokens;
+        _recentTurnWindow = recentTurnWindow;
     }
 
+    /// <summary>Hard ceiling on total tokens sent per turn.</summary>
     public int MaxTokens => _maxTokens;
 
     /// <summary>75% of max — crossing this triggers summarization of older turns.</summary>
@@ -24,7 +34,7 @@ public sealed class TokenBudget
     public int CriticalThreshold => (int)(_maxTokens * 0.94);
 
     /// <summary>Number of most recent turns to keep in the context window.</summary>
-    public int RecentTurnWindow { get; init; } = 6;
+    public int RecentTurnWindow => _recentTurnWindow;
 
     /// <summary>
     /// Estimates the token count for a sequence of messages.

--- a/src/Context/TokenBudget.cs
+++ b/src/Context/TokenBudget.cs
@@ -38,7 +38,7 @@ public sealed class TokenBudget
 
     /// <summary>
     /// Estimates the token count for a sequence of messages.
-    /// Uses ~4 chars/token heuristic with overhead for role tags and JSON framing.
+    /// Includes role framing, content, and optional tool metadata.
     /// </summary>
     public int EstimateTokens(IEnumerable<Message> messages)
     {
@@ -49,11 +49,13 @@ public sealed class TokenBudget
         {
             totalChars += msg.Content.Length;
             totalChars += msg.Role.Length;
+            totalChars += msg.ToolCallId?.Length ?? 0;
+            totalChars += msg.ToolName?.Length ?? 0;
             messageCount++;
         }
 
-        // ~4 chars per token for content, plus ~4 tokens per message for framing
-        return (totalChars / 4) + (messageCount * 4);
+        // ~4 chars per token for content, plus ~4 tokens per message for role/framing
+        return (int)Math.Ceiling(totalChars / 4.0) + (messageCount * 4);
     }
 
     /// <summary>
@@ -63,6 +65,18 @@ public sealed class TokenBudget
     {
         if (string.IsNullOrEmpty(text)) return 0;
         return text.Length / 4;
+    }
+
+    /// <summary>
+    /// Estimates the token count for a standalone text layer that will be wrapped
+    /// in a Message object (e.g. system prompt, user message). Accounts for role
+    /// framing overhead that the raw string overload misses.
+    /// </summary>
+    public int EstimateMessageTokens(string role, string text)
+    {
+        if (string.IsNullOrEmpty(text)) return 0;
+        var totalChars = role.Length + text.Length;
+        return (int)Math.Ceiling(totalChars / 4.0) + 4;
     }
 
     /// <summary>
@@ -82,16 +96,15 @@ public sealed class TokenBudget
 
     /// <summary>
     /// Trims a message list to fit within the recent turn window.
-    /// Returns the most recent N turns (a turn = one user + one assistant message).
+    /// Scans from the end counting user messages as turn starts, so tool/system
+    /// messages within a turn are kept together rather than split mid-turn.
     /// </summary>
     public List<Message> TrimToRecentWindow(List<Message> messages)
     {
-        if (messages.Count <= RecentTurnWindow * 2)
-            return messages;
-
-        // Keep last N*2 messages (each turn is user+assistant)
-        var startIndex = messages.Count - (RecentTurnWindow * 2);
-        return messages.GetRange(startIndex, messages.Count - startIndex);
+        var startIndex = FindRecentWindowStart(messages);
+        return startIndex == 0
+            ? new List<Message>(messages)
+            : messages.GetRange(startIndex, messages.Count - startIndex);
     }
 
     /// <summary>
@@ -100,11 +113,36 @@ public sealed class TokenBudget
     /// </summary>
     public List<Message> GetEvictedMessages(List<Message> messages)
     {
-        if (messages.Count <= RecentTurnWindow * 2)
-            return new List<Message>();
+        var startIndex = FindRecentWindowStart(messages);
+        return startIndex == 0
+            ? new List<Message>()
+            : messages.GetRange(0, startIndex);
+    }
 
-        var evictCount = messages.Count - (RecentTurnWindow * 2);
-        return messages.GetRange(0, evictCount);
+    /// <summary>
+    /// Finds the index where the recent turn window starts by scanning backwards
+    /// and counting "user" messages as turn boundaries.
+    /// </summary>
+    private int FindRecentWindowStart(IReadOnlyList<Message> messages)
+    {
+        if (messages.Count == 0)
+            return 0;
+        if (RecentTurnWindow == 0)
+            return messages.Count;
+
+        var userTurnsSeen = 0;
+        for (var i = messages.Count - 1; i >= 0; i--)
+        {
+            if (string.Equals(messages[i].Role, "user", StringComparison.Ordinal))
+            {
+                userTurnsSeen++;
+                if (userTurnsSeen == RecentTurnWindow)
+                    return i;
+            }
+        }
+
+        // Fewer turns than the window — keep everything
+        return 0;
     }
 }
 

--- a/src/Context/TokenBudget.cs
+++ b/src/Context/TokenBudget.cs
@@ -8,13 +8,20 @@ namespace Hermes.Agent.Context;
 /// </summary>
 public sealed class TokenBudget
 {
-    public int MaxTokens { get; init; } = 8000;
+    private readonly int _maxTokens;
+
+    public TokenBudget(int maxTokens = 8000)
+    {
+        _maxTokens = maxTokens;
+    }
+
+    public int MaxTokens => _maxTokens;
 
     /// <summary>75% of max — crossing this triggers summarization of older turns.</summary>
-    public int SummaryThreshold { get; init; } = 6000;
+    public int SummaryThreshold => (int)(_maxTokens * 0.75);
 
     /// <summary>94% of max — crossing this triggers aggressive trimming.</summary>
-    public int CriticalThreshold { get; init; } = 7500;
+    public int CriticalThreshold => (int)(_maxTokens * 0.94);
 
     /// <summary>Number of most recent turns to keep in the context window.</summary>
     public int RecentTurnWindow { get; init; } = 6;


### PR DESCRIPTION
Replace the naive "send entire conversation history" pattern with a structured
context runtime that sends only what matters per turn:
- SessionState: structured rolling memory (active goal, decisions, constraints)
- TokenBudget: enforces hard limits with automatic summarization thresholds
- PromptBuilder: assembles cache-safe prompts with stable system prefix anchor
- ContextManager: orchestrates context preparation, eviction, and summarization

This enables provider-side KV cache reuse, bounded latency, and linear cost
regardless of conversation length.

https://claude.ai/code/session_013xmL4JG4kjE5rVNsL1D3Bq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new context-orchestration code that changes how prompts can be constructed and summarizes prior conversation via LLM calls, which can affect response quality/cost and has concurrency/state-management implications. Desktop change is low risk but pinning Windows SDK package versions may impact build compatibility.
> 
> **Overview**
> Adds a new **Context Runtime** layer (`ContextManager`, `SessionState`, `TokenBudget`, `PromptBuilder`) to replace “send entire conversation history” with a budgeted, cache-friendly prompt assembly that keeps a recent-turn window, maintains structured session memory, and optionally injects retrieved context.
> 
> `ContextManager.PrepareContextAsync` now calculates token pressure, summarizes evicted transcript segments via `IChatClient` when needed, compacts state under critical pressure, and returns an OpenAI-style `List<Message>` built with a stable system prompt prefix for provider caching.
> 
> Separately, the desktop project stops using wildcard package versions and pins `Microsoft.Windows.SDK.BuildTools` and `Microsoft.WindowsAppSDK` to specific versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3153123238cca53b4e694c467c99eb501bda785. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-based conversation memory with rolling summaries and automatic compaction for long interactions
  * Intelligent token budgeting with High/Critical pressure detection that trims history to preserve response quality
  * Automatic summarization of evicted history, with resilience on failures
  * Improved prompt assembly that includes session state, recent turns, and retrieved context for state-aware replies
  * End-user APIs to record decisions, set active goals, and evict or reinitialize session memory
<!-- end of auto-generated comment: release notes by coderabbit.ai -->