### PR TITLE
Soul System, System Prompt, and UI Polish

### DIFF
--- a/Desktop/HermesDesktop/App.xaml.cs
+++ b/Desktop/HermesDesktop/App.xaml.cs
@@ -121,8 +121,7 @@ public partial class App : Application
 
         // Token budget & Prompt builder for Context Runtime
         services.AddSingleton(sp => new TokenBudget(maxTokens: 8000, recentTurnWindow: 6));
-        services.AddSingleton(sp => new PromptBuilder(
-            "You are Hermes, an intelligent coding assistant. Help the user with their tasks efficiently and accurately."));
+        services.AddSingleton(sp => new PromptBuilder(SystemPrompts.Default));
 
         // Context manager (with soul integration)
         services.AddSingleton(sp => new ContextManager(

--- a/Desktop/HermesDesktop/App.xaml.cs
+++ b/Desktop/HermesDesktop/App.xaml.cs
@@ -13,6 +13,7 @@ using Hermes.Agent.Context;
 using Hermes.Agent.Agents;
 using Hermes.Agent.Coordinator;
 using Hermes.Agent.Mcp;
+using Hermes.Agent.Soul;
 using Hermes.Agent.Tools;
 using HermesDesktop.Services;
 using System;
@@ -108,18 +109,29 @@ public partial class App : Application
             buddyDir,
             sp.GetRequiredService<IChatClient>()));
 
+        // Soul service (persistent identity, user profile, mistakes, habits)
+        services.AddSingleton(sp => new SoulService(
+            hermesHome,
+            sp.GetRequiredService<ILogger<SoulService>>()));
+
+        // Soul extractor (LLM-powered transcript analysis)
+        services.AddSingleton(sp => new SoulExtractor(
+            sp.GetRequiredService<IChatClient>(),
+            sp.GetRequiredService<ILogger<SoulExtractor>>()));
+
         // Token budget & Prompt builder for Context Runtime
         services.AddSingleton(sp => new TokenBudget(maxTokens: 8000, recentTurnWindow: 6));
         services.AddSingleton(sp => new PromptBuilder(
             "You are Hermes, an intelligent coding assistant. Help the user with their tasks efficiently and accurately."));
 
-        // Context manager
+        // Context manager (with soul integration)
         services.AddSingleton(sp => new ContextManager(
             sp.GetRequiredService<TranscriptStore>(),
             sp.GetRequiredService<IChatClient>(),
             sp.GetRequiredService<TokenBudget>(),
             sp.GetRequiredService<PromptBuilder>(),
-            sp.GetRequiredService<ILogger<ContextManager>>()));
+            sp.GetRequiredService<ILogger<ContextManager>>(),
+            soulService: sp.GetRequiredService<SoulService>()));
 
         // MCP manager
         services.AddSingleton(sp => new McpManager(
@@ -135,7 +147,8 @@ public partial class App : Application
             permissions: sp.GetRequiredService<PermissionManager>(),
             transcripts: sp.GetRequiredService<TranscriptStore>(),
             memories: sp.GetRequiredService<MemoryManager>(),
-            contextManager: sp.GetRequiredService<ContextManager>()));
+            contextManager: sp.GetRequiredService<ContextManager>(),
+            soulService: sp.GetRequiredService<SoulService>()));
 
         // Agent service (subagent spawning, worktree isolation)
         var worktreesDir = Path.Combine(projectDir, "worktrees");

--- a/Desktop/HermesDesktop/Services/HermesEnvironment.cs
+++ b/Desktop/HermesDesktop/Services/HermesEnvironment.cs
@@ -35,6 +35,15 @@ internal static class HermesEnvironment
 
     internal static bool HermesInstalled => File.Exists(HermesCommandPath);
 
+    // ── Soul system paths ──
+    internal static string SoulDir => Path.Combine(HermesHomePath, "soul");
+    internal static string SoulFilePath => Path.Combine(HermesHomePath, "SOUL.md");
+    internal static string UserFilePath => Path.Combine(HermesHomePath, "USER.md");
+    internal static string MistakesFilePath => Path.Combine(SoulDir, "mistakes.jsonl");
+    internal static string HabitsFilePath => Path.Combine(SoulDir, "habits.jsonl");
+    internal static string ProjectAgentsPath(string projectDir) =>
+        Path.Combine(HermesHomePath, "projects", Path.GetFileName(projectDir), "AGENTS.md");
+
     /// <summary>Create LlmConfig from config.yaml for DI.</summary>
     internal static Hermes.Agent.LLM.LlmConfig CreateLlmConfig() => new()
     {

--- a/Desktop/HermesDesktop/Strings/en-us/Resources.resw
+++ b/Desktop/HermesDesktop/Strings/en-us/Resources.resw
@@ -52,7 +52,7 @@
     <value>Send the current message</value>
   </data>
   <data name="ChatInitialAssistantMessage" xml:space="preserve">
-    <value>Hermes is ready. Ask me anything — I can read and write files, run commands, search the web, and more.</value>
+    <value>Ready. Type a message or /help for commands.</value>
   </data>
   <data name="ChatComposerHint" xml:space="preserve">
     <value>Desktop chat is ready.</value>

--- a/Desktop/HermesDesktop/Strings/en-us/Resources.resw
+++ b/Desktop/HermesDesktop/Strings/en-us/Resources.resw
@@ -52,7 +52,7 @@
     <value>Send the current message</value>
   </data>
   <data name="ChatInitialAssistantMessage" xml:space="preserve">
-    <value>Hermes is ready. This desktop chat keeps the conversation front and center while the agent runs through {1} behind the scenes for {0}.</value>
+    <value>Hermes is ready. Ask me anything — I can read and write files, run commands, search the web, and more.</value>
   </data>
   <data name="ChatComposerHint" xml:space="preserve">
     <value>Desktop chat is ready.</value>

--- a/Desktop/HermesDesktop/Views/ChatPage.xaml
+++ b/Desktop/HermesDesktop/Views/ChatPage.xaml
@@ -15,9 +15,9 @@
 
     <Grid x:Name="MainGrid" Padding="20,12,24,20" ColumnSpacing="14" RowSpacing="14">
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" MinWidth="400"/>
+            <ColumnDefinition Width="*" MinWidth="300"/>
             <ColumnDefinition Width="Auto"/>
-            <ColumnDefinition Width="340" MinWidth="260" MaxWidth="500"/>
+            <ColumnDefinition Width="340" MinWidth="200" MaxWidth="700"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -125,10 +125,13 @@
             </Grid>
         </Border>
 
-        <!-- Splitter -->
-        <Border Grid.Column="1" Grid.Row="1" Width="6" Background="Transparent"
-                PointerPressed="Splitter_PointerPressed" PointerMoved="Splitter_PointerMoved" PointerReleased="Splitter_PointerReleased">
-            <Border Width="2" Background="{StaticResource AppStrokeBrush}" HorizontalAlignment="Center" CornerRadius="1"/>
+        <!-- Splitter (drag to resize chat ↔ right panel) -->
+        <Border Grid.Column="1" Grid.Row="1" Width="12" Background="Transparent" Margin="-3,0"
+                PointerPressed="Splitter_PointerPressed" PointerMoved="Splitter_PointerMoved"
+                PointerReleased="Splitter_PointerReleased" PointerEntered="Splitter_PointerEntered"
+                PointerExited="Splitter_PointerExited">
+            <Border x:Name="SplitterHandle" Width="4" Background="{StaticResource AppStrokeBrush}"
+                    HorizontalAlignment="Center" CornerRadius="2" Opacity="0.5"/>
         </Border>
 
         <!-- Right Panel - Tabbed Panels -->

--- a/Desktop/HermesDesktop/Views/ChatPage.xaml
+++ b/Desktop/HermesDesktop/Views/ChatPage.xaml
@@ -32,12 +32,9 @@
             </Grid.ColumnDefinitions>
 
             <StackPanel Spacing="4">
-                <TextBlock Text="Hermes.C# - Your AI Teammate" FontSize="22" FontWeight="SemiBold" />
+                <TextBlock Text="Hermes Agent" FontSize="22" FontWeight="SemiBold" />
                 <StackPanel Orientation="Horizontal" Spacing="12">
                     <TextBlock x:Name="ConnectionStateText" Style="{StaticResource BodySecondaryTextStyle}" />
-                    <TextBlock x:Name="CurrentModelText" FontSize="13"
-                               Foreground="{StaticResource AppTextSecondaryBrush}"
-                               Text="" />
                 </StackPanel>
             </StackPanel>
 

--- a/Desktop/HermesDesktop/Views/ChatPage.xaml.cs
+++ b/Desktop/HermesDesktop/Views/ChatPage.xaml.cs
@@ -64,10 +64,6 @@ public sealed partial class ChatPage : Page
         ConnectionStateText.Text = ResourceLoader.GetString("ChatStatusChecking");
         SessionIdLabel.Text = "New Session";
 
-        // Show current model in header
-        var modelName = HermesEnvironment.DefaultModel;
-        CurrentModelText.Text = string.IsNullOrWhiteSpace(modelName) ? "" : $"Model: {modelName}";
-
         // Wire session panel click → load session into chat
         SessionPanelView.SessionSelected += OnSessionSelected;
 

--- a/Desktop/HermesDesktop/Views/ChatPage.xaml.cs
+++ b/Desktop/HermesDesktop/Views/ChatPage.xaml.cs
@@ -110,9 +110,7 @@ public sealed partial class ChatPage : Page
             }
         };
 
-        AppendSystemMessage(string.Format(CultureInfo.CurrentCulture,
-            ResourceLoader.GetString("ChatInitialAssistantMessage"),
-            "Hermes.C# Workspace", "Qwen3.5"));
+        AppendSystemMessage(ResourceLoader.GetString("ChatInitialAssistantMessage"));
 
         await RefreshConnectionStatusAsync();
     }
@@ -357,9 +355,7 @@ public sealed partial class ChatPage : Page
         Messages.Clear();
         SessionIdLabel.Text = "New Session";
 
-        AppendSystemMessage(string.Format(CultureInfo.CurrentCulture,
-            ResourceLoader.GetString("ChatInitialAssistantMessage"),
-            "Hermes.C# Workspace", "Qwen3.5"));
+        AppendSystemMessage(ResourceLoader.GetString("ChatInitialAssistantMessage"));
 
         await RefreshConnectionStatusAsync();
     }

--- a/Desktop/HermesDesktop/Views/ChatPage.xaml.cs
+++ b/Desktop/HermesDesktop/Views/ChatPage.xaml.cs
@@ -110,7 +110,7 @@ public sealed partial class ChatPage : Page
             }
         };
 
-        AppendSystemMessage(ResourceLoader.GetString("ChatInitialAssistantMessage"));
+        AppendWelcomeMessage();
 
         await RefreshConnectionStatusAsync();
     }
@@ -355,7 +355,7 @@ public sealed partial class ChatPage : Page
         Messages.Clear();
         SessionIdLabel.Text = "New Session";
 
-        AppendSystemMessage(ResourceLoader.GetString("ChatInitialAssistantMessage"));
+        AppendWelcomeMessage();
 
         await RefreshConnectionStatusAsync();
     }
@@ -403,6 +403,29 @@ public sealed partial class ChatPage : Page
     private void AppendSystemMessage(string text) =>
         AddMessage(ResourceLoader.GetString("ChatSystemLabel"), text, HorizontalAlignment.Left,
             _systemBackgroundBrush, _systemBorderBrush, _secondaryLabelBrush);
+
+    private void AppendWelcomeMessage()
+    {
+        var caduceus =
+            "            ⠀⠀⠀⢀⣀⡀⠀⣀⣀⠀⢀⣀⡀\n" +
+            "            ⢀⣠⣴⣾⣿⣿⣇⠸⣿⣿⠇⣸⣿⣿⣷⣦⣄⡀\n" +
+            "       ⢀⣠⣴⣶⠿⠋⣩⡿⣿⡿⠻⣿⡇⢠⡄⢸⣿⠟⢿⣿⢿⣍⠙⠿⣶⣦⣄⡀\n" +
+            "       ⠀⠉⠉⠁⠶⠟⠋⠀⠉⠀⢀⣈⣁⡈⢁⣈⣁⡀⠀⠉⠀⠙⠻⠶⠈⠉⠉\n" +
+            "            ⠀⠀⠀⠀⠀⠀⣴⣿⡿⠛⢁⡈⠛⢿⣿⣦\n" +
+            "            ⠀⠀⠀⠀⠀⠀⠿⣿⣦⣤⣈⠁⢠⣴⣿⠿\n" +
+            "            ⠀⠀⠀⠀⠀⠀⠀⠈⠉⠻⢿⣿⣦⡉⠁\n" +
+            "            ⠀⠀⠀⠀⠀⠀⠀⠀⠘⢷⣦⣈⠛⠃\n" +
+            "            ⠀⠀⠀⠀⠀⠀⢠⣴⠦⠈⠙⠿⣦⡄\n" +
+            "            ⠀⠀⠀⠀⠀⠀⠸⣿⣤⡈⠁⢤⣿⠇\n" +
+            "            ⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⠷⠄\n" +
+            "            ⠀⠀⠀⠀⠀⠀⠀⢀⣀⠑⢶⣄⡀\n" +
+            "            ⠀⠀⠀⠀⠀⠀⠀⣿⠁⢰⡆⠈⡿\n" +
+            "            ⠀⠀⠀⠀⠀⠀⠀⠈⠳⠈⣡⠞⠁\n\n" +
+            "         H E R M E S   A G E N T\n\n" +
+            "  Ready. Type a message or /help for commands.";
+
+        AppendSystemMessage(caduceus);
+    }
 
     private ChatMessageItem AddMessage(string author, string content, HorizontalAlignment align,
         Brush bg, Brush border, Brush label, ChatMessageType type = ChatMessageType.Text)

--- a/Desktop/HermesDesktop/Views/ChatPage.xaml.cs
+++ b/Desktop/HermesDesktop/Views/ChatPage.xaml.cs
@@ -453,6 +453,8 @@ public sealed partial class ChatPage : Page
     {
         _isDragging = true;
         ((UIElement)sender).CapturePointer(e.Pointer);
+        SplitterHandle.Opacity = 1.0;
+        SplitterHandle.Background = (Brush)Application.Current.Resources["AppAccentBrush"];
         e.Handled = true;
     }
 
@@ -470,7 +472,27 @@ public sealed partial class ChatPage : Page
     {
         _isDragging = false;
         ((UIElement)sender).ReleasePointerCapture(e.Pointer);
+        SplitterHandle.Opacity = 0.5;
+        SplitterHandle.Background = (Brush)Application.Current.Resources["AppStrokeBrush"];
         e.Handled = true;
+    }
+
+    private void Splitter_PointerEntered(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
+    {
+        if (!_isDragging)
+        {
+            SplitterHandle.Opacity = 0.8;
+            ProtectedCursor = Microsoft.UI.Input.InputSystemCursor.Create(Microsoft.UI.Input.InputSystemCursorShape.SizeWestEast);
+        }
+    }
+
+    private void Splitter_PointerExited(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
+    {
+        if (!_isDragging)
+        {
+            SplitterHandle.Opacity = 0.5;
+            ProtectedCursor = Microsoft.UI.Input.InputSystemCursor.Create(Microsoft.UI.Input.InputSystemCursorShape.Arrow);
+        }
     }
 
     // ── Panel Tabs ──

--- a/Desktop/HermesDesktop/Views/Panels/MemoryPanel.xaml
+++ b/Desktop/HermesDesktop/Views/Panels/MemoryPanel.xaml
@@ -4,41 +4,136 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <Grid RowDefinitions="Auto,*,Auto">
-        <TextBlock Text="Memory" Style="{StaticResource SectionTitleTextStyle}" Margin="0,0,0,8"/>
+    <Grid RowDefinitions="Auto,Auto,*">
+        <!-- Tab selector -->
+        <StackPanel Orientation="Horizontal" Spacing="2" Margin="0,0,0,8">
+            <Button x:Name="TabMemories" Content="Memories" Click="SubTab_Click" Tag="memories"
+                    Background="Transparent" Foreground="{StaticResource AppAccentTextBrush}" FontSize="11" Padding="8,4" CornerRadius="6" MinWidth="0"/>
+            <Button x:Name="TabSoul" Content="Soul" Click="SubTab_Click" Tag="soul"
+                    Background="Transparent" Foreground="{StaticResource AppTextSecondaryBrush}" FontSize="11" Padding="8,4" CornerRadius="6" MinWidth="0"/>
+            <Button x:Name="TabProject" Content="Project" Click="SubTab_Click" Tag="project"
+                    Background="Transparent" Foreground="{StaticResource AppTextSecondaryBrush}" FontSize="11" Padding="8,4" CornerRadius="6" MinWidth="0"/>
+        </StackPanel>
 
-        <TextBlock Grid.Row="1" x:Name="EmptyState" Visibility="Collapsed"
-                   Text="No memories yet.&#x0a;Memories are created automatically during conversations."
-                   Foreground="{StaticResource AppTextSecondaryBrush}"
-                   HorizontalAlignment="Center" VerticalAlignment="Center"
-                   TextAlignment="Center" FontSize="13" Opacity="0.7"/>
+        <!-- ═══ Memories Tab ═══ -->
+        <Grid x:Name="MemoriesContent" Grid.Row="2" RowDefinitions="*,Auto">
+            <TextBlock x:Name="EmptyState" Visibility="Collapsed"
+                       Text="No memories yet.&#x0a;Memories are created automatically during conversations."
+                       Foreground="{StaticResource AppTextSecondaryBrush}"
+                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                       TextAlignment="Center" FontSize="13" Opacity="0.7"/>
 
-        <ListView Grid.Row="1" x:Name="MemoryList" SelectionChanged="MemoryList_SelectionChanged" Background="Transparent">
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <Grid ColumnDefinitions="*,Auto" Margin="0,4">
-                        <StackPanel>
-                            <TextBlock Text="{Binding Filename}" FontSize="13" FontWeight="SemiBold"
-                                       Foreground="{StaticResource AppAccentTextBrush}"/>
-                            <StackPanel Orientation="Horizontal" Spacing="8">
-                                <Border Background="{Binding TypeColor}" CornerRadius="4" Padding="6,2">
-                                    <TextBlock Text="{Binding Type}" FontSize="10" Foreground="White"/>
-                                </Border>
-                                <TextBlock Text="{Binding Age}" FontSize="11" Foreground="{Binding AgeBrush}"/>
+            <ListView x:Name="MemoryList" SelectionChanged="MemoryList_SelectionChanged" Background="Transparent">
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <Grid ColumnDefinitions="*,Auto" Margin="0,4">
+                            <StackPanel>
+                                <TextBlock Text="{Binding Filename}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource AppAccentTextBrush}"/>
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <Border Background="{Binding TypeColor}" CornerRadius="4" Padding="6,2">
+                                        <TextBlock Text="{Binding Type}" FontSize="10" Foreground="White"/>
+                                    </Border>
+                                    <TextBlock Text="{Binding Age}" FontSize="11" Foreground="{Binding AgeBrush}"/>
+                                </StackPanel>
                             </StackPanel>
-                        </StackPanel>
-                    </Grid>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
+                        </Grid>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
 
-        <!-- Editor -->
-        <Border Grid.Row="2" x:Name="EditorBorder" Style="{StaticResource InsetCardStyle}"
-                Visibility="Collapsed" MaxHeight="200" Margin="0,6,0,0">
-            <ScrollViewer>
-                <TextBox x:Name="EditorText" FontSize="12" AcceptsReturn="True" TextWrapping="Wrap"
-                         Background="Transparent" BorderThickness="0"/>
-            </ScrollViewer>
-        </Border>
+            <!-- Memory editor -->
+            <Border Grid.Row="1" x:Name="EditorBorder" Style="{StaticResource InsetCardStyle}"
+                    Visibility="Collapsed" MaxHeight="200" Margin="0,6,0,0">
+                <ScrollViewer>
+                    <TextBox x:Name="EditorText" FontSize="12" AcceptsReturn="True" TextWrapping="Wrap"
+                             Background="Transparent" BorderThickness="0"/>
+                </ScrollViewer>
+            </Border>
+        </Grid>
+
+        <!-- ═══ Soul Tab ═══ -->
+        <ScrollViewer x:Name="SoulContent" Grid.Row="2" Visibility="Collapsed">
+            <StackPanel Spacing="12" Padding="0,4">
+                <!-- SOUL.md editor -->
+                <StackPanel Spacing="4">
+                    <TextBlock Text="Agent Identity (SOUL.md)" FontSize="13" FontWeight="SemiBold"
+                               Foreground="{StaticResource AppAccentTextBrush}"/>
+                    <TextBox x:Name="SoulEditor" AcceptsReturn="True" TextWrapping="Wrap"
+                             MinHeight="120" MaxHeight="200" FontSize="12" FontFamily="Consolas"
+                             Background="{StaticResource AppInsetBrush}" BorderBrush="{StaticResource AppStrokeBrush}"/>
+                    <Button Content="Save Soul" Click="SaveSoul_Click" FontSize="11" Padding="12,4"
+                            Background="{StaticResource AppAccentGradientBrush}" Foreground="#16110D"/>
+                </StackPanel>
+
+                <!-- USER.md editor -->
+                <StackPanel Spacing="4">
+                    <TextBlock Text="User Profile (USER.md)" FontSize="13" FontWeight="SemiBold"
+                               Foreground="{StaticResource AppAccentTextBrush}"/>
+                    <TextBox x:Name="UserEditor" AcceptsReturn="True" TextWrapping="Wrap"
+                             MinHeight="100" MaxHeight="180" FontSize="12" FontFamily="Consolas"
+                             Background="{StaticResource AppInsetBrush}" BorderBrush="{StaticResource AppStrokeBrush}"/>
+                    <Button Content="Save User Profile" Click="SaveUser_Click" FontSize="11" Padding="12,4"
+                            Background="{StaticResource AppAccentGradientBrush}" Foreground="#16110D"/>
+                </StackPanel>
+
+                <!-- Mistakes journal (read-only) -->
+                <StackPanel Spacing="4">
+                    <TextBlock Text="Learned from Mistakes" FontSize="13" FontWeight="SemiBold"
+                               Foreground="#FF6B6B"/>
+                    <ListView x:Name="MistakesList" Background="Transparent" SelectionMode="None" MaxHeight="150">
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="0,2">
+                                    <TextBlock Text="{Binding Lesson}" FontSize="12" TextWrapping="Wrap"
+                                               Foreground="{StaticResource AppTextSecondaryBrush}"/>
+                                    <TextBlock Text="{Binding TimestampText}" FontSize="10" Opacity="0.5"
+                                               Foreground="{StaticResource AppTextSecondaryBrush}"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                    <TextBlock x:Name="NoMistakes" Text="No mistakes recorded yet."
+                               FontSize="11" Opacity="0.5" Foreground="{StaticResource AppTextSecondaryBrush}"/>
+                </StackPanel>
+
+                <!-- Habits journal (read-only) -->
+                <StackPanel Spacing="4">
+                    <TextBlock Text="Good Habits" FontSize="13" FontWeight="SemiBold"
+                               Foreground="#6BCB77"/>
+                    <ListView x:Name="HabitsList" Background="Transparent" SelectionMode="None" MaxHeight="150">
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="0,2">
+                                    <TextBlock Text="{Binding Habit}" FontSize="12" TextWrapping="Wrap"
+                                               Foreground="{StaticResource AppTextSecondaryBrush}"/>
+                                    <TextBlock Text="{Binding TimestampText}" FontSize="10" Opacity="0.5"
+                                               Foreground="{StaticResource AppTextSecondaryBrush}"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                    <TextBlock x:Name="NoHabits" Text="No good habits recorded yet."
+                               FontSize="11" Opacity="0.5" Foreground="{StaticResource AppTextSecondaryBrush}"/>
+                </StackPanel>
+            </StackPanel>
+        </ScrollViewer>
+
+        <!-- ═══ Project Tab ═══ -->
+        <ScrollViewer x:Name="ProjectContent" Grid.Row="2" Visibility="Collapsed">
+            <StackPanel Spacing="12" Padding="0,4">
+                <StackPanel Spacing="4">
+                    <TextBlock Text="Project Rules (AGENTS.md)" FontSize="13" FontWeight="SemiBold"
+                               Foreground="{StaticResource AppAccentTextBrush}"/>
+                    <TextBlock Text="Define coding conventions, architecture patterns, and project-specific rules."
+                               FontSize="11" Foreground="{StaticResource AppTextSecondaryBrush}" Opacity="0.7"/>
+                    <TextBox x:Name="AgentsEditor" AcceptsReturn="True" TextWrapping="Wrap"
+                             MinHeight="200" MaxHeight="400" FontSize="12" FontFamily="Consolas"
+                             Background="{StaticResource AppInsetBrush}" BorderBrush="{StaticResource AppStrokeBrush}"/>
+                    <Button Content="Save Project Rules" Click="SaveAgents_Click" FontSize="11" Padding="12,4"
+                            Background="{StaticResource AppAccentGradientBrush}" Foreground="#16110D"/>
+                </StackPanel>
+            </StackPanel>
+        </ScrollViewer>
     </Grid>
 </UserControl>

--- a/Desktop/HermesDesktop/Views/Panels/MemoryPanel.xaml.cs
+++ b/Desktop/HermesDesktop/Views/Panels/MemoryPanel.xaml.cs
@@ -2,10 +2,13 @@ using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using Hermes.Agent.Soul;
 using HermesDesktop.Services;
 
 namespace HermesDesktop.Views.Panels;
@@ -21,9 +24,23 @@ public sealed class MemoryListItem
     public SolidColorBrush AgeBrush { get; set; } = new(ColorHelper.FromArgb(255, 149, 162, 177));
 }
 
+public sealed class MistakeDisplayItem
+{
+    public string Lesson { get; set; } = "";
+    public string TimestampText { get; set; } = "";
+}
+
+public sealed class HabitDisplayItem
+{
+    public string Habit { get; set; } = "";
+    public string TimestampText { get; set; } = "";
+}
+
 public sealed partial class MemoryPanel : UserControl
 {
     private readonly string _memoryDir;
+    private SoulService? _soulService;
+    private string _activeTab = "memories";
 
     public ObservableCollection<MemoryListItem> Memories { get; } = new();
 
@@ -31,10 +48,47 @@ public sealed partial class MemoryPanel : UserControl
     {
         InitializeComponent();
         _memoryDir = Path.Combine(HermesEnvironment.HermesHomePath, "hermes-cs", "memory");
-        Loaded += (_, _) => Refresh();
+        Loaded += (_, _) =>
+        {
+            _soulService = App.Services?.GetService<SoulService>();
+            Refresh();
+        };
     }
 
     public void Refresh()
+    {
+        if (_activeTab == "memories") RefreshMemories();
+        else if (_activeTab == "soul") _ = RefreshSoulAsync();
+        else if (_activeTab == "project") _ = RefreshProjectAsync();
+    }
+
+    // ── Tab switching ──
+
+    private void SubTab_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button btn && btn.Tag is string tag)
+        {
+            _activeTab = tag;
+
+            // Update tab button styles
+            var accentBrush = Application.Current.Resources["AppAccentTextBrush"] as Brush;
+            var secondaryBrush = Application.Current.Resources["AppTextSecondaryBrush"] as Brush;
+            TabMemories.Foreground = tag == "memories" ? accentBrush : secondaryBrush;
+            TabSoul.Foreground = tag == "soul" ? accentBrush : secondaryBrush;
+            TabProject.Foreground = tag == "project" ? accentBrush : secondaryBrush;
+
+            // Switch content visibility
+            MemoriesContent.Visibility = tag == "memories" ? Visibility.Visible : Visibility.Collapsed;
+            SoulContent.Visibility = tag == "soul" ? Visibility.Visible : Visibility.Collapsed;
+            ProjectContent.Visibility = tag == "project" ? Visibility.Visible : Visibility.Collapsed;
+
+            Refresh();
+        }
+    }
+
+    // ── Memories tab ──
+
+    private void RefreshMemories()
     {
         Memories.Clear();
         if (!Directory.Exists(_memoryDir))
@@ -81,9 +135,7 @@ public sealed partial class MemoryPanel : UserControl
             catch { /* skip unreadable */ }
         }
         MemoryList.ItemsSource = Memories;
-        EmptyState.Visibility = Memories.Count == 0
-            ? Visibility.Visible
-            : Visibility.Collapsed;
+        EmptyState.Visibility = Memories.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private void MemoryList_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -94,6 +146,81 @@ public sealed partial class MemoryPanel : UserControl
             EditorBorder.Visibility = Visibility.Visible;
         }
     }
+
+    // ── Soul tab ──
+
+    private async System.Threading.Tasks.Task RefreshSoulAsync()
+    {
+        if (_soulService is null) return;
+
+        try
+        {
+            SoulEditor.Text = await _soulService.LoadFileAsync(SoulFileType.Soul);
+            UserEditor.Text = await _soulService.LoadFileAsync(SoulFileType.User);
+
+            // Load mistakes
+            var mistakes = await _soulService.LoadMistakesAsync();
+            var mistakeItems = mistakes.TakeLast(20).Reverse().Select(m => new MistakeDisplayItem
+            {
+                Lesson = m.Lesson,
+                TimestampText = m.Timestamp.ToString("yyyy-MM-dd HH:mm")
+            }).ToList();
+            MistakesList.ItemsSource = mistakeItems;
+            NoMistakes.Visibility = mistakeItems.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            MistakesList.Visibility = mistakeItems.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
+
+            // Load habits
+            var habits = await _soulService.LoadHabitsAsync();
+            var habitItems = habits.TakeLast(20).Reverse().Select(h => new HabitDisplayItem
+            {
+                Habit = h.Habit,
+                TimestampText = h.Timestamp.ToString("yyyy-MM-dd HH:mm")
+            }).ToList();
+            HabitsList.ItemsSource = habitItems;
+            NoHabits.Visibility = habitItems.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            HabitsList.Visibility = habitItems.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Failed to load soul data: {ex.Message}");
+        }
+    }
+
+    private async void SaveSoul_Click(object sender, RoutedEventArgs e)
+    {
+        if (_soulService is null) return;
+        await _soulService.SaveFileAsync(SoulFileType.Soul, SoulEditor.Text);
+    }
+
+    private async void SaveUser_Click(object sender, RoutedEventArgs e)
+    {
+        if (_soulService is null) return;
+        await _soulService.SaveFileAsync(SoulFileType.User, UserEditor.Text);
+    }
+
+    // ── Project tab ──
+
+    private async System.Threading.Tasks.Task RefreshProjectAsync()
+    {
+        if (_soulService is null) return;
+
+        try
+        {
+            AgentsEditor.Text = await _soulService.LoadFileAsync(SoulFileType.ProjectRules);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Failed to load project rules: {ex.Message}");
+        }
+    }
+
+    private async void SaveAgents_Click(object sender, RoutedEventArgs e)
+    {
+        if (_soulService is null) return;
+        await _soulService.SaveFileAsync(SoulFileType.ProjectRules, AgentsEditor.Text);
+    }
+
+    // ── Helpers ──
 
     private static string FormatAge(DateTime timestamp)
     {

--- a/src/Context/ContextManager.cs
+++ b/src/Context/ContextManager.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using Hermes.Agent.Core;
 using Hermes.Agent.LLM;
+using Hermes.Agent.Soul;
 using Hermes.Agent.Transcript;
 using Microsoft.Extensions.Logging;
 
@@ -20,6 +21,7 @@ public sealed class ContextManager
     private readonly TokenBudget _budget;
     private readonly PromptBuilder _promptBuilder;
     private readonly ILogger<ContextManager> _logger;
+    private readonly SoulService? _soulService;
 
     private readonly ConcurrentDictionary<string, SessionState> _sessionStates = new();
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _sessionLocks = new();
@@ -32,13 +34,15 @@ public sealed class ContextManager
         IChatClient chatClient,
         TokenBudget budget,
         PromptBuilder promptBuilder,
-        ILogger<ContextManager> logger)
+        ILogger<ContextManager> logger,
+        SoulService? soulService = null)
     {
         _transcripts = transcripts;
         _chatClient = chatClient;
         _budget = budget;
         _promptBuilder = promptBuilder;
         _logger = logger;
+        _soulService = soulService;
     }
 
     /// <summary>
@@ -121,13 +125,28 @@ public sealed class ContextManager
             // Increment turn count only after all async work succeeds
             state.TurnCount++;
 
+            // Load soul context (identity, user profile, project rules, learned behaviors)
+            string? soulContext = null;
+            if (_soulService is not null)
+            {
+                try
+                {
+                    soulContext = await _soulService.AssembleSoulContextAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to load soul context — continuing without it");
+                }
+            }
+
             // Build the prompt
             var packet = _promptBuilder.Build(new BuildRequest
             {
                 State = state,
                 CurrentUserMessage = userMessage,
                 RecentTurns = recentTurns,
-                RetrievedContext = retrievedContext
+                RetrievedContext = retrievedContext,
+                SoulContext = soulContext
             });
 
             return _promptBuilder.ToOpenAiMessages(packet);

--- a/src/Context/PromptBuilder.cs
+++ b/src/Context/PromptBuilder.cs
@@ -50,6 +50,7 @@ public sealed class PromptBuilder
         return new PromptPacket
         {
             SystemPrompt = _systemPrompt,
+            SoulContext = request.SoulContext,
             SessionStateJson = stateJson,
             RetrievedContext = request.RetrievedContext,
             RecentTurns = request.RecentTurns,
@@ -69,6 +70,17 @@ public sealed class PromptBuilder
     public List<Message> ToOpenAiMessages(PromptPacket packet)
     {
         var messages = new List<Message>();
+
+        // Layer 0: Soul context (identity, user profile, project rules, learned behaviors)
+        // Changes extremely rarely — excellent cache anchor. Injected before system prompt.
+        if (!string.IsNullOrWhiteSpace(packet.SoulContext))
+        {
+            messages.Add(new Message
+            {
+                Role = "system",
+                Content = packet.SoulContext
+            });
+        }
 
         // Layer 1: Stable system prompt (cache anchor — never changes)
         messages.Add(new Message
@@ -139,6 +151,9 @@ public sealed class BuildRequest
 
     /// <summary>Optional context chunks retrieved on demand (e.g. from memory or search).</summary>
     public List<string>? RetrievedContext { get; init; }
+
+    /// <summary>Optional assembled soul context (identity, user profile, project rules, learned behaviors).</summary>
+    public string? SoulContext { get; init; }
 }
 
 /// <summary>Assembled prompt ready for conversion to provider message format.</summary>
@@ -152,6 +167,9 @@ public sealed class PromptPacket
 
     /// <summary>Optional retrieved context chunks.</summary>
     public List<string>? RetrievedContext { get; init; }
+
+    /// <summary>Assembled soul context (identity, user profile, project rules, learned behaviors).</summary>
+    public string? SoulContext { get; init; }
 
     /// <summary>Recent conversation turns from the sliding window.</summary>
     public List<Message> RecentTurns { get; init; } = new();

--- a/src/Core/SystemPrompts.cs
+++ b/src/Core/SystemPrompts.cs
@@ -1,0 +1,88 @@
+namespace Hermes.Agent.Core;
+
+/// <summary>
+/// Default system prompt for the Hermes Agent.
+/// Modeled after Claude Code's approach: detailed tool usage guidance,
+/// coding best practices, and quality guardrails.
+/// </summary>
+public static class SystemPrompts
+{
+    /// <summary>
+    /// The default system prompt used as the cache anchor in PromptBuilder.
+    /// Soul context (identity, user profile, project rules) is injected as Layer 0 BEFORE this.
+    /// </summary>
+    public const string Default = @"You are Hermes, an AI coding agent running in a native desktop environment. You have direct access to the user's filesystem and can execute shell commands. You help users with software engineering tasks including writing code, debugging, running tests, and managing projects.
+
+# Tool Usage Guidelines
+
+## Reading Files
+- ALWAYS read a file before editing or overwriting it. Never blindly write to a file you haven't read.
+- Use `read_file` with offset/limit for large files — don't read entire files when you only need a section.
+- Use `glob` to find files by pattern before reading — don't guess file paths.
+- Use `grep` to search for specific content — it's faster than reading entire directories.
+
+## Editing Files
+- Prefer `edit_file` (string replacement) over `write_file` (full overwrite) for modifications.
+- The `old_string` in edit_file must be an EXACT match of existing content, including whitespace and indentation.
+- Include enough surrounding context in `old_string` to ensure uniqueness — if the string appears multiple times, the edit will fail.
+- After editing, verify your changes make sense in context. Don't leave partial edits.
+
+## Writing Files
+- Use `write_file` only for creating NEW files or when a complete rewrite is necessary.
+- You MUST read the file first before overwriting — the tool enforces this.
+- Preserve the original file's style, conventions, and formatting.
+
+## Shell Commands (bash)
+- Use bash for: running tests, building projects, git operations, installing dependencies, checking system state.
+- Keep commands focused and single-purpose. Chain with && when commands depend on each other.
+- For long-running processes, use background execution.
+- Always quote file paths that may contain spaces.
+- Never run destructive commands (rm -rf, git reset --hard, etc.) without explicit user confirmation.
+
+## Search Strategy
+- Start broad with `glob` to understand project structure.
+- Use `grep` with specific patterns to find relevant code.
+- Read the most relevant files based on search results.
+- Only then start making changes.
+
+# Coding Best Practices
+
+## Code Quality
+- Follow the existing code style and conventions of the project.
+- Write clean, readable code with meaningful names.
+- Add comments for non-obvious logic, but don't over-comment obvious code.
+- Handle errors appropriately — don't swallow exceptions silently.
+- Prefer simple, direct solutions over clever abstractions.
+
+## Making Changes
+- Understand the codebase before modifying it. Read related files first.
+- Make minimal, focused changes. Don't refactor unrelated code.
+- When adding new features, follow existing patterns in the codebase.
+- Test your changes when possible — run the project's test suite.
+- If you break something, fix it before moving on.
+
+## Git Operations
+- Write clear, descriptive commit messages that explain WHY, not just WHAT.
+- Commit related changes together, unrelated changes separately.
+- Never force-push to shared branches without asking.
+- Check `git status` and `git diff` before committing.
+
+# Communication Style
+
+- Be direct and concise. Lead with the answer or action.
+- Show your work — explain what you found and why you're making specific changes.
+- When uncertain, say so and explain your reasoning.
+- If a task is complex, break it down and explain your approach before starting.
+- After completing work, summarize what was done and any follow-up needed.
+- Don't repeat back the user's request — just do it.
+- If you encounter an error, diagnose it and fix it. Don't just report it.
+
+# Important Constraints
+
+- Never output secrets, API keys, passwords, or tokens in your responses.
+- Respect .gitignore and don't commit sensitive files.
+- If a file looks auto-generated, don't edit it — edit the source instead.
+- When you see a build or test failure, investigate and fix it before declaring success.
+- Be careful with file paths — use the correct OS path separator for the platform.
+- This is a Windows environment — use appropriate commands and path formats.";
+}

--- a/src/Core/agent.cs
+++ b/src/Core/agent.cs
@@ -3,6 +3,7 @@ namespace Hermes.Agent.Core;
 using Hermes.Agent.LLM;
 using Hermes.Agent.Permissions;
 using Hermes.Agent.Security;
+using Hermes.Agent.Soul;
 using Hermes.Agent.Transcript;
 using Hermes.Agent.Memory;
 using Hermes.Agent.Context;
@@ -20,6 +21,7 @@ public sealed class Agent : IAgent
     private readonly TranscriptStore? _transcripts;
     private readonly MemoryManager? _memories;
     private readonly ContextManager? _contextManager;
+    private readonly SoulService? _soulService;
 
     /// <summary>Safety limit to prevent infinite tool loops.</summary>
     public int MaxToolIterations { get; set; } = 25;
@@ -46,7 +48,8 @@ public sealed class Agent : IAgent
         PermissionManager? permissions = null,
         TranscriptStore? transcripts = null,
         MemoryManager? memories = null,
-        ContextManager? contextManager = null)
+        ContextManager? contextManager = null,
+        SoulService? soulService = null)
     {
         _chatClient = chatClient;
         _logger = logger;
@@ -54,6 +57,7 @@ public sealed class Agent : IAgent
         _transcripts = transcripts;
         _memories = memories;
         _contextManager = contextManager;
+        _soulService = soulService;
     }
 
     public void RegisterTool(ITool tool)
@@ -114,6 +118,30 @@ public sealed class Agent : IAgent
             await _transcripts.SaveMessageAsync(session.Id, userMessage, ct);
 
         _logger.LogInformation("Processing message for session {SessionId}", session.Id);
+
+        // ── Soul injection (fallback path — when ContextManager is null) ──
+        // If ContextManager is available, it handles soul injection via PromptBuilder.
+        // If not, inject soul context directly as the first system message.
+        if (_contextManager is null && _soulService is not null)
+        {
+            try
+            {
+                var soulContext = await _soulService.AssembleSoulContextAsync();
+                if (!string.IsNullOrWhiteSpace(soulContext))
+                {
+                    // Insert soul as first message (before memories)
+                    session.Messages.Insert(0, new Message
+                    {
+                        Role = "system",
+                        Content = soulContext
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to load soul context, continuing without it");
+            }
+        }
 
         // ── Context manager integration ──
         // If ContextManager is available, use it to build optimized context instead of raw session.Messages
@@ -298,6 +326,25 @@ public sealed class Agent : IAgent
                 activityEntry.DurationMs = sw.ElapsedMilliseconds;
                 activityEntry.Status = result.Success ? ActivityStatus.Success : ActivityStatus.Failed;
                 activityEntry.OutputSummary = Truncate(result.Content, 200);
+
+                // ── Soul: record mistakes on tool failure ──
+                if (!result.Success && _soulService is not null)
+                {
+                    _ = Task.Run(async () =>
+                    {
+                        try
+                        {
+                            await _soulService.RecordMistakeAsync(new MistakeEntry
+                            {
+                                Context = $"Tool: {toolCall.Name}, Args: {Truncate(toolCall.Arguments, 100)}",
+                                Mistake = $"Tool execution failed: {Truncate(result.Content, 200)}",
+                                Correction = "Tool returned an error — review approach",
+                                Lesson = $"When using {toolCall.Name}, verify inputs before execution"
+                            });
+                        }
+                        catch { /* fire and forget */ }
+                    }, CancellationToken.None);
+                }
 
                 // Detect diff content
                 if (result.Content.Contains("--- a/") || result.Content.Contains("+++ b/"))

--- a/src/dream/autodreamservice.cs
+++ b/src/dream/autodreamservice.cs
@@ -2,6 +2,7 @@ namespace Hermes.Agent.Dream;
 
 using Hermes.Agent.LLM;
 using Hermes.Agent.Core;
+using Hermes.Agent.Soul;
 using Hermes.Agent.Transcript;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Hosting;
@@ -21,6 +22,8 @@ public sealed class AutoDreamService : BackgroundService
     private readonly string _memoryDir;
     private readonly IChatClient _chatClient;
     private readonly TranscriptStore _transcriptStore;
+    private readonly SoulService? _soulService;
+    private readonly SoulExtractor? _soulExtractor;
     private DateTime _lastConsolidation = DateTime.MinValue;
 
     public AutoDreamService(
@@ -28,13 +31,17 @@ public sealed class AutoDreamService : BackgroundService
         ILoggerFactory loggerFactory,
         string memoryDir,
         IChatClient chatClient,
-        TranscriptStore transcriptStore)
+        TranscriptStore transcriptStore,
+        SoulService? soulService = null,
+        SoulExtractor? soulExtractor = null)
     {
         _logger = logger;
         _loggerFactory = loggerFactory;
         _memoryDir = memoryDir;
         _chatClient = chatClient;
         _transcriptStore = transcriptStore;
+        _soulService = soulService;
+        _soulExtractor = soulExtractor;
         Directory.CreateDirectory(memoryDir);
     }
 
@@ -103,6 +110,48 @@ public sealed class AutoDreamService : BackgroundService
             _loggerFactory.CreateLogger<ConsolidationAgent>());
 
         await consolidator.ConsolidateAsync(sessions, ct);
+
+        // ── Soul extraction: extract mistakes, habits, user profile signals ──
+        if (_soulService is not null && _soulExtractor is not null)
+        {
+            try
+            {
+                var combinedTranscript = string.Join("\n---\n",
+                    sessions.Select(s => FormatTranscriptForSoul(s)));
+
+                // Truncate to reasonable size for LLM
+                if (combinedTranscript.Length > 8000)
+                    combinedTranscript = combinedTranscript[..8000] + "\n[...truncated]";
+
+                var existingProfile = await _soulService.LoadFileAsync(SoulFileType.User);
+                var extraction = await _soulExtractor.ExtractAsync(combinedTranscript, existingProfile, ct);
+
+                // Record mistakes
+                foreach (var mistake in extraction.Mistakes)
+                    await _soulService.RecordMistakeAsync(mistake);
+
+                // Record habits
+                foreach (var habit in extraction.Habits)
+                    await _soulService.RecordHabitAsync(habit);
+
+                // Update user profile if there are significant new signals
+                if (extraction.UserProfileUpdate is not null)
+                {
+                    var currentProfile = await _soulService.LoadFileAsync(SoulFileType.User);
+                    var updatedProfile = currentProfile + "\n\n## Auto-Updated " + DateTime.UtcNow.ToString("yyyy-MM-dd") + "\n" + extraction.UserProfileUpdate;
+                    await _soulService.SaveFileAsync(SoulFileType.User, updatedProfile);
+                }
+
+                _logger.LogInformation(
+                    "Soul extraction: {Mistakes} mistakes, {Habits} habits recorded",
+                    extraction.Mistakes.Count, extraction.Habits.Count);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Soul extraction failed during dream consolidation");
+            }
+        }
+
         _lastConsolidation = DateTime.UtcNow;
 
         _logger.LogInformation("Dream consolidation complete");
@@ -129,6 +178,24 @@ public sealed class AutoDreamService : BackgroundService
     }
 
     private int GetSessionCount() => _transcriptStore.GetAllSessionIds().Count;
+
+    private static string FormatTranscriptForSoul(DreamSession session)
+    {
+        const int MaxChars = 3000;
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine($"## Session: {session.Id}");
+
+        foreach (var msg in session.Messages)
+        {
+            if (msg.Role == "tool") continue;
+            sb.AppendLine($"### {msg.Role}");
+            sb.AppendLine(msg.Content.Length > 400 ? msg.Content[..400] + "..." : msg.Content);
+            sb.AppendLine();
+            if (sb.Length > MaxChars) break;
+        }
+
+        return sb.Length > MaxChars ? sb.ToString()[..MaxChars] + "\n[...truncated]" : sb.ToString();
+    }
 }
 
 /// <summary>

--- a/src/soul/SoulExtractor.cs
+++ b/src/soul/SoulExtractor.cs
@@ -1,0 +1,203 @@
+namespace Hermes.Agent.Soul;
+
+using Hermes.Agent.Core;
+using Hermes.Agent.LLM;
+using Microsoft.Extensions.Logging;
+using System.Text.RegularExpressions;
+
+/// <summary>
+/// LLM-powered extractor that analyzes transcripts for mistakes, habits,
+/// and user profile signals. Used by the Dream consolidation service.
+/// </summary>
+public sealed class SoulExtractor
+{
+    private readonly IChatClient _chatClient;
+    private readonly ILogger<SoulExtractor> _logger;
+
+    public SoulExtractor(IChatClient chatClient, ILogger<SoulExtractor> logger)
+    {
+        _chatClient = chatClient;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Analyze transcript text for soul signals: mistakes, habits, and user profile updates.
+    /// </summary>
+    public async Task<SoulExtractionResult> ExtractAsync(
+        string transcriptText,
+        string? existingUserProfile,
+        CancellationToken ct)
+    {
+        var prompt = BuildExtractionPrompt(transcriptText, existingUserProfile);
+
+        try
+        {
+            var response = await _chatClient.CompleteAsync(
+                [new Message { Role = "user", Content = prompt }], ct);
+
+            return ParseExtractionResponse(response);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Soul extraction failed");
+            return new SoulExtractionResult();
+        }
+    }
+
+    private static string BuildExtractionPrompt(string transcriptText, string? existingUserProfile)
+    {
+        var userProfileSection = string.IsNullOrWhiteSpace(existingUserProfile)
+            ? "(no existing user profile)"
+            : existingUserProfile;
+
+        return $@"You are a behavioral analyst for an AI agent. Analyze this conversation transcript and extract behavioral signals.
+
+## Existing User Profile
+{userProfileSection}
+
+## Recent Transcript
+{transcriptText}
+
+## Your Task
+Identify these patterns in the conversation:
+
+### MISTAKES
+When the agent did something wrong and the user corrected it. Look for:
+- ""No, that's wrong"", ""don't do that"", ""that's not right""
+- User providing a correction after agent output
+- Failed tool calls that the user had to guide
+
+### HABITS
+When the agent did something right and the user confirmed it. Look for:
+- ""Perfect"", ""exactly"", ""that's great"", ""nice""
+- User expressing satisfaction with an approach
+- Successful patterns the agent should repeat
+
+### USER PROFILE
+New signals about who the user is:
+- Technical skill level (novice/intermediate/expert)
+- Preferred tools or approaches
+- Communication style preferences
+- Domain expertise
+
+## Response Format
+Return EXACTLY this format (include sections even if empty):
+
+## MISTAKES
+For each mistake:
+```
+CONTEXT: what was happening
+MISTAKE: what went wrong
+CORRECTION: what the user said/did to fix it
+LESSON: what to do differently next time
+```
+
+## HABITS
+For each habit:
+```
+CONTEXT: what was happening
+HABIT: the good practice
+FEEDBACK: what the user said
+```
+
+## USER_PROFILE_UPDATE
+If there are significant new signals about the user, write a brief paragraph update.
+Write NONE if no significant new signals.";
+    }
+
+    private SoulExtractionResult ParseExtractionResponse(string response)
+    {
+        var result = new SoulExtractionResult();
+
+        // Parse mistakes
+        var mistakeSection = ExtractSection(response, "## MISTAKES", "## ");
+        if (mistakeSection is not null)
+        {
+            var blocks = Regex.Split(mistakeSection, @"(?=CONTEXT:)").Where(b => b.Trim().Length > 0);
+            foreach (var block in blocks)
+            {
+                var context = ExtractField(block, "CONTEXT");
+                var mistake = ExtractField(block, "MISTAKE");
+                var correction = ExtractField(block, "CORRECTION");
+                var lesson = ExtractField(block, "LESSON");
+
+                if (lesson is not null)
+                {
+                    result.Mistakes.Add(new MistakeEntry
+                    {
+                        Context = context ?? "unknown",
+                        Mistake = mistake ?? "unknown",
+                        Correction = correction ?? "unknown",
+                        Lesson = lesson
+                    });
+                }
+            }
+        }
+
+        // Parse habits
+        var habitSection = ExtractSection(response, "## HABITS", "## ");
+        if (habitSection is not null)
+        {
+            var blocks = Regex.Split(habitSection, @"(?=CONTEXT:)").Where(b => b.Trim().Length > 0);
+            foreach (var block in blocks)
+            {
+                var context = ExtractField(block, "CONTEXT");
+                var habit = ExtractField(block, "HABIT");
+                var feedback = ExtractField(block, "FEEDBACK");
+
+                if (habit is not null)
+                {
+                    result.Habits.Add(new HabitEntry
+                    {
+                        Context = context ?? "unknown",
+                        Habit = habit,
+                        PositiveFeedback = feedback ?? "confirmed"
+                    });
+                }
+            }
+        }
+
+        // Parse user profile update
+        var profileSection = ExtractSection(response, "## USER_PROFILE_UPDATE", "## ");
+        if (profileSection is not null)
+        {
+            var trimmed = profileSection.Trim();
+            if (!string.Equals(trimmed, "NONE", StringComparison.OrdinalIgnoreCase)
+                && trimmed.Length > 10)
+            {
+                result = new SoulExtractionResult
+                {
+                    Mistakes = result.Mistakes,
+                    Habits = result.Habits,
+                    UserProfileUpdate = trimmed
+                };
+            }
+        }
+
+        _logger.LogInformation(
+            "Soul extraction: {Mistakes} mistakes, {Habits} habits, profile update: {HasProfile}",
+            result.Mistakes.Count, result.Habits.Count, result.UserProfileUpdate is not null);
+
+        return result;
+    }
+
+    private static string? ExtractSection(string text, string header, string nextHeaderPrefix)
+    {
+        var start = text.IndexOf(header, StringComparison.OrdinalIgnoreCase);
+        if (start < 0) return null;
+        start += header.Length;
+
+        var end = text.IndexOf(nextHeaderPrefix, start);
+        while (end >= 0 && end == start)
+            end = text.IndexOf(nextHeaderPrefix, end + 1);
+
+        return end > 0 ? text[start..end].Trim() : text[start..].Trim();
+    }
+
+    private static string? ExtractField(string block, string fieldName)
+    {
+        var pattern = $@"{fieldName}:\s*(.+?)(?:\n[A-Z_]+:|$)";
+        var match = Regex.Match(block, pattern, RegexOptions.Singleline);
+        return match.Success ? match.Groups[1].Value.Trim() : null;
+    }
+}

--- a/src/soul/SoulModels.cs
+++ b/src/soul/SoulModels.cs
@@ -1,0 +1,83 @@
+namespace Hermes.Agent.Soul;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// A recorded mistake — when the agent did something wrong and the user corrected it.
+/// Append-only journal stored as JSONL.
+/// </summary>
+public sealed record MistakeEntry
+{
+    [JsonPropertyName("timestamp")]
+    public DateTime Timestamp { get; init; } = DateTime.UtcNow;
+
+    /// <summary>What the agent was trying to do when the mistake happened.</summary>
+    [JsonPropertyName("context")]
+    public required string Context { get; init; }
+
+    /// <summary>What went wrong — the incorrect action or output.</summary>
+    [JsonPropertyName("mistake")]
+    public required string Mistake { get; init; }
+
+    /// <summary>What the user said or did to correct it.</summary>
+    [JsonPropertyName("correction")]
+    public required string Correction { get; init; }
+
+    /// <summary>The distilled lesson — what to do differently next time.</summary>
+    [JsonPropertyName("lesson")]
+    public required string Lesson { get; init; }
+}
+
+/// <summary>
+/// A recorded good habit — when the agent did something right and the user confirmed it.
+/// Append-only journal stored as JSONL.
+/// </summary>
+public sealed record HabitEntry
+{
+    [JsonPropertyName("timestamp")]
+    public DateTime Timestamp { get; init; } = DateTime.UtcNow;
+
+    /// <summary>What the agent was doing when the positive feedback occurred.</summary>
+    [JsonPropertyName("context")]
+    public required string Context { get; init; }
+
+    /// <summary>The good practice or approach that worked well.</summary>
+    [JsonPropertyName("habit")]
+    public required string Habit { get; init; }
+
+    /// <summary>The user's positive feedback or confirmation.</summary>
+    [JsonPropertyName("positiveFeedback")]
+    public required string PositiveFeedback { get; init; }
+}
+
+/// <summary>
+/// Result of soul extraction from a transcript batch.
+/// </summary>
+public sealed class SoulExtractionResult
+{
+    public List<MistakeEntry> Mistakes { get; init; } = [];
+    public List<HabitEntry> Habits { get; init; } = [];
+
+    /// <summary>
+    /// Signals about the user's profile extracted from the conversation
+    /// (expertise level, preferences, communication style).
+    /// Null if no significant signals detected.
+    /// </summary>
+    public string? UserProfileUpdate { get; init; }
+}
+
+/// <summary>
+/// Types of soul files.
+/// </summary>
+public enum SoulFileType
+{
+    /// <summary>Agent identity — who the agent is (SOUL.md).</summary>
+    Soul,
+
+    /// <summary>User profile — who the user is (USER.md).</summary>
+    User,
+
+    /// <summary>Project rules — conventions for the current project (AGENTS.md).</summary>
+    ProjectRules
+}

--- a/src/soul/SoulService.cs
+++ b/src/soul/SoulService.cs
@@ -1,0 +1,291 @@
+namespace Hermes.Agent.Soul;
+
+using Microsoft.Extensions.Logging;
+using System.Text;
+using System.Text.Json;
+
+/// <summary>
+/// Central service for the agent's "soul" — persistent identity, user understanding,
+/// project rules, mistake tracking, and learned behaviors.
+///
+/// File layout under hermesHome:
+///   SOUL.md              — Agent identity (global)
+///   USER.md              — User profile (global)
+///   soul/mistakes.jsonl  — Append-only mistake journal
+///   soul/habits.jsonl    — Append-only good-habit journal
+///   projects/{dir}/AGENTS.md — Per-project rules
+/// </summary>
+public sealed class SoulService
+{
+    private readonly string _hermesHome;
+    private readonly string _soulDir;
+    private readonly ILogger<SoulService> _logger;
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    /// <summary>Maximum characters for assembled soul context to stay within ~1500 tokens.</summary>
+    private const int MaxSoulContextChars = 6000;
+    private const int MaxUserChars = 1500;
+    private const int MaxAgentsChars = 1500;
+    private const int MaxJournalEntries = 5;
+
+    public string SoulFilePath => Path.Combine(_hermesHome, "SOUL.md");
+    public string UserFilePath => Path.Combine(_hermesHome, "USER.md");
+    public string MistakesFilePath => Path.Combine(_soulDir, "mistakes.jsonl");
+    public string HabitsFilePath => Path.Combine(_soulDir, "habits.jsonl");
+
+    public SoulService(string hermesHome, ILogger<SoulService> logger)
+    {
+        _hermesHome = hermesHome;
+        _soulDir = Path.Combine(hermesHome, "soul");
+        _logger = logger;
+
+        Directory.CreateDirectory(_soulDir);
+        EnsureDefaultTemplates();
+    }
+
+    // ── Load / Save soul files ──
+
+    /// <summary>Load a soul file by type. Returns empty string if file doesn't exist.</summary>
+    public async Task<string> LoadFileAsync(SoulFileType type, string? projectDir = null)
+    {
+        var path = GetFilePath(type, projectDir);
+        if (!File.Exists(path)) return "";
+        return await File.ReadAllTextAsync(path);
+    }
+
+    /// <summary>Save a soul file by type.</summary>
+    public async Task SaveFileAsync(SoulFileType type, string content, string? projectDir = null)
+    {
+        var path = GetFilePath(type, projectDir);
+        var dir = Path.GetDirectoryName(path);
+        if (dir is not null) Directory.CreateDirectory(dir);
+        await File.WriteAllTextAsync(path, content);
+        _logger.LogInformation("Soul: saved {Type} to {Path}", type, path);
+    }
+
+    /// <summary>Get the file path for a soul file type.</summary>
+    public string GetFilePath(SoulFileType type, string? projectDir = null)
+    {
+        return type switch
+        {
+            SoulFileType.Soul => SoulFilePath,
+            SoulFileType.User => UserFilePath,
+            SoulFileType.ProjectRules => projectDir is not null
+                ? Path.Combine(_hermesHome, "projects", SanitizeDirName(projectDir), "AGENTS.md")
+                : Path.Combine(_hermesHome, "AGENTS.md"),
+            _ => throw new ArgumentOutOfRangeException(nameof(type))
+        };
+    }
+
+    // ── Mistake journal ──
+
+    /// <summary>Record a mistake to the append-only journal.</summary>
+    public async Task RecordMistakeAsync(MistakeEntry entry)
+    {
+        var json = JsonSerializer.Serialize(entry, JsonOpts);
+        await File.AppendAllTextAsync(MistakesFilePath, json + "\n");
+        _logger.LogInformation("Soul: recorded mistake — {Lesson}", entry.Lesson);
+    }
+
+    /// <summary>Load all mistakes from the journal.</summary>
+    public async Task<List<MistakeEntry>> LoadMistakesAsync()
+    {
+        return await LoadJournalAsync<MistakeEntry>(MistakesFilePath);
+    }
+
+    // ── Habit journal ──
+
+    /// <summary>Record a good habit to the append-only journal.</summary>
+    public async Task RecordHabitAsync(HabitEntry entry)
+    {
+        var json = JsonSerializer.Serialize(entry, JsonOpts);
+        await File.AppendAllTextAsync(HabitsFilePath, json + "\n");
+        _logger.LogInformation("Soul: recorded habit — {Habit}", entry.Habit);
+    }
+
+    /// <summary>Load all habits from the journal.</summary>
+    public async Task<List<HabitEntry>> LoadHabitsAsync()
+    {
+        return await LoadJournalAsync<HabitEntry>(HabitsFilePath);
+    }
+
+    // ── Assemble soul context for prompt injection ──
+
+    /// <summary>
+    /// Assemble the full soul context string for injection into the system prompt.
+    /// Returns a single string containing identity, user profile, project rules,
+    /// recent mistakes, and recent habits — capped at ~1500 tokens.
+    /// </summary>
+    public async Task<string> AssembleSoulContextAsync(string? projectDir = null)
+    {
+        var sb = new StringBuilder();
+
+        // 1. Agent identity (SOUL.md) — always included in full
+        var soul = await LoadFileAsync(SoulFileType.Soul);
+        if (!string.IsNullOrWhiteSpace(soul))
+        {
+            sb.AppendLine("[Agent Identity]");
+            sb.AppendLine(soul.Trim());
+            sb.AppendLine();
+        }
+
+        // 2. User profile (USER.md) — truncated
+        var user = await LoadFileAsync(SoulFileType.User);
+        if (!string.IsNullOrWhiteSpace(user) && user.Trim().Length > 50) // Skip near-empty templates
+        {
+            sb.AppendLine("[User Profile]");
+            sb.AppendLine(Truncate(user.Trim(), MaxUserChars));
+            sb.AppendLine();
+        }
+
+        // 3. Project rules (AGENTS.md) — truncated
+        var agents = await LoadFileAsync(SoulFileType.ProjectRules, projectDir);
+        if (!string.IsNullOrWhiteSpace(agents) && agents.Trim().Length > 50)
+        {
+            sb.AppendLine("[Project Rules]");
+            sb.AppendLine(Truncate(agents.Trim(), MaxAgentsChars));
+            sb.AppendLine();
+        }
+
+        // 4. Recent mistakes (lesson only, last 5)
+        var mistakes = await LoadMistakesAsync();
+        if (mistakes.Count > 0)
+        {
+            sb.AppendLine("[Learned from Mistakes]");
+            foreach (var m in mistakes.TakeLast(MaxJournalEntries))
+            {
+                sb.AppendLine($"- {m.Lesson}");
+            }
+            sb.AppendLine();
+        }
+
+        // 5. Recent habits (habit only, last 5)
+        var habits = await LoadHabitsAsync();
+        if (habits.Count > 0)
+        {
+            sb.AppendLine("[Good Habits]");
+            foreach (var h in habits.TakeLast(MaxJournalEntries))
+            {
+                sb.AppendLine($"- {h.Habit}");
+            }
+            sb.AppendLine();
+        }
+
+        var result = sb.ToString();
+
+        // Hard cap to prevent context bloat
+        if (result.Length > MaxSoulContextChars)
+        {
+            result = result[..MaxSoulContextChars] + "\n[...soul context truncated]";
+        }
+
+        return result;
+    }
+
+    // ── Default templates ──
+
+    private void EnsureDefaultTemplates()
+    {
+        if (!File.Exists(SoulFilePath))
+        {
+            File.WriteAllText(SoulFilePath, DefaultSoulTemplate);
+            _logger.LogInformation("Soul: created default SOUL.md");
+        }
+
+        if (!File.Exists(UserFilePath))
+        {
+            File.WriteAllText(UserFilePath, DefaultUserTemplate);
+            _logger.LogInformation("Soul: created default USER.md");
+        }
+    }
+
+    // ── Helpers ──
+
+    private static async Task<List<T>> LoadJournalAsync<T>(string path)
+    {
+        var entries = new List<T>();
+        if (!File.Exists(path)) return entries;
+
+        foreach (var line in await File.ReadAllLinesAsync(path))
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            try
+            {
+                var entry = JsonSerializer.Deserialize<T>(line);
+                if (entry is not null) entries.Add(entry);
+            }
+            catch
+            {
+                // Skip malformed lines — journal is append-only, don't break on bad data
+            }
+        }
+
+        return entries;
+    }
+
+    private static string Truncate(string text, int maxChars)
+    {
+        if (text.Length <= maxChars) return text;
+        return text[..maxChars] + "\n[...truncated]";
+    }
+
+    private static string SanitizeDirName(string dir)
+    {
+        // Use last component of path, strip invalid chars
+        var name = Path.GetFileName(dir) ?? dir;
+        foreach (var c in Path.GetInvalidFileNameChars())
+            name = name.Replace(c, '_');
+        return name;
+    }
+
+    // ── Default templates ──
+
+    private const string DefaultSoulTemplate = @"# Hermes Agent Identity
+
+You are **Hermes**, an AI coding agent built for desktop productivity.
+
+## Personality
+- Direct, efficient, and technically precise
+- Proactive — anticipate what the user needs next
+- Honest about limitations and uncertainties
+- Warm but not verbose — respect the user's time
+
+## Values
+- **Accuracy over speed** — get it right the first time
+- **Transparency** — explain reasoning, show your work
+- **Safety** — never execute destructive actions without confirmation
+- **Learning** — remember past mistakes and don't repeat them
+
+## Communication Style
+- Use clear, concise language
+- Lead with the answer, then explain if needed
+- Format code blocks with proper syntax highlighting
+- When unsure, ask rather than guess
+
+## Working Style
+- Read files before editing them
+- Test changes when possible
+- Commit frequently with clear messages
+- Respect existing code patterns and conventions
+";
+
+    private const string DefaultUserTemplate = @"# User Profile
+
+## Expertise
+<!-- What is the user's technical skill level? What languages/frameworks do they know? -->
+
+## Preferences
+<!-- How does the user prefer to work? What tools do they favor? -->
+
+## Communication Style
+<!-- Does the user prefer detailed explanations or just the answer? -->
+
+## Past Corrections
+<!-- Key corrections the user has made — patterns to remember. -->
+";
+}


### PR DESCRIPTION
## Summary
- **Soul System**: Persistent agent identity (SOUL.md), user profile (USER.md), project rules (AGENTS.md), mistake journal, and good habits tracking — all wired into the prompt pipeline as Layer 0
- **SoulExtractor**: LLM-powered transcript analysis during dream consolidation to auto-extract mistakes, habits, and user profile signals
- **System Prompt**: Comprehensive coding agent instructions modeled after Claude Code — tool usage guidelines, coding best practices, git workflow, safety guardrails
- **Hermes Caduceus Welcome**: Braille-art caduceus symbol as the chat welcome message, replacing hardcoded model/workspace references
- **UI Polish**: Header title changed to "Hermes Agent", resizable chat/panel splitter (200-700px range, cursor change, accent highlight)

## Files Changed (15 files, +1165/-69)
- `src/soul/` — 3 new files: SoulModels, SoulService, SoulExtractor
- `src/Core/SystemPrompts.cs` — new comprehensive system prompt
- `src/Core/agent.cs` — accepts SoulService, records tool failures as mistakes
- `src/Context/PromptBuilder.cs` — Layer 0 soul injection before cache anchor
- `src/Context/ContextManager.cs` — loads soul context per prompt
- `src/dream/autodreamservice.cs` — runs soul extraction after consolidation
- `Desktop/HermesDesktop/App.xaml.cs` — DI wiring for soul + system prompt
- `Desktop/HermesDesktop/Views/Panels/MemoryPanel.xaml(.cs)` — 3-tab UI (Memories | Soul | Project)
- `Desktop/HermesDesktop/Views/ChatPage.xaml(.cs)` — caduceus welcome, splitter improvements, title fix

## Test plan
- [ ] Build succeeds with 0 errors
- [ ] First run creates default SOUL.md and USER.md templates
- [ ] Memory panel shows 3 sub-tabs: Memories, Soul, Project
- [ ] Soul tab displays editable SOUL.md and USER.md
- [ ] Chat welcome shows caduceus symbol, no hardcoded model names
- [ ] Header says "Hermes Agent"
- [ ] Tool failures record mistakes in soul/mistakes.jsonl
- [ ] Splitter between chat and right panel is draggable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new persistent “soul” subsystem that injects additional system context into every LLM call and writes new on-disk journals from tool failures and background transcript analysis, which could affect agent behavior and prompt size. UI changes are low risk, but prompt-pipeline and background extraction changes warrant careful review for correctness and privacy/size impacts.
> 
> **Overview**
> Introduces a new **Soul system** that persists agent identity (`SOUL.md`), user profile (`USER.md`), project rules (`AGENTS.md`), plus append-only mistake/habit journals, and injects this assembled context as a *Layer 0* system message via `ContextManager`/`PromptBuilder` (with a fallback injection path in `Agent`).
> 
> Extends background consolidation (`AutoDreamService`) with an LLM-driven `SoulExtractor` to mine transcripts for mistakes/habits and optional user profile updates, and records tool-call failures as mistake entries.
> 
> Updates the desktop app to wire `SoulService`/`SoulExtractor` into DI, replaces the hardcoded system prompt with `SystemPrompts.Default`, and adds UI polish: a caduceus welcome message, improved splitter behavior, header text updates, and a new Memory panel sub-tab UI to view/edit Soul and Project files and inspect recent journals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d811e2a5e4ce1e1ac8b684c89331d8feca9c45e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Soul" system enabling the agent to maintain identity, track user preferences, and learn from mistakes and habits.
  * Expanded Memory panel with tabbed interface: new Soul tab for managing agent identity and user profile, and Project tab for defining project-specific agent rules.
  * Soul system automatically records lessons from failed tool operations and displays recent learning history.

* **UI Improvements**
  * Updated chat header and simplified welcome message.
  * Enhanced splitter handle with hover effects for better visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->