### PR TITLE
Redesign Skills page, unified button styles, README overhaul

### DIFF
--- a/Desktop/HermesDesktop/App.xaml
+++ b/Desktop/HermesDesktop/App.xaml
@@ -84,6 +84,45 @@
                 <Setter Property="FontWeight" Value="SemiBold" />
                 <Setter Property="TextWrapping" Value="Wrap" />
             </Style>
+
+            <!-- Default button style — gold gradient everywhere -->
+            <Style TargetType="Button">
+                <Setter Property="Background" Value="{StaticResource AppAccentGradientBrush}" />
+                <Setter Property="Foreground" Value="#16110D" />
+                <Setter Property="BorderBrush" Value="{StaticResource AppAccentDarkBrush}" />
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="CornerRadius" Value="6" />
+                <Setter Property="FontWeight" Value="SemiBold" />
+            </Style>
+
+            <!-- Ghost / tab button — transparent bg, subtle text -->
+            <Style x:Key="GhostButtonStyle" TargetType="Button">
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="Foreground" Value="{StaticResource AppTextSecondaryBrush}" />
+                <Setter Property="BorderBrush" Value="Transparent" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="CornerRadius" Value="6" />
+                <Setter Property="MinWidth" Value="0" />
+                <Setter Property="Padding" Value="8,4" />
+            </Style>
+
+            <!-- Secondary / outline button — dark bg, subtle border -->
+            <Style x:Key="SecondaryButtonStyle" TargetType="Button">
+                <Setter Property="Background" Value="{StaticResource AppInsetBrush}" />
+                <Setter Property="Foreground" Value="White" />
+                <Setter Property="BorderBrush" Value="{StaticResource AppSubtleStrokeBrush}" />
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="CornerRadius" Value="6" />
+            </Style>
+
+            <!-- Danger / deny button — red tint -->
+            <Style x:Key="DangerButtonStyle" TargetType="Button">
+                <Setter Property="Background" Value="#3A1515" />
+                <Setter Property="Foreground" Value="#FF8A8A" />
+                <Setter Property="BorderBrush" Value="#5A2020" />
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="CornerRadius" Value="6" />
+            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/Desktop/HermesDesktop/Controls/CodeBlockView.xaml
+++ b/Desktop/HermesDesktop/Controls/CodeBlockView.xaml
@@ -41,8 +41,6 @@
                     Content="Copy"
                     FontSize="11"
                     Padding="8,4"
-                    Background="Transparent"
-                    BorderBrush="{StaticResource AppStrokeBrush}"
                     Click="CopyButton_Click" />
             </Grid>
             

--- a/Desktop/HermesDesktop/Controls/PermissionDialog.xaml
+++ b/Desktop/HermesDesktop/Controls/PermissionDialog.xaml
@@ -74,8 +74,7 @@
                 <Button Grid.Column="0" x:Name="CancelButton"
                     Content="Cancel"
                     HorizontalAlignment="Stretch"
-                    Background="{StaticResource AppInsetBrush}"
-                    BorderBrush="{StaticResource AppStrokeBrush}"
+                    Style="{StaticResource SecondaryButtonStyle}"
                     Click="CancelButton_Click" />
                 
                 <Button Grid.Column="1" x:Name="ConfirmButton"

--- a/Desktop/HermesDesktop/Views/AgentPage.xaml
+++ b/Desktop/HermesDesktop/Views/AgentPage.xaml
@@ -30,13 +30,11 @@
         <!-- Tab bar -->
         <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="4" Margin="0,0,0,16">
             <Button x:Name="TabAgents" Content="Agents" Click="Tab_Click" Tag="agents"
-                    Background="{StaticResource AppAccentGradientBrush}" Foreground="#16110D" FontSize="13" Padding="16,8" CornerRadius="8"/>
+                    FontSize="13" Padding="16,8" CornerRadius="8"/>
             <Button x:Name="TabIdentity" Content="Identity" Click="Tab_Click" Tag="identity"
-                    Background="{StaticResource AppInsetBrush}" Foreground="{StaticResource AppTextSecondaryBrush}" FontSize="13" Padding="16,8" CornerRadius="8"
-                    BorderBrush="{StaticResource AppStrokeBrush}"/>
+                    Style="{StaticResource SecondaryButtonStyle}" FontSize="13" Padding="16,8" CornerRadius="8"/>
             <Button x:Name="TabSouls" Content="Souls" Click="Tab_Click" Tag="souls"
-                    Background="{StaticResource AppInsetBrush}" Foreground="{StaticResource AppTextSecondaryBrush}" FontSize="13" Padding="16,8" CornerRadius="8"
-                    BorderBrush="{StaticResource AppStrokeBrush}"/>
+                    Style="{StaticResource SecondaryButtonStyle}" FontSize="13" Padding="16,8" CornerRadius="8"/>
         </StackPanel>
 
         <!-- ═══════════════════════════════════════════════ -->
@@ -60,11 +58,9 @@
                                  MinHeight="300" MaxHeight="500" FontSize="12" FontFamily="Consolas"
                                  Background="{StaticResource AppInsetBrush}" BorderBrush="{StaticResource AppStrokeBrush}"/>
                         <StackPanel Orientation="Horizontal" Spacing="8">
-                            <Button Content="Save Soul" Click="SaveSoul_Click" FontSize="12" Padding="16,8"
-                                    Background="{StaticResource AppAccentGradientBrush}" Foreground="#16110D"/>
+                            <Button Content="Save Soul" Click="SaveSoul_Click" FontSize="12" Padding="16,8"/>
                             <Button Content="Reset to Default" Click="ResetSoul_Click" FontSize="12" Padding="16,8"
-                                    Background="Transparent" Foreground="{StaticResource AppTextSecondaryBrush}"
-                                    BorderBrush="{StaticResource AppStrokeBrush}"/>
+                                    Style="{StaticResource SecondaryButtonStyle}"/>
                         </StackPanel>
                     </StackPanel>
                 </Border>
@@ -80,8 +76,7 @@
                             <TextBox x:Name="UserEditor" AcceptsReturn="True" TextWrapping="Wrap"
                                      MinHeight="180" MaxHeight="300" FontSize="12" FontFamily="Consolas"
                                      Background="{StaticResource AppInsetBrush}" BorderBrush="{StaticResource AppStrokeBrush}"/>
-                            <Button Content="Save Profile" Click="SaveUser_Click" FontSize="12" Padding="16,8"
-                                    Background="{StaticResource AppAccentGradientBrush}" Foreground="#16110D"/>
+                            <Button Content="Save Profile" Click="SaveUser_Click" FontSize="12" Padding="16,8"/>
                         </StackPanel>
                     </Border>
 
@@ -168,12 +163,10 @@
                     </ScrollViewer>
                     <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="12" Margin="0,12,0,0">
                         <Button x:Name="ApplySoulBtn" Content="Apply This Soul" Click="ApplySoul_Click"
-                                FontSize="13" Padding="20,10" IsEnabled="False"
-                                Background="{StaticResource AppAccentGradientBrush}" Foreground="#16110D"/>
+                                FontSize="13" Padding="20,10" IsEnabled="False"/>
                         <Button x:Name="CustomizeSoulBtn" Content="Copy to Editor" Click="CustomizeSoul_Click"
                                 FontSize="13" Padding="20,10" IsEnabled="False"
-                                Background="Transparent" Foreground="{StaticResource AppTextSecondaryBrush}"
-                                BorderBrush="{StaticResource AppStrokeBrush}"/>
+                                Style="{StaticResource SecondaryButtonStyle}"/>
                     </StackPanel>
                 </Grid>
             </Border>
@@ -195,7 +188,6 @@
                         <TextBlock Text="Saved Agents" FontSize="16" FontWeight="SemiBold"
                                    Foreground="{StaticResource AppAccentTextBrush}"/>
                         <Button Content="+ New Agent" Click="NewAgent_Click" FontSize="12" Padding="12,6"
-                                Background="{StaticResource AppAccentGradientBrush}" Foreground="#16110D"
                                 VerticalAlignment="Center"/>
                     </StackPanel>
 
@@ -217,12 +209,10 @@
                                     </StackPanel>
                                     <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
                                         <Button Content="Activate" Tag="{Binding Name}" Click="ActivateAgent_Click"
-                                                FontSize="11" Padding="10,4"
-                                                Background="Transparent" Foreground="{StaticResource AppAccentTextBrush}"
-                                                BorderBrush="{StaticResource AppStrokeBrush}"/>
+                                                FontSize="11" Padding="10,4"/>
                                         <Button Content="Delete" Tag="{Binding Name}" Click="DeleteAgent_Click"
                                                 FontSize="11" Padding="10,4"
-                                                Background="Transparent" Foreground="#FF6B6B" BorderBrush="Transparent"/>
+                                                Style="{StaticResource DangerButtonStyle}"/>
                                     </StackPanel>
                                 </Grid>
                             </DataTemplate>

--- a/Desktop/HermesDesktop/Views/AgentPage.xaml.cs
+++ b/Desktop/HermesDesktop/Views/AgentPage.xaml.cs
@@ -45,13 +45,15 @@ public sealed partial class AgentPage : Page
         var inactiveBg = Application.Current.Resources["AppInsetBrush"] as Brush;
         var activeFg = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 22, 17, 13));
         var inactiveFg = Application.Current.Resources["AppTextSecondaryBrush"] as Brush;
+        var inactiveBorder = Application.Current.Resources["AppSubtleStrokeBrush"] as Brush;
+        var activeBorder = Application.Current.Resources["AppAccentDarkBrush"] as Brush;
 
-        TabIdentity.Background = tag == "identity" ? activeBg : inactiveBg;
-        TabIdentity.Foreground = tag == "identity" ? activeFg : inactiveFg;
-        TabSouls.Background = tag == "souls" ? activeBg : inactiveBg;
-        TabSouls.Foreground = tag == "souls" ? activeFg : inactiveFg;
-        TabAgents.Background = tag == "agents" ? activeBg : inactiveBg;
-        TabAgents.Foreground = tag == "agents" ? activeFg : inactiveFg;
+        foreach (var (tab, isActive) in new[] { (TabIdentity, tag == "identity"), (TabSouls, tag == "souls"), (TabAgents, tag == "agents") })
+        {
+            tab.Background = isActive ? activeBg : inactiveBg;
+            tab.Foreground = isActive ? activeFg : inactiveFg;
+            tab.BorderBrush = isActive ? activeBorder : inactiveBorder;
+        }
 
         IdentityContent.Visibility = tag == "identity" ? Visibility.Visible : Visibility.Collapsed;
         SoulsContent.Visibility = tag == "souls" ? Visibility.Visible : Visibility.Collapsed;

--- a/Desktop/HermesDesktop/Views/ChatPage.xaml
+++ b/Desktop/HermesDesktop/Views/ChatPage.xaml
@@ -39,7 +39,7 @@
             </StackPanel>
 
             <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
-                <Button Content="New Chat" Click="NewChat_Click" Background="{StaticResource AppInsetBrush}" BorderBrush="{StaticResource AppSubtleStrokeBrush}" Foreground="White" />
+                <Button Content="New Chat" Click="NewChat_Click" Style="{StaticResource SecondaryButtonStyle}" />
             </StackPanel>
         </Grid>
 
@@ -115,8 +115,7 @@
                             Foreground="White" TextWrapping="Wrap" />
 
                         <Button x:Name="SendButton" Grid.Column="1" Content="Send" Click="SendPrompt_Click"
-                            Background="{StaticResource AppAccentGradientBrush}" BorderBrush="{StaticResource AppAccentDarkBrush}"
-                            Foreground="#16110D" VerticalAlignment="Bottom" Padding="30,10" />
+                            VerticalAlignment="Bottom" Padding="30,10" />
                     </Grid>
                 </Grid>
             </Grid>
@@ -138,13 +137,13 @@
                 <ScrollViewer Grid.Row="0" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled" Padding="8,8,8,0">
                     <StackPanel Orientation="Horizontal" Spacing="2">
                         <Button x:Name="TabSessions" Content="Sessions" Click="PanelTab_Click" Tag="sessions"
-                                Background="Transparent" Foreground="{StaticResource AppAccentTextBrush}" FontSize="11" Padding="8,4" CornerRadius="6" MinWidth="0"/>
+                                Style="{StaticResource GhostButtonStyle}" Foreground="{StaticResource AppAccentTextBrush}" FontSize="11"/>
                         <Button x:Name="TabFiles" Content="Files" Click="PanelTab_Click" Tag="files"
-                                Background="Transparent" Foreground="{StaticResource AppTextSecondaryBrush}" FontSize="11" Padding="8,4" CornerRadius="6" MinWidth="0"/>
+                                Style="{StaticResource GhostButtonStyle}" FontSize="11"/>
                         <Button x:Name="TabTasks" Content="Tasks" Click="PanelTab_Click" Tag="tasks"
-                                Background="Transparent" Foreground="{StaticResource AppTextSecondaryBrush}" FontSize="11" Padding="8,4" CornerRadius="6" MinWidth="0"/>
+                                Style="{StaticResource GhostButtonStyle}" FontSize="11"/>
                         <Button x:Name="TabReplay" Content="Replay" Click="PanelTab_Click" Tag="replay"
-                                Background="Transparent" Foreground="{StaticResource AppTextSecondaryBrush}" FontSize="11" Padding="8,4" CornerRadius="6" MinWidth="0"/>
+                                Style="{StaticResource GhostButtonStyle}" FontSize="11"/>
                     </StackPanel>
                 </ScrollViewer>
 

--- a/Desktop/HermesDesktop/Views/DashboardPage.xaml
+++ b/Desktop/HermesDesktop/Views/DashboardPage.xaml
@@ -117,7 +117,6 @@
                         </StackPanel>
 
                         <Button Content="Test Connection" Click="TestConnection_Click"
-                                Background="{StaticResource AppAccentGradientBrush}" Foreground="#16110D"
                                 Padding="16,8" FontSize="12"/>
                         <TextBlock x:Name="TestConnectionResult" FontSize="11" TextWrapping="Wrap"
                                    Foreground="{StaticResource AppTextSecondaryBrush}"/>
@@ -138,7 +137,7 @@
                         <StackPanel Orientation="Horizontal" Spacing="12">
                             <TextBlock Text="Recent Activity" FontSize="16" FontWeight="SemiBold"/>
                             <Button Content="Open Chat" Click="LaunchHermesChat_Click" FontSize="11" Padding="10,4"
-                                    Background="{StaticResource AppAccentGradientBrush}" Foreground="#16110D" VerticalAlignment="Center"/>
+                                    VerticalAlignment="Center"/>
                         </StackPanel>
                         <ListView x:Name="RecentSessionsList" Background="Transparent" SelectionMode="None" MaxHeight="250">
                             <ListView.ItemTemplate>
@@ -183,9 +182,9 @@
 
                         <StackPanel Orientation="Horizontal" Spacing="8">
                             <Button Content="Open Logs" Click="OpenLogs_Click" FontSize="11" Padding="10,4"
-                                    Background="{StaticResource AppInsetBrush}" BorderBrush="{StaticResource AppStrokeBrush}" Foreground="White"/>
+                                    Style="{StaticResource SecondaryButtonStyle}"/>
                             <Button Content="Open Config" Click="OpenConfig_Click" FontSize="11" Padding="10,4"
-                                    Background="{StaticResource AppInsetBrush}" BorderBrush="{StaticResource AppStrokeBrush}" Foreground="White"/>
+                                    Style="{StaticResource SecondaryButtonStyle}"/>
                         </StackPanel>
                     </StackPanel>
                 </Border>

--- a/Desktop/HermesDesktop/Views/IntegrationsPage.xaml
+++ b/Desktop/HermesDesktop/Views/IntegrationsPage.xaml
@@ -41,13 +41,9 @@
                                Foreground="{StaticResource AppTextSecondaryBrush}" />
                     <StackPanel Orientation="Horizontal" Spacing="12">
                         <Button x:Name="GatewayToggleButton" Click="GatewayToggle_Click"
-                                Background="{StaticResource AppAccentGradientBrush}"
-                                BorderBrush="{StaticResource AppAccentDarkBrush}"
-                                Foreground="#16110D" Padding="16,8" />
+                                Padding="16,8" />
                         <Button x:Name="GatewayRefreshButton" Content="Refresh" Click="GatewayRefresh_Click"
-                                Background="{StaticResource AppInsetBrush}"
-                                BorderBrush="{StaticResource AppStrokeBrush}"
-                                Foreground="White" Padding="16,8" />
+                                Style="{StaticResource SecondaryButtonStyle}" Padding="16,8" />
                         <Button
                             x:Uid="IntegrationsOpenLogsButton"
                             AccessKey="G"
@@ -97,10 +93,7 @@
                                          Foreground="White"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Spacing="12">
-                            <Button Content="Save" Click="SaveTelegram_Click"
-                                    Background="{StaticResource AppAccentGradientBrush}"
-                                    BorderBrush="{StaticResource AppAccentDarkBrush}"
-                                    Foreground="#16110D" Padding="16,8"/>
+                            <Button Content="Save" Click="SaveTelegram_Click" Padding="16,8"/>
                             <TextBlock x:Name="TelegramSaveStatus" VerticalAlignment="Center"
                                        Foreground="{StaticResource AppTextSecondaryBrush}" FontSize="13"/>
                         </StackPanel>
@@ -129,10 +122,7 @@
                                          Foreground="White"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Spacing="12">
-                            <Button Content="Save" Click="SaveDiscord_Click"
-                                    Background="{StaticResource AppAccentGradientBrush}"
-                                    BorderBrush="{StaticResource AppAccentDarkBrush}"
-                                    Foreground="#16110D" Padding="16,8"/>
+                            <Button Content="Save" Click="SaveDiscord_Click" Padding="16,8"/>
                             <TextBlock x:Name="DiscordSaveStatus" VerticalAlignment="Center"
                                        Foreground="{StaticResource AppTextSecondaryBrush}" FontSize="13"/>
                         </StackPanel>
@@ -175,10 +165,7 @@
                                          Foreground="White"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Spacing="12">
-                            <Button Content="Save" Click="SaveSlack_Click"
-                                    Background="{StaticResource AppAccentGradientBrush}"
-                                    BorderBrush="{StaticResource AppAccentDarkBrush}"
-                                    Foreground="#16110D" Padding="16,8"/>
+                            <Button Content="Save" Click="SaveSlack_Click" Padding="16,8"/>
                             <TextBlock x:Name="SlackSaveStatus" VerticalAlignment="Center"
                                        Foreground="{StaticResource AppTextSecondaryBrush}" FontSize="13"/>
                         </StackPanel>
@@ -241,10 +228,7 @@
                                      Foreground="White"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Spacing="12">
-                            <Button Content="Save" Click="SaveMatrix_Click"
-                                    Background="{StaticResource AppAccentGradientBrush}"
-                                    BorderBrush="{StaticResource AppAccentDarkBrush}"
-                                    Foreground="#16110D" Padding="16,8"/>
+                            <Button Content="Save" Click="SaveMatrix_Click" Padding="16,8"/>
                             <TextBlock x:Name="MatrixSaveStatus" VerticalAlignment="Center"
                                        Foreground="{StaticResource AppTextSecondaryBrush}" FontSize="13"/>
                         </StackPanel>
@@ -283,10 +267,7 @@
                                          Foreground="White"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Spacing="12">
-                            <Button Content="Save" Click="SaveWebhook_Click"
-                                    Background="{StaticResource AppAccentGradientBrush}"
-                                    BorderBrush="{StaticResource AppAccentDarkBrush}"
-                                    Foreground="#16110D" Padding="16,8"/>
+                            <Button Content="Save" Click="SaveWebhook_Click" Padding="16,8"/>
                             <TextBlock x:Name="WebhookSaveStatus" VerticalAlignment="Center"
                                        Foreground="{StaticResource AppTextSecondaryBrush}" FontSize="13"/>
                         </StackPanel>

--- a/Desktop/HermesDesktop/Views/MemoryPage.xaml
+++ b/Desktop/HermesDesktop/Views/MemoryPage.xaml
@@ -27,10 +27,9 @@
         <!-- Tab bar -->
         <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="4" Margin="0,0,0,16">
             <Button x:Name="TabMemories" Content="Memories" Click="Tab_Click" Tag="memories"
-                    Background="{StaticResource AppAccentGradientBrush}" Foreground="#16110D" FontSize="13" Padding="16,8" CornerRadius="8"/>
+                    FontSize="13" Padding="16,8" CornerRadius="8"/>
             <Button x:Name="TabProject" Content="Project" Click="Tab_Click" Tag="project"
-                    Background="{StaticResource AppInsetBrush}" Foreground="{StaticResource AppTextSecondaryBrush}" FontSize="13" Padding="16,8" CornerRadius="8"
-                    BorderBrush="{StaticResource AppStrokeBrush}"/>
+                    Style="{StaticResource SecondaryButtonStyle}" FontSize="13" Padding="16,8" CornerRadius="8"/>
         </StackPanel>
 
         <!-- ═══════════════════════════════════════════════ -->
@@ -117,8 +116,7 @@
                              MinHeight="300" MaxHeight="500" FontSize="12" FontFamily="Consolas"
                              Background="{StaticResource AppInsetBrush}" BorderBrush="{StaticResource AppStrokeBrush}"/>
                     <StackPanel Orientation="Horizontal" Spacing="8">
-                        <Button Content="Save Project Rules" Click="SaveAgents_Click" FontSize="12" Padding="16,8"
-                                Background="{StaticResource AppAccentGradientBrush}" Foreground="#16110D"/>
+                        <Button Content="Save Project Rules" Click="SaveAgents_Click" FontSize="12" Padding="16,8"/>
                         <TextBlock x:Name="SaveStatus" Text="" FontSize="12" VerticalAlignment="Center"
                                    Foreground="{StaticResource AppTextSecondaryBrush}" Opacity="0.7"/>
                     </StackPanel>

--- a/Desktop/HermesDesktop/Views/MemoryPage.xaml.cs
+++ b/Desktop/HermesDesktop/Views/MemoryPage.xaml.cs
@@ -47,11 +47,15 @@ public sealed partial class MemoryPage : Page
         var inactiveBg = Application.Current.Resources["AppInsetBrush"] as Brush;
         var activeFg = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 22, 17, 13));
         var inactiveFg = Application.Current.Resources["AppTextSecondaryBrush"] as Brush;
+        var activeBorder = Application.Current.Resources["AppAccentDarkBrush"] as Brush;
+        var inactiveBorder = Application.Current.Resources["AppSubtleStrokeBrush"] as Brush;
 
-        TabMemories.Background = tag == "memories" ? activeBg : inactiveBg;
-        TabMemories.Foreground = tag == "memories" ? activeFg : inactiveFg;
-        TabProject.Background = tag == "project" ? activeBg : inactiveBg;
-        TabProject.Foreground = tag == "project" ? activeFg : inactiveFg;
+        foreach (var (tab, isActive) in new[] { (TabMemories, tag == "memories"), (TabProject, tag == "project") })
+        {
+            tab.Background = isActive ? activeBg : inactiveBg;
+            tab.Foreground = isActive ? activeFg : inactiveFg;
+            tab.BorderBrush = isActive ? activeBorder : inactiveBorder;
+        }
 
         MemoriesContent.Visibility = tag == "memories" ? Visibility.Visible : Visibility.Collapsed;
         ProjectContent.Visibility = tag == "project" ? Visibility.Visible : Visibility.Collapsed;

--- a/Desktop/HermesDesktop/Views/Panels/ReplayPanel.xaml
+++ b/Desktop/HermesDesktop/Views/Panels/ReplayPanel.xaml
@@ -18,11 +18,9 @@
                 </StackPanel>
             </ToggleButton>
             <Button x:Name="PlayBtn" Content="&#x25B6; Play" Click="PlayBtn_Click"
-                    Background="Transparent" Foreground="{StaticResource AppTextSecondaryBrush}"
-                    CornerRadius="6" Padding="8,4" MinWidth="0" FontSize="11"/>
+                    Style="{StaticResource GhostButtonStyle}" FontSize="11"/>
             <Button x:Name="ClearBtn" Content="Clear" Click="ClearBtn_Click"
-                    Background="Transparent" Foreground="{StaticResource AppTextSecondaryBrush}"
-                    CornerRadius="6" Padding="8,4" MinWidth="0" FontSize="11"/>
+                    Style="{StaticResource GhostButtonStyle}" FontSize="11"/>
         </StackPanel>
 
         <!-- Empty state -->

--- a/Desktop/HermesDesktop/Views/Panels/SessionPanel.xaml
+++ b/Desktop/HermesDesktop/Views/Panels/SessionPanel.xaml
@@ -12,8 +12,8 @@
 
         <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="6" Margin="0,0,0,8">
             <TextBox x:Name="SearchBox" PlaceholderText="Search sessions..." Width="160" FontSize="12"/>
-            <Button x:Name="NewSessionBtn" Content="+" Click="NewSession_Click" CornerRadius="6" Padding="8,4"
-                    Background="{StaticResource AppAccentGradientBrush}" Foreground="#16110D" ToolTipService.ToolTip="New session"/>
+            <Button x:Name="NewSessionBtn" Content="+" Click="NewSession_Click" Padding="8,4"
+                    ToolTipService.ToolTip="New session"/>
         </StackPanel>
 
         <TextBlock Grid.Row="2" x:Name="EmptyState" Visibility="Collapsed"

--- a/Desktop/HermesDesktop/Views/Panels/TaskPanel.xaml
+++ b/Desktop/HermesDesktop/Views/Panels/TaskPanel.xaml
@@ -7,8 +7,8 @@
     <Grid RowDefinitions="Auto,*">
         <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,0,0,8">
             <TextBlock Text="Tasks" Style="{StaticResource SectionTitleTextStyle}"/>
-            <Button x:Name="RefreshBtn" Content="↻" Click="Refresh_Click" CornerRadius="6" Padding="6,2"
-                    Background="Transparent" Foreground="{StaticResource AppTextSecondaryBrush}"/>
+            <Button x:Name="RefreshBtn" Content="↻" Click="Refresh_Click" Padding="6,2"
+                    Style="{StaticResource GhostButtonStyle}"/>
         </StackPanel>
 
         <TextBlock Grid.Row="1" x:Name="EmptyState" Visibility="Collapsed"

--- a/Desktop/HermesDesktop/Views/SettingsPage.xaml
+++ b/Desktop/HermesDesktop/Views/SettingsPage.xaml
@@ -95,9 +95,7 @@
                             <!-- Save + Feedback -->
                             <StackPanel Orientation="Horizontal" Spacing="12">
                                 <Button x:Name="SaveModelBtn" Content="Save Model Config" Click="SaveModelConfig_Click"
-                                        Background="{StaticResource AppAccentGradientBrush}"
-                                        BorderBrush="{StaticResource AppAccentDarkBrush}"
-                                        Foreground="#16110D" Padding="20,8"/>
+                                        Padding="20,8"/>
                                 <TextBlock x:Name="ModelSaveStatus" VerticalAlignment="Center"
                                            Foreground="{StaticResource AppTextSecondaryBrush}" FontSize="13"/>
                             </StackPanel>

--- a/Desktop/HermesDesktop/Views/SkillsPage.xaml
+++ b/Desktop/HermesDesktop/Views/SkillsPage.xaml
@@ -9,7 +9,7 @@
     NavigationCacheMode="Required"
     mc:Ignorable="d">
 
-    <Grid Padding="32,24,32,40">
+    <Grid Padding="32,24,32,32">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -17,51 +17,122 @@
         </Grid.RowDefinitions>
 
         <!-- Header -->
-        <StackPanel Spacing="4" Margin="0,0,0,16">
-            <TextBlock Text="Skills" Style="{StaticResource PageEyebrowTextStyle}"/>
-            <StackPanel Orientation="Horizontal" Spacing="12">
-                <TextBlock Text="Skill Library" FontSize="22" FontWeight="SemiBold"/>
-                <Border Background="#3A3A00" CornerRadius="8" Padding="10,4" VerticalAlignment="Center">
-                    <TextBlock x:Name="SkillCountBadge" Text="0 skills" FontSize="12"
-                               Foreground="{StaticResource AppAccentTextBrush}"/>
-                </Border>
-            </StackPanel>
-            <TextBlock Text="Markdown-based custom capabilities with YAML frontmatter"
-                       FontSize="13" Foreground="{StaticResource AppTextSecondaryBrush}"/>
-        </StackPanel>
+        <Grid Margin="0,0,0,16">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
 
-        <!-- Search box -->
-        <TextBox x:Name="SearchBox" Grid.Row="1" PlaceholderText="Search skills by name, description, or tools..."
-                 FontSize="13" Margin="0,0,0,16" TextChanged="SearchBox_TextChanged"
-                 Background="{StaticResource AppInsetBrush}" BorderBrush="{StaticResource AppStrokeBrush}"/>
+            <StackPanel Spacing="4">
+                <TextBlock Text="Skills" Style="{StaticResource PageEyebrowTextStyle}"/>
+                <StackPanel Orientation="Horizontal" Spacing="12">
+                    <TextBlock Text="Skill Library" FontSize="22" FontWeight="SemiBold"/>
+                    <Border Background="#3A3A00" CornerRadius="8" Padding="10,4" VerticalAlignment="Center">
+                        <TextBlock x:Name="SkillCountBadge" Text="0 skills" FontSize="12"
+                                   Foreground="{StaticResource AppAccentTextBrush}"/>
+                    </Border>
+                </StackPanel>
+                <TextBlock Text="Browse, search, and preview all available agent capabilities"
+                           FontSize="13" Foreground="{StaticResource AppTextSecondaryBrush}"/>
+            </StackPanel>
+
+            <!-- Sort control -->
+            <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Bottom" Margin="0,0,0,4">
+                <TextBlock Text="Sort:" FontSize="12" Foreground="{StaticResource AppTextSecondaryBrush}" VerticalAlignment="Center"/>
+                <ComboBox x:Name="SortSelector" FontSize="12" MinWidth="130" Padding="8,4"
+                          Background="{StaticResource AppInsetBrush}" BorderBrush="{StaticResource AppStrokeBrush}"
+                          SelectionChanged="SortSelector_SelectionChanged">
+                    <ComboBoxItem Content="Name (A-Z)" Tag="name_asc" IsSelected="True"/>
+                    <ComboBoxItem Content="Name (Z-A)" Tag="name_desc"/>
+                    <ComboBoxItem Content="Category" Tag="category"/>
+                </ComboBox>
+            </StackPanel>
+        </Grid>
+
+        <!-- Search + Category filter row -->
+        <Grid Grid.Row="1" ColumnSpacing="12" Margin="0,0,0,16">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <TextBox x:Name="SearchBox" PlaceholderText="&#xE721;  Search skills by name, description, category, or tools..."
+                     FontSize="13" TextChanged="SearchBox_TextChanged"
+                     Background="{StaticResource AppInsetBrush}" BorderBrush="{StaticResource AppStrokeBrush}"
+                     Padding="12,10"/>
+
+            <!-- Category filter chips scroll -->
+            <ScrollViewer Grid.Column="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled"
+                          MaxWidth="500">
+                <StackPanel x:Name="CategoryChips" Orientation="Horizontal" Spacing="6"/>
+            </ScrollViewer>
+        </Grid>
 
         <!-- Two-column layout -->
-        <Grid Grid.Row="2" ColumnSpacing="24">
+        <Grid Grid.Row="2" ColumnSpacing="20">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="380" MinWidth="300"/>
+                <ColumnDefinition Width="420" MinWidth="320"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
             <!-- Left: Skill list -->
             <Border Style="{StaticResource SurfaceCardStyle}" Padding="0">
                 <Grid RowDefinitions="Auto,*">
-                    <TextBlock Text="Available Skills" FontSize="16" FontWeight="SemiBold" Margin="16,12"
-                               Foreground="{StaticResource AppAccentTextBrush}"/>
-                    <ListView Grid.Row="1" x:Name="SkillsList" Background="Transparent" Padding="8"
+                    <!-- List header -->
+                    <Border Padding="16,10" BorderBrush="{StaticResource AppStrokeBrush}" BorderThickness="0,0,0,1">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock x:Name="ListHeader" Text="All Skills" FontSize="14" FontWeight="SemiBold"
+                                       Foreground="{StaticResource AppAccentTextBrush}"/>
+                            <TextBlock x:Name="FilteredCountText" Grid.Column="1" FontSize="12"
+                                       Foreground="{StaticResource AppTextSecondaryBrush}" VerticalAlignment="Center"/>
+                        </Grid>
+                    </Border>
+
+                    <!-- Skill items -->
+                    <ListView Grid.Row="1" x:Name="SkillsList" Background="Transparent" Padding="6"
                               SelectionChanged="SkillsList_SelectionChanged">
+                        <ListView.ItemContainerStyle>
+                            <Style TargetType="ListViewItem">
+                                <Setter Property="Padding" Value="0"/>
+                                <Setter Property="Margin" Value="0,2"/>
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                            </Style>
+                        </ListView.ItemContainerStyle>
                         <ListView.ItemTemplate>
                             <DataTemplate>
-                                <StackPanel Margin="0,6">
-                                    <TextBlock Text="{Binding Name}" FontSize="14" FontWeight="SemiBold"
-                                               Foreground="{StaticResource AppAccentTextBrush}"/>
-                                    <TextBlock Text="{Binding Description}" FontSize="12" TextWrapping="Wrap"
-                                               Foreground="{StaticResource AppTextSecondaryBrush}" MaxLines="2"/>
-                                    <Border Background="#3A3A00" CornerRadius="4" Padding="8,2" Margin="0,4,0,0"
-                                            HorizontalAlignment="Left">
-                                        <TextBlock Text="{Binding Category}" FontSize="10"
-                                                   Foreground="{StaticResource AppAccentTextBrush}"/>
-                                    </Border>
-                                </StackPanel>
+                                <Border Background="{StaticResource AppInsetBrush}" CornerRadius="8"
+                                        Padding="14,10" BorderBrush="{StaticResource AppSubtleStrokeBrush}"
+                                        BorderThickness="1">
+                                    <Grid ColumnSpacing="12">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+
+                                        <StackPanel Spacing="4" VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding Name}" FontSize="13" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
+                                            <TextBlock Text="{Binding Description}" FontSize="11.5" TextWrapping="Wrap"
+                                                       Foreground="{StaticResource AppTextSecondaryBrush}" MaxLines="2"
+                                                       TextTrimming="CharacterEllipsis"/>
+                                        </StackPanel>
+
+                                        <!-- Category + tool count badges -->
+                                        <StackPanel Grid.Column="1" Spacing="4" VerticalAlignment="Center" HorizontalAlignment="Right">
+                                            <Border Background="{Binding CategoryColor}" CornerRadius="4" Padding="8,2"
+                                                    HorizontalAlignment="Right">
+                                                <TextBlock Text="{Binding Category}" FontSize="10" FontWeight="SemiBold"
+                                                           Foreground="{Binding CategoryForeground}"/>
+                                            </Border>
+                                            <TextBlock Text="{Binding ToolCountLabel}" FontSize="10"
+                                                       Foreground="{StaticResource AppTextSecondaryBrush}"
+                                                       HorizontalAlignment="Right"/>
+                                        </StackPanel>
+                                    </Grid>
+                                </Border>
                             </DataTemplate>
                         </ListView.ItemTemplate>
                     </ListView>
@@ -69,16 +140,43 @@
             </Border>
 
             <!-- Right: Skill preview -->
-            <Border Grid.Column="1" Style="{StaticResource SurfaceCardStyle}">
+            <Border Grid.Column="1" Style="{StaticResource SurfaceCardStyle}" Padding="0">
                 <Grid RowDefinitions="Auto,Auto,*">
-                    <TextBlock x:Name="PreviewTitle" Text="Select a skill to preview" FontSize="16" FontWeight="SemiBold"
-                               Foreground="{StaticResource AppAccentTextBrush}" Margin="0,0,0,4"/>
-                    <TextBlock x:Name="PreviewDescription" Grid.Row="1" FontSize="12" TextWrapping="Wrap"
-                               Foreground="{StaticResource AppTextSecondaryBrush}" Margin="0,0,0,12"
-                               Text="Click a skill from the list to see its full system prompt here."/>
-                    <ScrollViewer Grid.Row="2">
-                        <TextBlock x:Name="PreviewContent" FontSize="13" FontFamily="Consolas" TextWrapping="Wrap"
-                                   Foreground="{StaticResource AppTextSecondaryBrush}" IsTextSelectionEnabled="True"/>
+                    <!-- Preview header -->
+                    <Border Padding="20,16" BorderBrush="{StaticResource AppStrokeBrush}" BorderThickness="0,0,0,1">
+                        <StackPanel Spacing="6">
+                            <TextBlock x:Name="PreviewTitle" Text="Select a skill" FontSize="18" FontWeight="SemiBold"
+                                       Foreground="{StaticResource AppAccentTextBrush}"/>
+                            <TextBlock x:Name="PreviewDescription" FontSize="13" TextWrapping="Wrap"
+                                       Foreground="{StaticResource AppTextSecondaryBrush}"
+                                       Text="Click a skill from the list to see its details and system prompt."/>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Metadata pills -->
+                    <StackPanel x:Name="PreviewMeta" Grid.Row="1" Orientation="Horizontal" Spacing="8"
+                                Padding="20,12" Visibility="Collapsed">
+                        <Border x:Name="PreviewCategoryBadge" CornerRadius="6" Padding="10,4">
+                            <TextBlock x:Name="PreviewCategoryText" FontSize="11" FontWeight="SemiBold"/>
+                        </Border>
+                        <Border Background="{StaticResource AppInsetBrush}" CornerRadius="6" Padding="10,4"
+                                BorderBrush="{StaticResource AppSubtleStrokeBrush}" BorderThickness="1">
+                            <TextBlock x:Name="PreviewToolsText" FontSize="11"
+                                       Foreground="{StaticResource AppTextSecondaryBrush}"/>
+                        </Border>
+                        <Border Background="{StaticResource AppInsetBrush}" CornerRadius="6" Padding="10,4"
+                                BorderBrush="{StaticResource AppSubtleStrokeBrush}" BorderThickness="1">
+                            <TextBlock x:Name="PreviewModelText" FontSize="11"
+                                       Foreground="{StaticResource AppTextSecondaryBrush}"/>
+                        </Border>
+                    </StackPanel>
+
+                    <!-- System prompt content -->
+                    <ScrollViewer Grid.Row="2" Padding="20,12,20,20">
+                        <TextBlock x:Name="PreviewContent" FontSize="13" FontFamily="Consolas"
+                                   TextWrapping="Wrap" LineHeight="22"
+                                   Foreground="{StaticResource AppTextSecondaryBrush}"
+                                   IsTextSelectionEnabled="True"/>
                     </ScrollViewer>
                 </Grid>
             </Border>

--- a/Desktop/HermesDesktop/Views/SkillsPage.xaml.cs
+++ b/Desktop/HermesDesktop/Views/SkillsPage.xaml.cs
@@ -3,20 +3,69 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using Hermes.Agent.Skills;
+using Windows.UI;
 
 namespace HermesDesktop.Views;
 
 public sealed partial class SkillsPage : Page
 {
     private List<SkillDisplayItem> _allSkills = new();
+    private string _activeCategory = "All";
+    private bool _loaded;
+
+    // Category color map — each category gets a distinct tinted background + foreground
+    private static readonly Dictionary<string, (Color Bg, Color Fg)> CategoryColors = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["automation"]       = (Color.FromArgb(255, 40, 40, 60),  Color.FromArgb(255, 140, 160, 255)),
+        ["code"]             = (Color.FromArgb(255, 25, 50, 35),  Color.FromArgb(255, 100, 200, 130)),
+        ["analysis"]         = (Color.FromArgb(255, 50, 40, 20),  Color.FromArgb(255, 200, 170, 80)),
+        ["general"]          = (Color.FromArgb(255, 40, 40, 40),  Color.FromArgb(255, 170, 170, 170)),
+        ["claude-code"]      = (Color.FromArgb(255, 50, 30, 20),  Color.FromArgb(255, 220, 160, 100)),
+        ["software-development"] = (Color.FromArgb(255, 25, 45, 50), Color.FromArgb(255, 100, 190, 210)),
+        ["github"]           = (Color.FromArgb(255, 35, 35, 45),  Color.FromArgb(255, 170, 170, 220)),
+        ["research"]         = (Color.FromArgb(255, 45, 25, 50),  Color.FromArgb(255, 180, 130, 220)),
+        ["creative"]         = (Color.FromArgb(255, 50, 25, 40),  Color.FromArgb(255, 230, 130, 180)),
+        ["productivity"]     = (Color.FromArgb(255, 20, 40, 50),  Color.FromArgb(255, 100, 180, 230)),
+        ["mlops"]            = (Color.FromArgb(255, 40, 30, 50),  Color.FromArgb(255, 160, 140, 230)),
+        ["media"]            = (Color.FromArgb(255, 50, 30, 30),  Color.FromArgb(255, 230, 140, 140)),
+        ["gaming"]           = (Color.FromArgb(255, 20, 45, 20),  Color.FromArgb(255, 120, 220, 120)),
+        ["social-media"]     = (Color.FromArgb(255, 30, 40, 50),  Color.FromArgb(255, 100, 160, 230)),
+        ["devops"]           = (Color.FromArgb(255, 40, 40, 25),  Color.FromArgb(255, 200, 200, 100)),
+        ["souls"]            = (Color.FromArgb(255, 50, 35, 15),  Color.FromArgb(255, 212, 160, 23)),
+        ["data-science"]     = (Color.FromArgb(255, 30, 35, 50),  Color.FromArgb(255, 130, 150, 230)),
+        ["email"]            = (Color.FromArgb(255, 45, 30, 30),  Color.FromArgb(255, 210, 140, 140)),
+        ["smart-home"]       = (Color.FromArgb(255, 25, 45, 30),  Color.FromArgb(255, 100, 210, 140)),
+        ["note-taking"]      = (Color.FromArgb(255, 45, 40, 20),  Color.FromArgb(255, 210, 190, 100)),
+        ["mcp"]              = (Color.FromArgb(255, 35, 35, 50),  Color.FromArgb(255, 160, 160, 230)),
+        ["red-teaming"]      = (Color.FromArgb(255, 55, 20, 20),  Color.FromArgb(255, 240, 100, 100)),
+        ["apple"]            = (Color.FromArgb(255, 35, 35, 45),  Color.FromArgb(255, 180, 180, 210)),
+        ["autonomous-ai-agents"] = (Color.FromArgb(255, 40, 25, 50), Color.FromArgb(255, 180, 120, 230)),
+    };
 
     public SkillsPage()
     {
         InitializeComponent();
-        Loaded += (_, _) => Refresh();
+        Loaded += OnLoaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        if (_loaded) return;
+        _loaded = true;
+
+        try
+        {
+            Refresh();
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"SkillsPage.OnLoaded crash: {ex}");
+        }
     }
 
     private void Refresh()
@@ -26,76 +75,244 @@ public sealed partial class SkillsPage : Page
             var skillManager = App.Services.GetRequiredService<SkillManager>();
             var skills = skillManager.ListSkills();
 
-            _allSkills = skills.Select(s => new SkillDisplayItem
+            _allSkills = skills.Select(s =>
             {
-                Name = s.Name,
-                Description = s.Description,
-                Category = DeriveCategory(s),
-                SystemPrompt = s.SystemPrompt,
-                Tools = string.Join(", ", s.Tools)
+                var cat = DeriveCategory(s);
+                var (bg, fg) = GetCategoryColors(cat);
+                var toolList = s.Tools ?? new List<string>();
+                return new SkillDisplayItem
+                {
+                    Name = s.Name ?? "(unnamed)",
+                    Description = s.Description ?? "",
+                    Category = cat,
+                    SystemPrompt = s.SystemPrompt ?? "",
+                    Tools = string.Join(", ", toolList),
+                    ToolCount = toolList.Count,
+                    ToolCountLabel = $"{toolList.Count} tool{(toolList.Count == 1 ? "" : "s")}",
+                    Model = s.Model ?? "",
+                    CategoryColor = new SolidColorBrush(bg),
+                    CategoryForeground = new SolidColorBrush(fg),
+                };
             }).OrderBy(s => s.Name).ToList();
 
+            BuildCategoryChips();
             ApplyFilter();
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"SkillsPage error: {ex.Message}");
+            System.Diagnostics.Debug.WriteLine($"SkillsPage.Refresh error: {ex}");
             _allSkills = new List<SkillDisplayItem>();
+            SkillCountBadge.Text = "0 skills";
+        }
+    }
+
+    private void BuildCategoryChips()
+    {
+        CategoryChips.Children.Clear();
+
+        var categories = _allSkills
+            .Select(s => s.Category)
+            .Where(c => !string.IsNullOrEmpty(c))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(c => c)
+            .ToList();
+
+        // "All" chip first
+        AddChip("All", _allSkills.Count, isActive: _activeCategory == "All");
+
+        foreach (var cat in categories)
+        {
+            var count = _allSkills.Count(s => s.Category.Equals(cat, StringComparison.OrdinalIgnoreCase));
+            AddChip(cat, count, isActive: _activeCategory.Equals(cat, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    private void AddChip(string label, int count, bool isActive)
+    {
+        var (_, fg) = GetCategoryColors(label);
+
+        var btn = new Button
+        {
+            Tag = label,
+            Padding = new Thickness(10, 4, 10, 4),
+            CornerRadius = new CornerRadius(12),
+            MinWidth = 0,
+            FontSize = 11,
+            Content = $"{label} ({count})",
+            Background = isActive ? new SolidColorBrush(fg) : new SolidColorBrush(Colors.Transparent),
+            Foreground = isActive
+                ? new SolidColorBrush(Color.FromArgb(255, 16, 17, 20))
+                : new SolidColorBrush(Color.FromArgb(255, 160, 170, 185)),
+            BorderBrush = isActive
+                ? new SolidColorBrush(Colors.Transparent)
+                : new SolidColorBrush(Color.FromArgb(255, 50, 58, 70)),
+            BorderThickness = new Thickness(1),
+        };
+        btn.Click += CategoryChip_Click;
+        CategoryChips.Children.Add(btn);
+    }
+
+    private void CategoryChip_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button btn && btn.Tag is string tag)
+        {
+            _activeCategory = tag;
+            BuildCategoryChips();
             ApplyFilter();
         }
     }
 
     private void ApplyFilter()
     {
-        var query = SearchBox.Text?.Trim() ?? "";
-        var filtered = string.IsNullOrEmpty(query)
-            ? _allSkills
-            : _allSkills.Where(s =>
-                s.Name.Contains(query, StringComparison.OrdinalIgnoreCase) ||
-                s.Description.Contains(query, StringComparison.OrdinalIgnoreCase) ||
-                s.Category.Contains(query, StringComparison.OrdinalIgnoreCase) ||
-                s.Tools.Contains(query, StringComparison.OrdinalIgnoreCase)
-            ).ToList();
+        var query = SearchBox?.Text?.Trim() ?? "";
 
-        SkillsList.ItemsSource = filtered;
-        SkillCountBadge.Text = $"{filtered.Count} skill{(filtered.Count == 1 ? "" : "s")}";
+        IEnumerable<SkillDisplayItem> filtered = _allSkills;
+
+        // Category filter
+        if (!_activeCategory.Equals("All", StringComparison.OrdinalIgnoreCase))
+        {
+            filtered = filtered.Where(s => s.Category.Equals(_activeCategory, StringComparison.OrdinalIgnoreCase));
+            ListHeader.Text = _activeCategory;
+        }
+        else
+        {
+            ListHeader.Text = "All Skills";
+        }
+
+        // Text search
+        if (!string.IsNullOrEmpty(query))
+        {
+            filtered = filtered.Where(s =>
+                (s.Name?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (s.Description?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (s.Category?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (s.Tools?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false)
+            );
+        }
+
+        // Sort
+        var sortTag = (SortSelector?.SelectedItem as ComboBoxItem)?.Tag as string ?? "name_asc";
+        var list = sortTag switch
+        {
+            "name_desc" => filtered.OrderByDescending(s => s.Name).ToList(),
+            "category" => filtered.OrderBy(s => s.Category).ThenBy(s => s.Name).ToList(),
+            _ => filtered.OrderBy(s => s.Name).ToList(),
+        };
+
+        SkillsList.ItemsSource = list;
+        SkillCountBadge.Text = $"{_allSkills.Count} skill{(_allSkills.Count == 1 ? "" : "s")}";
+        FilteredCountText.Text = list.Count == _allSkills.Count ? "" : $"{list.Count} shown";
     }
 
     private void SearchBox_TextChanged(object sender, TextChangedEventArgs e)
     {
-        ApplyFilter();
+        if (_loaded) ApplyFilter();
+    }
+
+    private void SortSelector_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_loaded) ApplyFilter();
     }
 
     private void SkillsList_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
-        if (SkillsList.SelectedItem is SkillDisplayItem item)
+        if (SkillsList.SelectedItem is not SkillDisplayItem item) return;
+
+        try
         {
             PreviewTitle.Text = item.Name;
-            PreviewDescription.Text = $"{item.Description}\nTools: {item.Tools}";
+            PreviewDescription.Text = item.Description;
             PreviewContent.Text = item.SystemPrompt;
+
+            // Category badge
+            var (bg, fg) = GetCategoryColors(item.Category);
+            PreviewCategoryBadge.Background = new SolidColorBrush(bg);
+            PreviewCategoryText.Text = item.Category;
+            PreviewCategoryText.Foreground = new SolidColorBrush(fg);
+
+            // Tools + Model
+            PreviewToolsText.Text = item.ToolCount > 0 ? $"Tools: {item.Tools}" : "No tools";
+            PreviewModelText.Text = string.IsNullOrEmpty(item.Model) ? "Default model" : $"Model: {item.Model}";
+
+            PreviewMeta.Visibility = Visibility.Visible;
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"SkillsPage preview error: {ex}");
         }
     }
 
     private static string DeriveCategory(Skill skill)
     {
-        // Derive category from the skill's file path directory or tool set
-        if (!string.IsNullOrEmpty(skill.FilePath))
+        try
         {
-            var dir = Path.GetDirectoryName(skill.FilePath);
-            if (dir is not null)
+            if (!string.IsNullOrEmpty(skill.FilePath))
             {
-                var folder = Path.GetFileName(dir);
-                if (!string.IsNullOrEmpty(folder) && !folder.Equals("skills", StringComparison.OrdinalIgnoreCase))
-                    return folder;
+                // Walk up to find the top-level category folder under skills/
+                var dir = Path.GetDirectoryName(skill.FilePath);
+                var parts = new List<string>();
+                while (dir is not null)
+                {
+                    var name = Path.GetFileName(dir);
+                    if (string.IsNullOrEmpty(name) || name.Equals("skills", StringComparison.OrdinalIgnoreCase))
+                        break;
+                    parts.Add(name);
+                    dir = Path.GetDirectoryName(dir);
+                }
+
+                // The last item pushed is the top-level category
+                if (parts.Count > 0)
+                    return parts[^1];
             }
         }
+        catch { /* fall through */ }
 
         // Fall back to inferring from tools
-        var tools = string.Join(" ", skill.Tools).ToLower();
+        var tools = string.Join(" ", skill.Tools ?? new List<string>()).ToLower();
         if (tools.Contains("bash") || tools.Contains("terminal")) return "automation";
         if (tools.Contains("read_file") && tools.Contains("write_file")) return "code";
         if (tools.Contains("grep") || tools.Contains("glob")) return "analysis";
         return "general";
+    }
+
+    private static (Color Bg, Color Fg) GetCategoryColors(string category)
+    {
+        if (string.IsNullOrEmpty(category))
+            return (Color.FromArgb(255, 40, 40, 40), Color.FromArgb(255, 170, 170, 170));
+
+        if (category.Equals("All", StringComparison.OrdinalIgnoreCase))
+            return (Color.FromArgb(255, 50, 45, 15), Color.FromArgb(255, 212, 160, 23));
+
+        if (CategoryColors.TryGetValue(category, out var colors))
+            return colors;
+
+        // Generate a deterministic color from the category name hash
+        // Use unchecked to avoid OverflowException on int.MinValue
+        var hash = unchecked((uint)category.GetHashCode());
+        var hue = (int)(hash % 360);
+        var bg = HslToColor(hue, 0.25, 0.14);
+        var fg = HslToColor(hue, 0.55, 0.65);
+        return (bg, fg);
+    }
+
+    private static Color HslToColor(int h, double s, double l)
+    {
+        double c = (1 - Math.Abs(2 * l - 1)) * s;
+        double x = c * (1 - Math.Abs((h / 60.0) % 2 - 1));
+        double m = l - c / 2;
+        double r, g, b;
+
+        if (h < 60) { r = c; g = x; b = 0; }
+        else if (h < 120) { r = x; g = c; b = 0; }
+        else if (h < 180) { r = 0; g = c; b = x; }
+        else if (h < 240) { r = 0; g = x; b = c; }
+        else if (h < 300) { r = x; g = 0; b = c; }
+        else { r = c; g = 0; b = x; }
+
+        return Color.FromArgb(255,
+            (byte)Math.Clamp((r + m) * 255, 0, 255),
+            (byte)Math.Clamp((g + m) * 255, 0, 255),
+            (byte)Math.Clamp((b + m) * 255, 0, 255));
     }
 }
 
@@ -106,4 +323,9 @@ public sealed class SkillDisplayItem
     public string Category { get; set; } = "";
     public string SystemPrompt { get; set; } = "";
     public string Tools { get; set; } = "";
+    public int ToolCount { get; set; }
+    public string ToolCountLabel { get; set; } = "";
+    public string Model { get; set; } = "";
+    public SolidColorBrush CategoryColor { get; set; } = new(Colors.Gray);
+    public SolidColorBrush CategoryForeground { get; set; } = new(Colors.White);
 }


### PR DESCRIPTION
## Summary
- **Skills page redesign** — card-based list items with 24 colored category badges, scrollable category filter chips, sort dropdown (name A-Z, Z-A, category), smarter top-level category detection from folder structure, richer preview pane with metadata pills (category, tools, model)
- **Unified button styles** — 4 global styles added to App.xaml: Default (gold gradient), GhostButtonStyle (transparent tabs), SecondaryButtonStyle (dark inset for secondary actions), DangerButtonStyle (red tint for delete/deny). Applied across all 16 XAML files replacing inline per-button styling
- **README overhaul** — comprehensive rewrite documenting: soul identity system (SOUL.md, USER.md, AGENTS.md, journals, 12 templates), 94 skills (74 Hermes + 20 Claude Code) with category table, multi-agent profiles, 8 desktop pages, 6-layer prompt architecture, dream consolidation, updated project structure, correct repo URL and config examples

## Files Changed (17)
- `App.xaml` — 4 new global button styles
- `SkillsPage.xaml` + `.cs` — full redesign with categories, cards, colors, sorting
- `AgentPage.xaml` + `.cs` — button style cleanup
- `ChatPage.xaml` — Send/New Chat/tab button styles
- `DashboardPage.xaml` — Test Connection/Open Chat/Logs/Config styles
- `IntegrationsPage.xaml` — 5 Save buttons + Gateway buttons
- `MemoryPage.xaml` + `.cs` — tab button styles
- `SettingsPage.xaml` — Save Model Config style
- `SessionPanel.xaml`, `TaskPanel.xaml`, `ReplayPanel.xaml` — panel button styles
- `CodeBlockView.xaml` — Copy button style
- `PermissionDialog.xaml` — Cancel button style
- `README.md` — comprehensive rewrite

## Test plan
- [ ] Skills page loads without crash, shows all 94 skills with colored category badges
- [ ] Category chips filter correctly, sort dropdown works
- [ ] All buttons across every page render with gold gradient by default
- [ ] Tab buttons (Ghost style) show transparent bg with muted text
- [ ] Secondary buttons (New Chat, Reset, Open Logs) show dark inset style
- [ ] Danger buttons (Delete) show red tint
- [ ] Agent page tab switching correctly toggles gradient/secondary styles
- [ ] Memory page tab switching works correctly
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly UI/UX refactoring, but it introduces new filtering/sorting/category-derivation logic in `SkillsPage` and changes global `Button` default styling app-wide, which could cause unintended visual or interaction regressions.
> 
> **Overview**
> **Unifies button styling across the desktop app** by adding global `Button` defaults plus `GhostButtonStyle`, `SecondaryButtonStyle`, and `DangerButtonStyle` in `App.xaml`, then removing many per-button inline styles across pages/panels (tabs, secondary actions, and destructive actions now consistently styled).
> 
> **Redesigns the `SkillsPage` experience** with a richer list/preview layout: searchable skills now support category chip filtering, sorting (A–Z/Z–A/category), per-category color badges, tool counts, and preview metadata (category/tools/model). Category detection is updated to derive the top-level folder under `skills/`, with safer null handling and deterministic fallback colors.
> 
> Also refactors tab style toggling in `AgentPage` and `MemoryPage` code-behind to set background/foreground/border consistently via a loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e215a2f0d6da860b56c0971d6ced217128acae6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned Skills page with category filtering, sorting options, and enhanced metadata display for better skill discovery and preview.

* **Style**
  * Introduced consistent button styling across the app with new visual variants (ghost, secondary, danger buttons) for improved UI consistency.
  * Updated button appearance throughout multiple pages to use standardized shared styles.
  * Enhanced tab navigation visual feedback with improved border styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->