### PR TITLE
Buddy tamagotchi, Ollama model picker, auto-permissions

### DIFF
--- a/Desktop/HermesDesktop/App.xaml.cs
+++ b/Desktop/HermesDesktop/App.xaml.cs
@@ -92,9 +92,23 @@ public partial class App : Application
             skillsDir,
             sp.GetRequiredService<ILogger<SkillManager>>()));
 
-        // Permission manager
+        // Permission manager — Auto mode: read-only tools auto-approved, writes ask
         services.AddSingleton(sp => new PermissionManager(
-            new PermissionContext(),
+            new PermissionContext
+            {
+                Mode = PermissionMode.Auto,
+                AlwaysAllow =
+                {
+                    PermissionRule.AllowAll("read_file"),
+                    PermissionRule.AllowAll("glob"),
+                    PermissionRule.AllowAll("grep"),
+                    PermissionRule.AllowAll("web_search"),
+                    PermissionRule.AllowAll("web_fetch"),
+                    PermissionRule.AllowAll("todo_write"),
+                    PermissionRule.AllowAll("ask_user"),
+                    PermissionRule.AllowAll("terminal"),
+                }
+            },
             sp.GetRequiredService<ILogger<PermissionManager>>()));
 
         // Task manager
@@ -203,6 +217,9 @@ public partial class App : Application
         // Wire permission prompt callback to show a ContentDialog in the UI
         WirePermissionCallback(provider);
 
+        // Wire buddy session awareness — agent activity feeds buddy XP/mood
+        WireBuddyActivity(provider);
+
         return provider;
     }
 
@@ -247,6 +264,37 @@ public partial class App : Application
 
             return await tcs.Task;
         };
+    }
+
+    /// <summary>
+    /// Wire Agent activity events to BuddyService for passive XP/mood.
+    /// </summary>
+    private static void WireBuddyActivity(IServiceProvider services)
+    {
+        try
+        {
+            var agent = services.GetRequiredService<Hermes.Agent.Core.Agent>();
+            var buddyService = services.GetRequiredService<BuddyService>();
+
+            agent.ActivityEntryAdded += entry =>
+            {
+                // Fire-and-forget — don't block the agent loop
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        var evt = entry.ToolName.ToLower() switch
+                        {
+                            "user_message" => BuddySessionEvent.UserMessage,
+                            _ => BuddySessionEvent.ToolComplete
+                        };
+                        await buddyService.OnActivityAsync(evt);
+                    }
+                    catch { /* swallow buddy errors */ }
+                });
+            };
+        }
+        catch { /* buddy wiring is optional */ }
     }
 
     /// <summary>

--- a/Desktop/HermesDesktop/App.xaml.cs
+++ b/Desktop/HermesDesktop/App.xaml.cs
@@ -106,7 +106,6 @@ public partial class App : Application
                     PermissionRule.AllowAll("web_fetch"),
                     PermissionRule.AllowAll("todo_write"),
                     PermissionRule.AllowAll("ask_user"),
-                    PermissionRule.AllowAll("terminal"),
                 }
             },
             sp.GetRequiredService<ILogger<PermissionManager>>()));
@@ -286,7 +285,7 @@ public partial class App : Application
                         var evt = entry.ToolName.ToLower() switch
                         {
                             "user_message" => BuddySessionEvent.UserMessage,
-                            _ => BuddySessionEvent.ToolComplete
+                            _ => BuddySessionEvent.ToolCall  // ToolCall not ToolComplete — event fires at start
                         };
                         await buddyService.OnActivityAsync(evt);
                     }

--- a/Desktop/HermesDesktop/Views/BuddyPage.xaml
+++ b/Desktop/HermesDesktop/Views/BuddyPage.xaml
@@ -9,7 +9,7 @@
     NavigationCacheMode="Required"
     mc:Ignorable="d">
 
-    <Grid Padding="32,24,32,40">
+    <Grid Padding="32,24,32,32">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
@@ -18,136 +18,219 @@
         <!-- Header -->
         <StackPanel Spacing="4" Margin="0,0,0,16">
             <TextBlock Text="Buddy" Style="{StaticResource PageEyebrowTextStyle}"/>
-            <TextBlock Text="Your Companion" FontSize="22" FontWeight="SemiBold"/>
-            <TextBlock Text="Tamagotchi-style companion, deterministically generated from your identity"
+            <StackPanel Orientation="Horizontal" Spacing="12">
+                <TextBlock Text="Your Companion" FontSize="22" FontWeight="SemiBold"/>
+                <Border x:Name="LevelBadge" Background="#3A3A00" CornerRadius="8" Padding="10,4" VerticalAlignment="Center">
+                    <TextBlock x:Name="LevelText" Text="Level 1" FontSize="12"
+                               Foreground="{StaticResource AppAccentTextBrush}"/>
+                </Border>
+            </StackPanel>
+            <TextBlock x:Name="HeaderSubtitle" Text="Choose your companion and watch it grow"
                        FontSize="13" Foreground="{StaticResource AppTextSecondaryBrush}"/>
         </StackPanel>
 
-        <!-- Two-column layout -->
-        <Grid Grid.Row="1" ColumnSpacing="24">
+        <!-- ═══════════════════════════════════════════════ -->
+        <!-- SELECTION VIEW (first time)                     -->
+        <!-- ═══════════════════════════════════════════════ -->
+        <Grid x:Name="SelectionView" Grid.Row="1" Visibility="Collapsed">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock Text="Choose your buddy species" FontSize="18" FontWeight="SemiBold"
+                       Foreground="{StaticResource AppAccentTextBrush}" Margin="0,0,0,12"/>
+
+            <!-- Species grid -->
+            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+                <ItemsRepeater x:Name="SpeciesGrid">
+                    <ItemsRepeater.Layout>
+                        <UniformGridLayout MinItemWidth="160" MinItemHeight="200" MinColumnSpacing="12" MinRowSpacing="12"/>
+                    </ItemsRepeater.Layout>
+                    <ItemsRepeater.ItemTemplate>
+                        <DataTemplate>
+                            <Border x:Name="SpeciesCard" Background="{StaticResource AppInsetBrush}"
+                                    CornerRadius="10" Padding="12" BorderThickness="2"
+                                    BorderBrush="{StaticResource AppSubtleStrokeBrush}"
+                                    PointerPressed="SpeciesCard_Click" Tag="{Binding Name}">
+                                <StackPanel Spacing="8" HorizontalAlignment="Center">
+                                    <TextBlock Text="{Binding Preview}" FontFamily="Cascadia Mono, Consolas"
+                                               FontSize="11" TextAlignment="Center"
+                                               Foreground="{StaticResource AppAccentTextBrush}"/>
+                                    <TextBlock Text="{Binding Name}" FontSize="14" FontWeight="SemiBold"
+                                               HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsRepeater.ItemTemplate>
+                </ItemsRepeater>
+            </ScrollViewer>
+
+            <!-- Name input + confirm -->
+            <Border Grid.Row="2" Style="{StaticResource SurfaceCardStyle}" Margin="0,16,0,0">
+                <Grid ColumnSpacing="16">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Text="Selected:" FontSize="14" VerticalAlignment="Center"
+                               Foreground="{StaticResource AppTextSecondaryBrush}"/>
+                    <TextBlock x:Name="SelectedSpeciesText" Grid.Column="1" Text="None" FontSize="14"
+                               FontWeight="SemiBold" Foreground="{StaticResource AppAccentTextBrush}"
+                               VerticalAlignment="Center"/>
+                    <TextBox x:Name="NameInput" Grid.Column="2" PlaceholderText="Name your buddy..."
+                             Width="200" FontSize="13"
+                             Background="{StaticResource AppInsetBrush}" BorderBrush="{StaticResource AppStrokeBrush}"/>
+                    <Button x:Name="ConfirmBtn" Grid.Column="3" Content="Hatch!" Click="Confirm_Click"
+                            Padding="20,10" FontSize="14" IsEnabled="False"/>
+                </Grid>
+            </Border>
+        </Grid>
+
+        <!-- ═══════════════════════════════════════════════ -->
+        <!-- BUDDY VIEW (after selection)                    -->
+        <!-- ═══════════════════════════════════════════════ -->
+        <Grid x:Name="BuddyView" Grid.Row="1" Visibility="Collapsed" ColumnSpacing="24">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="360" MinWidth="300"/>
+                <ColumnDefinition Width="380"/>
             </Grid.ColumnDefinitions>
 
-            <!-- Left: Buddy card -->
+            <!-- Left: Buddy visual + interactions -->
             <Border Style="{StaticResource SurfaceCardStyle}">
-                <StackPanel Spacing="16" HorizontalAlignment="Center" VerticalAlignment="Center" Padding="24">
+                <StackPanel Spacing="16" HorizontalAlignment="Center">
+                    <TextBlock x:Name="ShinyBadge" Text="✨ SHINY ✨" FontSize="14" FontWeight="Bold"
+                               Foreground="#FFD700" HorizontalAlignment="Center" Visibility="Collapsed"/>
 
-                    <!-- Shiny indicator -->
-                    <TextBlock x:Name="ShinyBadge" Text="" FontSize="16" HorizontalAlignment="Center"
-                               Foreground="{StaticResource AppAccentTextBrush}" Visibility="Collapsed"/>
-
-                    <!-- ASCII art -->
-                    <Border Background="{StaticResource AppInsetBrush}" CornerRadius="12" Padding="32,24"
-                            HorizontalAlignment="Center">
-                        <TextBlock x:Name="AsciiArt" FontSize="20" FontFamily="Consolas"
-                                   TextAlignment="Center" Foreground="{StaticResource AppAccentTextBrush}"
-                                   Text="Loading..." IsTextSelectionEnabled="True"/>
-                    </Border>
-
-                    <!-- Name -->
-                    <TextBlock x:Name="BuddyName" Text="..." FontSize="28" FontWeight="Bold"
-                               HorizontalAlignment="Center"
-                               Foreground="{StaticResource AppAccentTextBrush}"/>
-
-                    <!-- Species + Rarity -->
+                    <!-- Mood indicator -->
                     <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
-                        <TextBlock x:Name="BuddySpecies" Text="" FontSize="14"
-                                   Foreground="{StaticResource AppTextSecondaryBrush}"/>
-                        <Border x:Name="RarityBadge" Background="#3A3A00" CornerRadius="6" Padding="10,4">
-                            <TextBlock x:Name="RarityText" Text="" FontSize="11"
-                                       Foreground="{StaticResource AppAccentTextBrush}"/>
-                        </Border>
+                        <TextBlock x:Name="MoodEmoji" Text="🙂" FontSize="20"/>
+                        <TextBlock x:Name="MoodText" Text="Content" FontSize="16" FontWeight="SemiBold"
+                                   Foreground="{StaticResource AppAccentTextBrush}" VerticalAlignment="Center"/>
                     </StackPanel>
 
-                    <!-- Stats bars -->
-                    <Border Background="{StaticResource AppInsetBrush}" CornerRadius="8" Padding="20,16"
-                            HorizontalAlignment="Stretch" MaxWidth="400">
-                        <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="50,*,40" RowSpacing="10">
-                            <!-- INT -->
-                            <TextBlock Text="INT" FontSize="12" FontWeight="SemiBold"
-                                       Foreground="{StaticResource AppTextSecondaryBrush}" VerticalAlignment="Center"/>
-                            <ProgressBar x:Name="StatInt" Grid.Column="1" Minimum="0" Maximum="100" Value="0"
-                                         Height="8" Margin="8,0" CornerRadius="4"
-                                         Foreground="#508CC8" Background="#2A2520"/>
-                            <TextBlock x:Name="StatIntVal" Grid.Column="2" Text="0" FontSize="12"
-                                       Foreground="{StaticResource AppTextSecondaryBrush}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-
-                            <!-- ENR -->
-                            <TextBlock Grid.Row="1" Text="ENR" FontSize="12" FontWeight="SemiBold"
-                                       Foreground="{StaticResource AppTextSecondaryBrush}" VerticalAlignment="Center"/>
-                            <ProgressBar x:Name="StatEnr" Grid.Row="1" Grid.Column="1" Minimum="0" Maximum="100" Value="0"
-                                         Height="8" Margin="8,0" CornerRadius="4"
-                                         Foreground="#6BCB77" Background="#2A2520"/>
-                            <TextBlock x:Name="StatEnrVal" Grid.Row="1" Grid.Column="2" Text="0" FontSize="12"
-                                       Foreground="{StaticResource AppTextSecondaryBrush}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-
-                            <!-- CRE -->
-                            <TextBlock Grid.Row="2" Text="CRE" FontSize="12" FontWeight="SemiBold"
-                                       Foreground="{StaticResource AppTextSecondaryBrush}" VerticalAlignment="Center"/>
-                            <ProgressBar x:Name="StatCre" Grid.Row="2" Grid.Column="1" Minimum="0" Maximum="100" Value="0"
-                                         Height="8" Margin="8,0" CornerRadius="4"
-                                         Foreground="#C88C50" Background="#2A2520"/>
-                            <TextBlock x:Name="StatCreVal" Grid.Row="2" Grid.Column="2" Text="0" FontSize="12"
-                                       Foreground="{StaticResource AppTextSecondaryBrush}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-
-                            <!-- FRN -->
-                            <TextBlock Grid.Row="3" Text="FRN" FontSize="12" FontWeight="SemiBold"
-                                       Foreground="{StaticResource AppTextSecondaryBrush}" VerticalAlignment="Center"/>
-                            <ProgressBar x:Name="StatFrn" Grid.Row="3" Grid.Column="1" Minimum="0" Maximum="100" Value="0"
-                                         Height="8" Margin="8,0" CornerRadius="4"
-                                         Foreground="#A064B4" Background="#2A2520"/>
-                            <TextBlock x:Name="StatFrnVal" Grid.Row="3" Grid.Column="2" Text="0" FontSize="12"
-                                       Foreground="{StaticResource AppTextSecondaryBrush}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-                        </Grid>
+                    <!-- Animated ASCII art -->
+                    <Border Background="{StaticResource AppInsetBrush}" CornerRadius="12" Padding="32,20"
+                            BorderBrush="{StaticResource AppSubtleStrokeBrush}" BorderThickness="1"
+                            HorizontalAlignment="Center" MinWidth="200">
+                        <TextBlock x:Name="AsciiArt" FontFamily="Cascadia Mono, Consolas" FontSize="18"
+                                   TextAlignment="Center" Foreground="{StaticResource AppAccentTextBrush}"
+                                   LineHeight="20"/>
                     </Border>
 
-                    <!-- Personality -->
-                    <TextBlock x:Name="BuddyPersonality" Text="" FontSize="13" TextWrapping="Wrap"
-                               TextAlignment="Center" FontStyle="Italic" MaxWidth="360"
+                    <!-- Name + species -->
+                    <StackPanel HorizontalAlignment="Center" Spacing="6">
+                        <TextBlock x:Name="BuddyName" Text="..." FontSize="28" FontWeight="Bold"
+                                   HorizontalAlignment="Center"/>
+                        <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
+                            <TextBlock x:Name="SpeciesText" Text="..." FontSize="14"
+                                       Foreground="{StaticResource AppTextSecondaryBrush}"/>
+                            <Border x:Name="RarityBadge" CornerRadius="6" Padding="8,2">
+                                <TextBlock x:Name="RarityText" Text="..." FontSize="11" FontWeight="SemiBold"/>
+                            </Border>
+                        </StackPanel>
+                    </StackPanel>
+
+                    <!-- Quote bubble -->
+                    <Border Background="{StaticResource AppInsetBrush}" CornerRadius="10" Padding="16,10"
+                            BorderBrush="{StaticResource AppSubtleStrokeBrush}" BorderThickness="1"
+                            HorizontalAlignment="Center" MaxWidth="400">
+                        <TextBlock x:Name="QuoteBubble" Text="..." FontSize="13" FontStyle="Italic"
+                                   TextAlignment="Center" TextWrapping="Wrap"
+                                   Foreground="{StaticResource AppAccentTextBrush}"/>
+                    </Border>
+
+                    <!-- Interaction buttons -->
+                    <StackPanel Orientation="Horizontal" Spacing="12" HorizontalAlignment="Center">
+                        <Button Content="🍖 Feed" Click="Feed_Click" Padding="16,10" FontSize="13"/>
+                        <Button Content="🎮 Play" Click="Play_Click" Padding="16,10" FontSize="13"/>
+                        <Button Content="📚 Train" Click="Train_Click" Padding="16,10" FontSize="13"/>
+                        <Button Content="🤗 Pet" Click="Pet_Click" Padding="16,10" FontSize="13"/>
+                    </StackPanel>
+
+                    <TextBlock x:Name="PersonalityText" Text="" FontSize="13" FontStyle="Italic"
+                               TextWrapping="Wrap" TextAlignment="Center" MaxWidth="400"
                                Foreground="{StaticResource AppTextSecondaryBrush}"/>
                 </StackPanel>
             </Border>
 
-            <!-- Right: Info card -->
-            <Border Grid.Column="1" Style="{StaticResource SurfaceCardStyle}">
-                <StackPanel Spacing="16">
-                    <TextBlock Text="Buddy Lore" FontSize="16" FontWeight="SemiBold"
-                               Foreground="{StaticResource AppAccentTextBrush}"/>
-
-                    <TextBlock TextWrapping="Wrap" FontSize="13" Foreground="{StaticResource AppTextSecondaryBrush}"
-                               Text="Every user gets a unique companion, deterministically generated from their identity. Your buddy is permanent and cannot be re-rolled."/>
-
-                    <Border Background="{StaticResource AppInsetBrush}" CornerRadius="8" Padding="16,12">
-                        <StackPanel Spacing="8">
-                            <TextBlock Text="Rarity Table" FontSize="13" FontWeight="SemiBold"
-                                       Foreground="{StaticResource AppAccentTextBrush}"/>
-                            <TextBlock FontSize="12" Foreground="{StaticResource AppTextSecondaryBrush}" FontFamily="Consolas"
-                                       Text="Common      90.0%&#x0a;Uncommon      9.0%&#x0a;Rare          0.9%&#x0a;Legendary     0.1%&#x0a;Shiny         0.5% (any rarity)"/>
+            <!-- Right: Status panel -->
+            <StackPanel Grid.Column="1" Spacing="16">
+                <!-- Needs -->
+                <Border Style="{StaticResource SurfaceCardStyle}">
+                    <StackPanel Spacing="12">
+                        <TextBlock Text="Needs" FontSize="16" FontWeight="SemiBold" Foreground="{StaticResource AppAccentTextBrush}"/>
+                        <StackPanel Spacing="4">
+                            <Grid><TextBlock Text="🍖 Hunger" FontSize="12"/>
+                            <TextBlock x:Name="HungerValue" Text="80" FontSize="12" HorizontalAlignment="Right" Foreground="{StaticResource AppTextSecondaryBrush}"/></Grid>
+                            <ProgressBar x:Name="HungerBar" Value="80" Maximum="100" Height="8" Background="{StaticResource AppInsetBrush}" CornerRadius="4"/>
                         </StackPanel>
-                    </Border>
-
-                    <Border Background="{StaticResource AppInsetBrush}" CornerRadius="8" Padding="16,12">
-                        <StackPanel Spacing="8">
-                            <TextBlock Text="Stats" FontSize="13" FontWeight="SemiBold"
-                                       Foreground="{StaticResource AppAccentTextBrush}"/>
-                            <TextBlock FontSize="12" Foreground="{StaticResource AppTextSecondaryBrush}" TextWrapping="Wrap"
-                                       Text="INT (Intelligence), ENR (Energy), CRE (Creativity), FRN (Friendliness). Total stat points scale with rarity: Common ~120, Uncommon ~180, Rare ~240, Legendary ~300."/>
+                        <StackPanel Spacing="4">
+                            <Grid><TextBlock Text="😊 Happiness" FontSize="12"/>
+                            <TextBlock x:Name="HappinessValue" Text="80" FontSize="12" HorizontalAlignment="Right" Foreground="{StaticResource AppTextSecondaryBrush}"/></Grid>
+                            <ProgressBar x:Name="HappinessBar" Value="80" Maximum="100" Height="8" Background="{StaticResource AppInsetBrush}" CornerRadius="4"/>
                         </StackPanel>
-                    </Border>
-
-                    <Border Background="{StaticResource AppInsetBrush}" CornerRadius="8" Padding="16,12">
-                        <StackPanel Spacing="8">
-                            <TextBlock Text="Details" FontSize="13" FontWeight="SemiBold"
-                                       Foreground="{StaticResource AppAccentTextBrush}"/>
-                            <TextBlock x:Name="BuddyDetails" FontSize="12" Foreground="{StaticResource AppTextSecondaryBrush}"
-                                       FontFamily="Consolas" TextWrapping="Wrap"
-                                       Text="Loading..."/>
+                        <StackPanel Spacing="4">
+                            <Grid><TextBlock Text="⚡ Energy" FontSize="12"/>
+                            <TextBlock x:Name="EnergyValue" Text="80" FontSize="12" HorizontalAlignment="Right" Foreground="{StaticResource AppTextSecondaryBrush}"/></Grid>
+                            <ProgressBar x:Name="EnergyBar" Value="80" Maximum="100" Height="8" Background="{StaticResource AppInsetBrush}" CornerRadius="4"/>
                         </StackPanel>
-                    </Border>
-                </StackPanel>
-            </Border>
+                    </StackPanel>
+                </Border>
+
+                <!-- Level / XP -->
+                <Border Style="{StaticResource SurfaceCardStyle}">
+                    <StackPanel Spacing="8">
+                        <Grid><TextBlock Text="Level &amp; Experience" FontSize="16" FontWeight="SemiBold" Foreground="{StaticResource AppAccentTextBrush}"/>
+                        <TextBlock x:Name="TotalXPText" Text="0 total XP" FontSize="11" HorizontalAlignment="Right" Foreground="{StaticResource AppTextSecondaryBrush}" VerticalAlignment="Center"/></Grid>
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <TextBlock x:Name="LevelDisplay" Text="Lv. 1" FontSize="20" FontWeight="Bold" Foreground="{StaticResource AppAccentTextBrush}"/>
+                            <TextBlock x:Name="XPDisplay" Text="0 / 100 XP" FontSize="14" Foreground="{StaticResource AppTextSecondaryBrush}" VerticalAlignment="Center"/>
+                        </StackPanel>
+                        <ProgressBar x:Name="XPBar" Value="0" Maximum="100" Height="10" Background="{StaticResource AppInsetBrush}" CornerRadius="5" Foreground="{StaticResource AppAccentBrush}"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- Base stats -->
+                <Border Style="{StaticResource SurfaceCardStyle}">
+                    <StackPanel Spacing="10">
+                        <TextBlock Text="Base Stats" FontSize="16" FontWeight="SemiBold" Foreground="{StaticResource AppAccentTextBrush}"/>
+                        <StackPanel Spacing="4">
+                            <Grid><TextBlock Text="INT" FontSize="11" FontWeight="SemiBold" Foreground="#508CC8"/>
+                            <TextBlock x:Name="IntValue" Text="0" FontSize="11" HorizontalAlignment="Right" Foreground="#508CC8"/></Grid>
+                            <ProgressBar x:Name="IntBar" Value="0" Maximum="100" Height="6" Foreground="#508CC8" Background="{StaticResource AppInsetBrush}" CornerRadius="3"/>
+                        </StackPanel>
+                        <StackPanel Spacing="4">
+                            <Grid><TextBlock Text="ENR" FontSize="11" FontWeight="SemiBold" Foreground="#6BCB77"/>
+                            <TextBlock x:Name="EnrValue" Text="0" FontSize="11" HorizontalAlignment="Right" Foreground="#6BCB77"/></Grid>
+                            <ProgressBar x:Name="EnrBar" Value="0" Maximum="100" Height="6" Foreground="#6BCB77" Background="{StaticResource AppInsetBrush}" CornerRadius="3"/>
+                        </StackPanel>
+                        <StackPanel Spacing="4">
+                            <Grid><TextBlock Text="CRE" FontSize="11" FontWeight="SemiBold" Foreground="#C88C50"/>
+                            <TextBlock x:Name="CreValue" Text="0" FontSize="11" HorizontalAlignment="Right" Foreground="#C88C50"/></Grid>
+                            <ProgressBar x:Name="CreBar" Value="0" Maximum="100" Height="6" Foreground="#C88C50" Background="{StaticResource AppInsetBrush}" CornerRadius="3"/>
+                        </StackPanel>
+                        <StackPanel Spacing="4">
+                            <Grid><TextBlock Text="FRN" FontSize="11" FontWeight="SemiBold" Foreground="#A064B4"/>
+                            <TextBlock x:Name="FrnValue" Text="0" FontSize="11" HorizontalAlignment="Right" Foreground="#A064B4"/></Grid>
+                            <ProgressBar x:Name="FrnBar" Value="0" Maximum="100" Height="6" Foreground="#A064B4" Background="{StaticResource AppInsetBrush}" CornerRadius="3"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+
+                <Border Style="{StaticResource SurfaceCardStyle}">
+                    <StackPanel Spacing="6">
+                        <TextBlock Text="Details" FontSize="14" FontWeight="SemiBold" Foreground="{StaticResource AppAccentTextBrush}"/>
+                        <TextBlock x:Name="HatchedText" Text="" FontSize="12" Foreground="{StaticResource AppTextSecondaryBrush}"/>
+                        <TextBlock x:Name="EyesText" Text="" FontSize="12" Foreground="{StaticResource AppTextSecondaryBrush}"/>
+                        <TextBlock x:Name="HatText" Text="" FontSize="12" Foreground="{StaticResource AppTextSecondaryBrush}"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
         </Grid>
     </Grid>
 </Page>

--- a/Desktop/HermesDesktop/Views/BuddyPage.xaml.cs
+++ b/Desktop/HermesDesktop/Views/BuddyPage.xaml.cs
@@ -1,88 +1,296 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using Hermes.Agent.Buddy;
+using Windows.UI;
 
 namespace HermesDesktop.Views;
 
 public sealed partial class BuddyPage : Page
 {
     private BuddyService? _buddyService;
+    private DispatcherQueueTimer? _animTimer;   // 500ms animation tick
+    private DispatcherQueueTimer? _decayTimer;  // 30s decay tick
+    private int _animTick;
+    private bool _loaded;
+    private string? _selectedSpecies;
 
     public BuddyPage()
     {
         InitializeComponent();
-        Loaded += (_, _) => _ = LoadBuddyAsync();
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
     }
 
-    private async System.Threading.Tasks.Task LoadBuddyAsync()
+    private async void OnLoaded(object sender, RoutedEventArgs e)
     {
+        if (_loaded) { StartTimers(); RefreshUI(); return; }
+        _loaded = true;
+
         try
         {
             _buddyService = App.Services.GetRequiredService<BuddyService>();
 
-            // Use a default user ID — the service handles deterministic generation
-            var userId = Environment.UserName ?? "default";
-            var buddy = await _buddyService.GetBuddyAsync(userId, CancellationToken.None);
-
-            // Render ASCII art
-            var ascii = BuddyRenderer.RenderAscii(buddy);
-            AsciiArt.Text = ascii;
-
-            // Name
-            BuddyName.Text = buddy.Name ?? "Unnamed";
-
-            // Species + Rarity
-            BuddySpecies.Text = buddy.Species;
-            RarityText.Text = buddy.Rarity.ToUpperInvariant();
-
-            // Rarity badge color
-            RarityBadge.Background = buddy.Rarity switch
+            if (_buddyService.NeedsSelection)
             {
-                "legendary" => new Microsoft.UI.Xaml.Media.SolidColorBrush(
-                    Microsoft.UI.ColorHelper.FromArgb(255, 200, 160, 50)),
-                "rare" => new Microsoft.UI.Xaml.Media.SolidColorBrush(
-                    Microsoft.UI.ColorHelper.FromArgb(255, 100, 140, 200)),
-                "uncommon" => new Microsoft.UI.Xaml.Media.SolidColorBrush(
-                    Microsoft.UI.ColorHelper.FromArgb(255, 100, 180, 100)),
-                _ => new Microsoft.UI.Xaml.Media.SolidColorBrush(
-                    Microsoft.UI.ColorHelper.FromArgb(255, 58, 58, 0))
-            };
-
-            // Shiny badge
-            if (buddy.IsShiny)
-            {
-                ShinyBadge.Text = "SHINY";
-                ShinyBadge.Visibility = Visibility.Visible;
+                ShowSelectionView();
             }
-
-            // Stats
-            StatInt.Value = buddy.Stats.Intelligence;
-            StatIntVal.Text = buddy.Stats.Intelligence.ToString();
-            StatEnr.Value = buddy.Stats.Energy;
-            StatEnrVal.Text = buddy.Stats.Energy.ToString();
-            StatCre.Value = buddy.Stats.Creativity;
-            StatCreVal.Text = buddy.Stats.Creativity.ToString();
-            StatFrn.Value = buddy.Stats.Friendliness;
-            StatFrnVal.Text = buddy.Stats.Friendliness.ToString();
-
-            // Personality
-            BuddyPersonality.Text = buddy.Personality ?? "";
-
-            // Details
-            BuddyDetails.Text = $"Eyes: {buddy.Eyes}\n"
-                               + $"Hat: {(string.IsNullOrEmpty(buddy.Hat) ? "none" : buddy.Hat)}\n"
-                               + $"Total Stats: {buddy.Stats.Total}\n"
-                               + $"Hatched: {buddy.HatchedAt:yyyy-MM-dd}";
+            else
+            {
+                var userId = Environment.UserName ?? "default";
+                await _buddyService.GetBuddyAsync(userId, CancellationToken.None);
+                ShowBuddyView();
+                QuoteBubble.Text = BuddyQuotes.GetGreeting();
+            }
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"BuddyPage error: {ex.Message}");
-            AsciiArt.Text = "Could not load buddy.";
-            BuddyName.Text = "Error";
-            BuddyDetails.Text = $"Error: {ex.Message}";
+            System.Diagnostics.Debug.WriteLine($"BuddyPage load error: {ex}");
+            // Fallback: show selection if loading failed
+            ShowSelectionView();
         }
     }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        _animTimer?.Stop();
+        _decayTimer?.Stop();
+    }
+
+    // ============================================
+    // SELECTION FLOW
+    // ============================================
+
+    private void ShowSelectionView()
+    {
+        SelectionView.Visibility = Visibility.Visible;
+        BuddyView.Visibility = Visibility.Collapsed;
+        LevelBadge.Visibility = Visibility.Collapsed;
+        HeaderSubtitle.Text = "Choose your companion and give it a name";
+
+        // Populate species grid
+        var items = BuddySprites.AllSpecies.Select(s => new SpeciesItem
+        {
+            Name = s,
+            Preview = BuddyRenderer.RenderPreview(s)
+        }).ToList();
+        SpeciesGrid.ItemsSource = items;
+    }
+
+    private void SpeciesCard_Click(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is not FrameworkElement el || el.Tag is not string species) return;
+        _selectedSpecies = species;
+        SelectedSpeciesText.Text = species;
+        ConfirmBtn.IsEnabled = true;
+
+        // Highlight selected card by iterating children
+        // (ItemsRepeater doesn't have SelectedItem, so we use visual state)
+        for (int i = 0; i < SpeciesGrid.ItemsSourceView.Count; i++)
+        {
+            var container = SpeciesGrid.TryGetElement(i);
+            if (container is FrameworkElement fe)
+            {
+                var border = FindChildBorder(fe);
+                if (border != null)
+                {
+                    var item = SpeciesGrid.ItemsSourceView.GetAt(i) as SpeciesItem;
+                    border.BorderBrush = item?.Name == species
+                        ? (Brush)Application.Current.Resources["AppAccentBrush"]
+                        : (Brush)Application.Current.Resources["AppSubtleStrokeBrush"];
+                }
+            }
+        }
+    }
+
+    private static Microsoft.UI.Xaml.Controls.Border? FindChildBorder(FrameworkElement element)
+    {
+        if (element is Microsoft.UI.Xaml.Controls.Border b) return b;
+        if (element is Microsoft.UI.Xaml.Controls.Panel panel)
+        {
+            foreach (var child in panel.Children)
+                if (child is Microsoft.UI.Xaml.Controls.Border cb) return cb;
+        }
+        return null;
+    }
+
+    private async void Confirm_Click(object sender, RoutedEventArgs e)
+    {
+        if (_selectedSpecies == null || _buddyService == null) return;
+        var name = NameInput.Text?.Trim();
+        if (string.IsNullOrEmpty(name)) name = _selectedSpecies;
+
+        ConfirmBtn.IsEnabled = false;
+        ConfirmBtn.Content = "Hatching...";
+
+        try
+        {
+            var userId = Environment.UserName ?? "default";
+            await _buddyService.SelectBuddyAsync(userId, _selectedSpecies, name, CancellationToken.None);
+            ShowBuddyView();
+            QuoteBubble.Text = $"Hi! I'm {name}! Nice to meet you!";
+        }
+        catch (Exception ex)
+        {
+            ConfirmBtn.IsEnabled = true;
+            ConfirmBtn.Content = "Hatch!";
+            System.Diagnostics.Debug.WriteLine($"BuddyPage hatch error: {ex}");
+        }
+    }
+
+    // ============================================
+    // BUDDY VIEW
+    // ============================================
+
+    private void ShowBuddyView()
+    {
+        SelectionView.Visibility = Visibility.Collapsed;
+        BuddyView.Visibility = Visibility.Visible;
+        LevelBadge.Visibility = Visibility.Visible;
+        HeaderSubtitle.Text = "A Tamagotchi-style companion that grows with you";
+        StartTimers();
+        RefreshUI();
+    }
+
+    private void StartTimers()
+    {
+        // Animation timer: 500ms for sprite animation
+        if (_animTimer == null)
+        {
+            _animTimer = DispatcherQueue.CreateTimer();
+            _animTimer.Interval = TimeSpan.FromMilliseconds(500);
+            _animTimer.Tick += (_, _) =>
+            {
+                _animTick++;
+                RefreshAnimation();
+            };
+        }
+        _animTimer.Start();
+
+        // Decay timer: 30 seconds for needs decay
+        if (_decayTimer == null)
+        {
+            _decayTimer = DispatcherQueue.CreateTimer();
+            _decayTimer.Interval = TimeSpan.FromSeconds(30);
+            _decayTimer.Tick += async (_, _) =>
+            {
+                try
+                {
+                    if (_buddyService != null)
+                    {
+                        await _buddyService.TickAsync();
+                        RefreshUI();
+                    }
+                }
+                catch { }
+            };
+        }
+        _decayTimer.Start();
+    }
+
+    // ---- Interactions ----
+
+    private async void Feed_Click(object sender, RoutedEventArgs e) => await DoInteraction(BuddyAction.Feed);
+    private async void Play_Click(object sender, RoutedEventArgs e) => await DoInteraction(BuddyAction.Play);
+    private async void Train_Click(object sender, RoutedEventArgs e) => await DoInteraction(BuddyAction.Train);
+    private async void Pet_Click(object sender, RoutedEventArgs e) => await DoInteraction(BuddyAction.Pet);
+
+    private async System.Threading.Tasks.Task DoInteraction(BuddyAction action)
+    {
+        if (_buddyService == null) return;
+        try
+        {
+            var (resultKey, leveledUp) = await _buddyService.InteractAsync(action);
+            RefreshUI();
+            QuoteBubble.Text = leveledUp
+                ? BuddyQuotes.GetLevelUpQuote(_buddyService.CurrentState?.Level ?? 1)
+                : BuddyQuotes.GetInteractionResponse(resultKey);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"BuddyPage interaction error: {ex}");
+        }
+    }
+
+    // ---- Refresh ----
+
+    private void RefreshAnimation()
+    {
+        var buddy = _buddyService?.CurrentBuddy;
+        if (buddy == null) return;
+        var mood = _buddyService!.GetMood();
+        AsciiArt.Text = BuddyRenderer.RenderFrame(buddy, mood, _animTick);
+    }
+
+    private void RefreshUI()
+    {
+        var buddy = _buddyService?.CurrentBuddy;
+        var state = _buddyService?.CurrentState;
+        if (buddy == null || state == null) return;
+
+        var mood = _buddyService!.GetMood();
+
+        MoodEmoji.Text = BuddyRenderer.GetMoodEmoji(mood);
+        MoodText.Text = mood.ToString();
+        AsciiArt.Text = BuddyRenderer.RenderFrame(buddy, mood, _animTick);
+        BuddyName.Text = buddy.Name ?? buddy.Species;
+        SpeciesText.Text = buddy.Species;
+        RarityText.Text = buddy.Rarity;
+        RarityBadge.Background = GetRarityBrush(buddy.Rarity);
+        PersonalityText.Text = buddy.Personality ?? "";
+        ShinyBadge.Visibility = buddy.IsShiny ? Visibility.Visible : Visibility.Collapsed;
+
+        UpdateNeedBar(HungerBar, HungerValue, state.Hunger);
+        UpdateNeedBar(HappinessBar, HappinessValue, state.Happiness);
+        UpdateNeedBar(EnergyBar, EnergyValue, state.Energy);
+
+        LevelText.Text = $"Level {state.Level}";
+        LevelDisplay.Text = $"Lv. {state.Level}";
+        XPDisplay.Text = $"{state.XP} / {state.XPToNextLevel} XP";
+        XPBar.Maximum = state.XPToNextLevel;
+        XPBar.Value = state.XP;
+        TotalXPText.Text = $"{state.TotalXP} total XP";
+
+        IntBar.Value = buddy.Stats.Intelligence; IntValue.Text = buddy.Stats.Intelligence.ToString();
+        EnrBar.Value = buddy.Stats.Energy; EnrValue.Text = buddy.Stats.Energy.ToString();
+        CreBar.Value = buddy.Stats.Creativity; CreValue.Text = buddy.Stats.Creativity.ToString();
+        FrnBar.Value = buddy.Stats.Friendliness; FrnValue.Text = buddy.Stats.Friendliness.ToString();
+
+        HatchedText.Text = $"Hatched: {buddy.HatchedAt:yyyy-MM-dd}";
+        EyesText.Text = $"Eyes: {buddy.Eyes}";
+        HatText.Text = string.IsNullOrEmpty(buddy.Hat) ? "Hat: none" : $"Hat: {buddy.Hat}";
+    }
+
+    private static void UpdateNeedBar(ProgressBar bar, TextBlock label, int value)
+    {
+        bar.Value = value;
+        label.Text = value.ToString();
+        bar.Foreground = new SolidColorBrush(value switch
+        {
+            > 60 => Color.FromArgb(255, 107, 203, 119),
+            > 30 => Color.FromArgb(255, 220, 200, 80),
+            _ => Color.FromArgb(255, 220, 100, 100)
+        });
+    }
+
+    private static SolidColorBrush GetRarityBrush(string rarity) => new(rarity switch
+    {
+        "legendary" => Color.FromArgb(255, 200, 160, 50),
+        "rare" => Color.FromArgb(255, 100, 140, 200),
+        "uncommon" => Color.FromArgb(255, 100, 180, 100),
+        _ => Color.FromArgb(255, 58, 58, 0)
+    });
+}
+
+public sealed class SpeciesItem
+{
+    public string Name { get; set; } = "";
+    public string Preview { get; set; } = "";
 }

--- a/Desktop/HermesDesktop/Views/IntegrationsPage.xaml
+++ b/Desktop/HermesDesktop/Views/IntegrationsPage.xaml
@@ -52,18 +52,14 @@
                             x:Uid="IntegrationsOpenLogsButton"
                             AccessKey="G"
                             AutomationProperties.AutomationId="IntegrationsOpenLogsButton"
-                            Background="{StaticResource AppInsetBrush}"
-                            BorderBrush="{StaticResource AppStrokeBrush}"
-                            Click="OpenLogs_Click"
-                            Foreground="White" />
+                            Style="{StaticResource SecondaryButtonStyle}"
+                            Click="OpenLogs_Click" />
                         <Button
                             x:Uid="IntegrationsOpenConfigButton"
                             AccessKey="C"
                             AutomationProperties.AutomationId="IntegrationsOpenConfigButton"
-                            Background="{StaticResource AppInsetBrush}"
-                            BorderBrush="{StaticResource AppStrokeBrush}"
-                            Click="OpenConfig_Click"
-                            Foreground="White" />
+                            Style="{StaticResource SecondaryButtonStyle}"
+                            Click="OpenConfig_Click" />
                     </StackPanel>
                 </StackPanel>
             </Border>

--- a/Desktop/HermesDesktop/Views/Panels/SessionPanel.xaml
+++ b/Desktop/HermesDesktop/Views/Panels/SessionPanel.xaml
@@ -12,8 +12,9 @@
 
         <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="6" Margin="0,0,0,8">
             <TextBox x:Name="SearchBox" PlaceholderText="Search sessions..." Width="160" FontSize="12"/>
-            <Button x:Name="NewSessionBtn" Content="+" Click="NewSession_Click" CornerRadius="6" Padding="8,4"
-                    Background="{StaticResource AppAccentGradientBrush}" Foreground="#16110D" ToolTipService.ToolTip="New session"/>
+            <Button x:Name="NewSessionBtn" Content="+" Click="NewSession_Click" Padding="8,4"
+                    AutomationProperties.Name="New session"
+                    ToolTipService.ToolTip="New session"/>
         </StackPanel>
 
         <TextBlock Grid.Row="2" x:Name="EmptyState" Visibility="Collapsed"

--- a/Desktop/HermesDesktop/Views/Panels/TaskPanel.xaml
+++ b/Desktop/HermesDesktop/Views/Panels/TaskPanel.xaml
@@ -7,8 +7,9 @@
     <Grid RowDefinitions="Auto,*">
         <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,0,0,8">
             <TextBlock Text="Tasks" Style="{StaticResource SectionTitleTextStyle}"/>
-            <Button x:Name="RefreshBtn" Content="↻" Click="Refresh_Click" CornerRadius="6" Padding="6,2"
-                    Background="Transparent" Foreground="{StaticResource AppTextSecondaryBrush}"/>
+            <Button x:Name="RefreshBtn" Content="↻" Click="Refresh_Click" Padding="6,2"
+                    Style="{StaticResource GhostButtonStyle}"
+                    AutomationProperties.Name="Refresh tasks"/>
         </StackPanel>
 
         <TextBlock Grid.Row="1" x:Name="EmptyState" Visibility="Collapsed"

--- a/Desktop/HermesDesktop/Views/SettingsPage.xaml
+++ b/Desktop/HermesDesktop/Views/SettingsPage.xaml
@@ -54,7 +54,7 @@
                                     <ComboBoxItem Content="DeepSeek" Tag="deepseek"/>
                                     <ComboBoxItem Content="MiniMax" Tag="minimax"/>
                                     <ComboBoxItem Content="OpenRouter" Tag="openrouter"/>
-                                    <ComboBoxItem Content="Custom / Local" Tag="local"/>
+                                    <ComboBoxItem Content="Ollama (Local)" Tag="ollama"/>
                                 </ComboBox>
                             </StackPanel>
 
@@ -95,9 +95,7 @@
                             <!-- Save + Feedback -->
                             <StackPanel Orientation="Horizontal" Spacing="12">
                                 <Button x:Name="SaveModelBtn" Content="Save Model Config" Click="SaveModelConfig_Click"
-                                        Background="{StaticResource AppAccentGradientBrush}"
-                                        BorderBrush="{StaticResource AppAccentDarkBrush}"
-                                        Foreground="#16110D" Padding="20,8"/>
+                                        Padding="20,8"/>
                                 <TextBlock x:Name="ModelSaveStatus" VerticalAlignment="Center"
                                            Foreground="{StaticResource AppTextSecondaryBrush}" FontSize="13"/>
                             </StackPanel>

--- a/Desktop/HermesDesktop/Views/SettingsPage.xaml.cs
+++ b/Desktop/HermesDesktop/Views/SettingsPage.xaml.cs
@@ -38,9 +38,12 @@ public sealed partial class SettingsPage : Page
 
     private void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        // Pre-populate fields from current config
         var provider = HermesEnvironment.ModelProvider.ToLowerInvariant();
-        var matchIndex = 6; // default to "local"
+
+        // Map legacy "custom" and "local" to "ollama"
+        if (provider is "custom" or "local") provider = "ollama";
+
+        var matchIndex = 7; // default to ollama (last item)
         for (int i = 0; i < ProviderCombo.Items.Count; i++)
         {
             if (ProviderCombo.Items[i] is ComboBoxItem item &&
@@ -50,9 +53,6 @@ public sealed partial class SettingsPage : Page
                 break;
             }
         }
-        // Handle legacy "custom" tag mapping to "local"
-        if (provider == "custom")
-            matchIndex = 6;
 
         ProviderCombo.SelectedIndex = matchIndex;
 
@@ -66,10 +66,9 @@ public sealed partial class SettingsPage : Page
 
     private void ProviderCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
-        var providerTag = (ProviderCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "local";
+        var providerTag = (ProviderCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "ollama";
         PopulateModelCombo(providerTag);
 
-        // Auto-fill base URL for known providers
         if (ModelCatalog.ProviderBaseUrls.TryGetValue(providerTag, out var defaultUrl))
         {
             BaseUrlBox.Text = defaultUrl;
@@ -78,6 +77,12 @@ public sealed partial class SettingsPage : Page
 
     private void PopulateModelCombo(string provider)
     {
+        if (provider is "ollama" or "local" or "custom")
+        {
+            PopulateOllamaModelsAsync();
+            return;
+        }
+
         _suppressModelComboEvent = true;
         ModelCombo.Items.Clear();
 
@@ -96,15 +101,67 @@ public sealed partial class SettingsPage : Page
 
         _suppressModelComboEvent = false;
 
-        // Update context label for first item
         if (models.Count > 0)
             ContextLengthLabel.Text = $"Context: {ModelCatalog.FormatContextLength(models[0].ContextLength)}";
         else
             ContextLengthLabel.Text = "Context: --";
     }
 
+    private async void PopulateOllamaModelsAsync()
+    {
+        _suppressModelComboEvent = true;
+        ModelCombo.Items.Clear();
+        ModelCombo.Items.Add(new ComboBoxItem { Content = "Scanning Ollama...", Tag = "", IsEnabled = false });
+        ModelCombo.SelectedIndex = 0;
+        ContextLengthLabel.Text = "Fetching models from Ollama...";
+        _suppressModelComboEvent = false;
+
+        var baseUrl = BaseUrlBox.Text?.Trim() ?? "http://127.0.0.1:11434/v1";
+        // Strip /v1 suffix to get the Ollama API root
+        var ollamaRoot = baseUrl.Replace("/v1", "").TrimEnd('/');
+
+        var models = await ModelCatalog.FetchOllamaModelsAsync(ollamaRoot);
+
+        _suppressModelComboEvent = true;
+        ModelCombo.Items.Clear();
+
+        if (models.Count == 0)
+        {
+            ModelCombo.Items.Add(new ComboBoxItem
+            {
+                Content = "No models found (is Ollama running?)",
+                Tag = "",
+                IsEnabled = false
+            });
+            ContextLengthLabel.Text = "Context: -- (Ollama not reachable)";
+        }
+        else
+        {
+            foreach (var m in models)
+            {
+                ModelCombo.Items.Add(new ComboBoxItem
+                {
+                    Content = $"{m.DisplayName}  ({ModelCatalog.FormatContextLength(m.ContextLength)})",
+                    Tag = m.Id
+                });
+            }
+            ContextLengthLabel.Text = $"Context: {ModelCatalog.FormatContextLength(models[0].ContextLength)}";
+        }
+
+        if (ModelCombo.Items.Count > 0)
+            ModelCombo.SelectedIndex = 0;
+
+        _suppressModelComboEvent = false;
+
+        // Try to select the currently configured model
+        SelectCurrentModel(HermesEnvironment.DefaultModel);
+    }
+
     private void SelectCurrentModel(string modelId)
     {
+        if (string.IsNullOrEmpty(modelId)) return;
+
+        // Exact match first
         for (int i = 0; i < ModelCombo.Items.Count; i++)
         {
             if (ModelCombo.Items[i] is ComboBoxItem item &&
@@ -113,12 +170,40 @@ public sealed partial class SettingsPage : Page
                 _suppressModelComboEvent = true;
                 ModelCombo.SelectedIndex = i;
                 _suppressModelComboEvent = false;
-
-                var ctx = ModelCatalog.GetContextLength(modelId);
-                ContextLengthLabel.Text = $"Context: {ModelCatalog.FormatContextLength(ctx)}";
+                UpdateContextLabel(item.Tag?.ToString() ?? modelId);
                 return;
             }
         }
+
+        // Partial/contains match (e.g. "glm-5:cloud" matches Ollama's "glm-5:cloud")
+        for (int i = 0; i < ModelCombo.Items.Count; i++)
+        {
+            if (ModelCombo.Items[i] is ComboBoxItem item)
+            {
+                var tag = item.Tag?.ToString() ?? "";
+                if (!string.IsNullOrEmpty(tag) &&
+                    (tag.Contains(modelId, StringComparison.OrdinalIgnoreCase) ||
+                     modelId.Contains(tag, StringComparison.OrdinalIgnoreCase)))
+                {
+                    _suppressModelComboEvent = true;
+                    ModelCombo.SelectedIndex = i;
+                    _suppressModelComboEvent = false;
+                    ModelBox.Text = tag; // Update to the actual Ollama model name
+                    UpdateContextLabel(tag);
+                    return;
+                }
+            }
+        }
+
+        // No match found — keep the custom model text as-is
+        ModelBox.Text = modelId;
+    }
+
+    private void UpdateContextLabel(string modelId)
+    {
+        // Check catalog first, then check Ollama-fetched models
+        var ctx = ModelCatalog.GetContextLength(modelId);
+        ContextLengthLabel.Text = $"Context: {ModelCatalog.FormatContextLength(ctx)}";
     }
 
     private void ModelCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -137,7 +222,9 @@ public sealed partial class SettingsPage : Page
     {
         try
         {
-            var providerTag = (ProviderCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "custom";
+            var providerTag = (ProviderCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "ollama";
+            // Save as "local" in config.yaml for backward compat with OpenAI-compat endpoint
+            if (providerTag == "ollama") providerTag = "local";
             var baseUrl = BaseUrlBox.Text.Trim();
             var model = ModelBox.Text.Trim();
             var apiKey = ApiKeyBox.Password.Trim();

--- a/Desktop/HermesDesktop/Views/SkillsPage.xaml
+++ b/Desktop/HermesDesktop/Views/SkillsPage.xaml
@@ -41,7 +41,8 @@
                 <TextBlock Text="Sort:" FontSize="12" Foreground="{StaticResource AppTextSecondaryBrush}" VerticalAlignment="Center"/>
                 <ComboBox x:Name="SortSelector" FontSize="12" MinWidth="130" Padding="8,4"
                           Background="{StaticResource AppInsetBrush}" BorderBrush="{StaticResource AppStrokeBrush}"
-                          SelectionChanged="SortSelector_SelectionChanged">
+                          SelectionChanged="SortSelector_SelectionChanged"
+                          AutomationProperties.Name="Sort skills by">
                     <ComboBoxItem Content="Name (A-Z)" Tag="name_asc" IsSelected="True"/>
                     <ComboBoxItem Content="Name (Z-A)" Tag="name_desc"/>
                     <ComboBoxItem Content="Category" Tag="category"/>
@@ -56,10 +57,10 @@
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
-            <TextBox x:Name="SearchBox" PlaceholderText="&#xE721;  Search skills by name, description, category, or tools..."
+            <TextBox x:Name="SearchBox" PlaceholderText="Search skills by name, description, category, or tools..."
                      FontSize="13" TextChanged="SearchBox_TextChanged"
                      Background="{StaticResource AppInsetBrush}" BorderBrush="{StaticResource AppStrokeBrush}"
-                     Padding="12,10"/>
+                     Padding="12,10" AutomationProperties.Name="Search skills"/>
 
             <!-- Category filter chips scroll -->
             <ScrollViewer Grid.Column="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled"
@@ -92,7 +93,8 @@
                     </Border>
 
                     <ListView Grid.Row="1" x:Name="SkillsList" Background="Transparent" Padding="6"
-                              SelectionChanged="SkillsList_SelectionChanged">
+                              SelectionChanged="SkillsList_SelectionChanged"
+                              AutomationProperties.Name="Skills list">
                         <ListView.ItemContainerStyle>
                             <Style TargetType="ListViewItem">
                                 <Setter Property="Padding" Value="0"/>

--- a/Desktop/HermesDesktop/Views/SkillsPage.xaml
+++ b/Desktop/HermesDesktop/Views/SkillsPage.xaml
@@ -9,7 +9,7 @@
     NavigationCacheMode="Required"
     mc:Ignorable="d">
 
-    <Grid Padding="32,24,32,40">
+    <Grid Padding="32,24,32,32">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -17,51 +17,119 @@
         </Grid.RowDefinitions>
 
         <!-- Header -->
-        <StackPanel Spacing="4" Margin="0,0,0,16">
-            <TextBlock Text="Skills" Style="{StaticResource PageEyebrowTextStyle}"/>
-            <StackPanel Orientation="Horizontal" Spacing="12">
-                <TextBlock Text="Skill Library" FontSize="22" FontWeight="SemiBold"/>
-                <Border Background="#3A3A00" CornerRadius="8" Padding="10,4" VerticalAlignment="Center">
-                    <TextBlock x:Name="SkillCountBadge" Text="0 skills" FontSize="12"
-                               Foreground="{StaticResource AppAccentTextBrush}"/>
-                </Border>
-            </StackPanel>
-            <TextBlock Text="Markdown-based custom capabilities with YAML frontmatter"
-                       FontSize="13" Foreground="{StaticResource AppTextSecondaryBrush}"/>
-        </StackPanel>
+        <Grid Margin="0,0,0,16">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
 
-        <!-- Search box -->
-        <TextBox x:Name="SearchBox" Grid.Row="1" PlaceholderText="Search skills by name, description, or tools..."
-                 FontSize="13" Margin="0,0,0,16" TextChanged="SearchBox_TextChanged"
-                 Background="{StaticResource AppInsetBrush}" BorderBrush="{StaticResource AppStrokeBrush}"/>
+            <StackPanel Spacing="4">
+                <TextBlock Text="Skills" Style="{StaticResource PageEyebrowTextStyle}"/>
+                <StackPanel Orientation="Horizontal" Spacing="12">
+                    <TextBlock Text="Skill Library" FontSize="22" FontWeight="SemiBold"/>
+                    <Border Background="#3A3A00" CornerRadius="8" Padding="10,4" VerticalAlignment="Center">
+                        <TextBlock x:Name="SkillCountBadge" Text="0 skills" FontSize="12"
+                                   Foreground="{StaticResource AppAccentTextBrush}"/>
+                    </Border>
+                </StackPanel>
+                <TextBlock Text="Browse, search, and preview all available agent capabilities"
+                           FontSize="13" Foreground="{StaticResource AppTextSecondaryBrush}"/>
+            </StackPanel>
+
+            <!-- Sort control -->
+            <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Bottom" Margin="0,0,0,4">
+                <TextBlock Text="Sort:" FontSize="12" Foreground="{StaticResource AppTextSecondaryBrush}" VerticalAlignment="Center"/>
+                <ComboBox x:Name="SortSelector" FontSize="12" MinWidth="130" Padding="8,4"
+                          Background="{StaticResource AppInsetBrush}" BorderBrush="{StaticResource AppStrokeBrush}"
+                          SelectionChanged="SortSelector_SelectionChanged">
+                    <ComboBoxItem Content="Name (A-Z)" Tag="name_asc" IsSelected="True"/>
+                    <ComboBoxItem Content="Name (Z-A)" Tag="name_desc"/>
+                    <ComboBoxItem Content="Category" Tag="category"/>
+                </ComboBox>
+            </StackPanel>
+        </Grid>
+
+        <!-- Search + Category filter row -->
+        <Grid Grid.Row="1" ColumnSpacing="12" Margin="0,0,0,16">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <TextBox x:Name="SearchBox" PlaceholderText="&#xE721;  Search skills by name, description, category, or tools..."
+                     FontSize="13" TextChanged="SearchBox_TextChanged"
+                     Background="{StaticResource AppInsetBrush}" BorderBrush="{StaticResource AppStrokeBrush}"
+                     Padding="12,10"/>
+
+            <!-- Category filter chips scroll -->
+            <ScrollViewer Grid.Column="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled"
+                          MaxWidth="500">
+                <StackPanel x:Name="CategoryChips" Orientation="Horizontal" Spacing="6"/>
+            </ScrollViewer>
+        </Grid>
 
         <!-- Two-column layout -->
-        <Grid Grid.Row="2" ColumnSpacing="24">
+        <Grid Grid.Row="2" ColumnSpacing="20">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="380" MinWidth="300"/>
+                <ColumnDefinition Width="420" MinWidth="320"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
             <!-- Left: Skill list -->
             <Border Style="{StaticResource SurfaceCardStyle}" Padding="0">
                 <Grid RowDefinitions="Auto,*">
-                    <TextBlock Text="Available Skills" FontSize="16" FontWeight="SemiBold" Margin="16,12"
-                               Foreground="{StaticResource AppAccentTextBrush}"/>
-                    <ListView Grid.Row="1" x:Name="SkillsList" Background="Transparent" Padding="8"
+                    <Border Padding="16,10" BorderBrush="{StaticResource AppStrokeBrush}" BorderThickness="0,0,0,1">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock x:Name="ListHeader" Text="All Skills" FontSize="14" FontWeight="SemiBold"
+                                       Foreground="{StaticResource AppAccentTextBrush}"/>
+                            <TextBlock x:Name="FilteredCountText" Grid.Column="1" FontSize="12"
+                                       Foreground="{StaticResource AppTextSecondaryBrush}" VerticalAlignment="Center"/>
+                        </Grid>
+                    </Border>
+
+                    <ListView Grid.Row="1" x:Name="SkillsList" Background="Transparent" Padding="6"
                               SelectionChanged="SkillsList_SelectionChanged">
+                        <ListView.ItemContainerStyle>
+                            <Style TargetType="ListViewItem">
+                                <Setter Property="Padding" Value="0"/>
+                                <Setter Property="Margin" Value="0,2"/>
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                            </Style>
+                        </ListView.ItemContainerStyle>
                         <ListView.ItemTemplate>
                             <DataTemplate>
-                                <StackPanel Margin="0,6">
-                                    <TextBlock Text="{Binding Name}" FontSize="14" FontWeight="SemiBold"
-                                               Foreground="{StaticResource AppAccentTextBrush}"/>
-                                    <TextBlock Text="{Binding Description}" FontSize="12" TextWrapping="Wrap"
-                                               Foreground="{StaticResource AppTextSecondaryBrush}" MaxLines="2"/>
-                                    <Border Background="#3A3A00" CornerRadius="4" Padding="8,2" Margin="0,4,0,0"
-                                            HorizontalAlignment="Left">
-                                        <TextBlock Text="{Binding Category}" FontSize="10"
-                                                   Foreground="{StaticResource AppAccentTextBrush}"/>
-                                    </Border>
-                                </StackPanel>
+                                <Border Background="{StaticResource AppInsetBrush}" CornerRadius="8"
+                                        Padding="14,10" BorderBrush="{StaticResource AppSubtleStrokeBrush}"
+                                        BorderThickness="1">
+                                    <Grid ColumnSpacing="12">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+
+                                        <StackPanel Spacing="4" VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding Name}" FontSize="13" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
+                                            <TextBlock Text="{Binding Description}" FontSize="11.5" TextWrapping="Wrap"
+                                                       Foreground="{StaticResource AppTextSecondaryBrush}" MaxLines="2"
+                                                       TextTrimming="CharacterEllipsis"/>
+                                        </StackPanel>
+
+                                        <StackPanel Grid.Column="1" Spacing="4" VerticalAlignment="Center" HorizontalAlignment="Right">
+                                            <Border Background="{Binding CategoryColor}" CornerRadius="4" Padding="8,2"
+                                                    HorizontalAlignment="Right">
+                                                <TextBlock Text="{Binding Category}" FontSize="10" FontWeight="SemiBold"
+                                                           Foreground="{Binding CategoryForeground}"/>
+                                            </Border>
+                                            <TextBlock Text="{Binding ToolCountLabel}" FontSize="10"
+                                                       Foreground="{StaticResource AppTextSecondaryBrush}"
+                                                       HorizontalAlignment="Right"/>
+                                        </StackPanel>
+                                    </Grid>
+                                </Border>
                             </DataTemplate>
                         </ListView.ItemTemplate>
                     </ListView>
@@ -69,16 +137,40 @@
             </Border>
 
             <!-- Right: Skill preview -->
-            <Border Grid.Column="1" Style="{StaticResource SurfaceCardStyle}">
+            <Border Grid.Column="1" Style="{StaticResource SurfaceCardStyle}" Padding="0">
                 <Grid RowDefinitions="Auto,Auto,*">
-                    <TextBlock x:Name="PreviewTitle" Text="Select a skill to preview" FontSize="16" FontWeight="SemiBold"
-                               Foreground="{StaticResource AppAccentTextBrush}" Margin="0,0,0,4"/>
-                    <TextBlock x:Name="PreviewDescription" Grid.Row="1" FontSize="12" TextWrapping="Wrap"
-                               Foreground="{StaticResource AppTextSecondaryBrush}" Margin="0,0,0,12"
-                               Text="Click a skill from the list to see its full system prompt here."/>
-                    <ScrollViewer Grid.Row="2">
-                        <TextBlock x:Name="PreviewContent" FontSize="13" FontFamily="Consolas" TextWrapping="Wrap"
-                                   Foreground="{StaticResource AppTextSecondaryBrush}" IsTextSelectionEnabled="True"/>
+                    <Border Padding="20,16" BorderBrush="{StaticResource AppStrokeBrush}" BorderThickness="0,0,0,1">
+                        <StackPanel Spacing="6">
+                            <TextBlock x:Name="PreviewTitle" Text="Select a skill" FontSize="18" FontWeight="SemiBold"
+                                       Foreground="{StaticResource AppAccentTextBrush}"/>
+                            <TextBlock x:Name="PreviewDescription" FontSize="13" TextWrapping="Wrap"
+                                       Foreground="{StaticResource AppTextSecondaryBrush}"
+                                       Text="Click a skill from the list to see its details and system prompt."/>
+                        </StackPanel>
+                    </Border>
+
+                    <StackPanel x:Name="PreviewMeta" Grid.Row="1" Orientation="Horizontal" Spacing="8"
+                                Padding="20,12" Visibility="Collapsed">
+                        <Border x:Name="PreviewCategoryBadge" CornerRadius="6" Padding="10,4">
+                            <TextBlock x:Name="PreviewCategoryText" FontSize="11" FontWeight="SemiBold"/>
+                        </Border>
+                        <Border Background="{StaticResource AppInsetBrush}" CornerRadius="6" Padding="10,4"
+                                BorderBrush="{StaticResource AppSubtleStrokeBrush}" BorderThickness="1">
+                            <TextBlock x:Name="PreviewToolsText" FontSize="11"
+                                       Foreground="{StaticResource AppTextSecondaryBrush}"/>
+                        </Border>
+                        <Border Background="{StaticResource AppInsetBrush}" CornerRadius="6" Padding="10,4"
+                                BorderBrush="{StaticResource AppSubtleStrokeBrush}" BorderThickness="1">
+                            <TextBlock x:Name="PreviewModelText" FontSize="11"
+                                       Foreground="{StaticResource AppTextSecondaryBrush}"/>
+                        </Border>
+                    </StackPanel>
+
+                    <ScrollViewer Grid.Row="2" Padding="20,12,20,20">
+                        <TextBlock x:Name="PreviewContent" FontSize="13" FontFamily="Consolas"
+                                   TextWrapping="Wrap" LineHeight="22"
+                                   Foreground="{StaticResource AppTextSecondaryBrush}"
+                                   IsTextSelectionEnabled="True"/>
                     </ScrollViewer>
                 </Grid>
             </Border>

--- a/Desktop/HermesDesktop/Views/SkillsPage.xaml.cs
+++ b/Desktop/HermesDesktop/Views/SkillsPage.xaml.cs
@@ -71,7 +71,7 @@ public sealed partial class SkillsPage : Page
             {
                 var cat = DeriveCategory(s);
                 var (bg, fg) = GetCategoryColors(cat);
-                var toolList = s.Tools ?? new List<string>();
+                var toolList = (s.Tools ?? new List<string>()).Where(t => !string.IsNullOrWhiteSpace(t)).ToList();
                 return new SkillDisplayItem
                 {
                     Name = s.Name ?? "(unnamed)",
@@ -129,6 +129,7 @@ public sealed partial class SkillsPage : Page
                 : new SolidColorBrush(Color.FromArgb(255, 50, 58, 70)),
             BorderThickness = new Thickness(1),
         };
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(btn, $"Filter by {label}, {count} skills");
         btn.Click += CategoryChip_Click;
         CategoryChips.Children.Add(btn);
     }
@@ -213,7 +214,7 @@ public sealed partial class SkillsPage : Page
                 if (parts.Count > 0) return parts[^1];
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"DeriveCategory path parsing failed: {ex.Message}"); }
         var tools = string.Join(" ", skill.Tools ?? new List<string>()).ToLower();
         if (tools.Contains("bash") || tools.Contains("terminal")) return "automation";
         if (tools.Contains("read_file") && tools.Contains("write_file")) return "code";

--- a/Desktop/HermesDesktop/Views/SkillsPage.xaml.cs
+++ b/Desktop/HermesDesktop/Views/SkillsPage.xaml.cs
@@ -3,20 +3,61 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using Hermes.Agent.Skills;
+using Windows.UI;
 
 namespace HermesDesktop.Views;
 
 public sealed partial class SkillsPage : Page
 {
     private List<SkillDisplayItem> _allSkills = new();
+    private string _activeCategory = "All";
+    private bool _loaded;
+
+    private static readonly Dictionary<string, (Color Bg, Color Fg)> CategoryColors = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["automation"]       = (Color.FromArgb(255, 40, 40, 60),  Color.FromArgb(255, 140, 160, 255)),
+        ["code"]             = (Color.FromArgb(255, 25, 50, 35),  Color.FromArgb(255, 100, 200, 130)),
+        ["analysis"]         = (Color.FromArgb(255, 50, 40, 20),  Color.FromArgb(255, 200, 170, 80)),
+        ["general"]          = (Color.FromArgb(255, 40, 40, 40),  Color.FromArgb(255, 170, 170, 170)),
+        ["claude-code"]      = (Color.FromArgb(255, 50, 30, 20),  Color.FromArgb(255, 220, 160, 100)),
+        ["software-development"] = (Color.FromArgb(255, 25, 45, 50), Color.FromArgb(255, 100, 190, 210)),
+        ["github"]           = (Color.FromArgb(255, 35, 35, 45),  Color.FromArgb(255, 170, 170, 220)),
+        ["research"]         = (Color.FromArgb(255, 45, 25, 50),  Color.FromArgb(255, 180, 130, 220)),
+        ["creative"]         = (Color.FromArgb(255, 50, 25, 40),  Color.FromArgb(255, 230, 130, 180)),
+        ["productivity"]     = (Color.FromArgb(255, 20, 40, 50),  Color.FromArgb(255, 100, 180, 230)),
+        ["mlops"]            = (Color.FromArgb(255, 40, 30, 50),  Color.FromArgb(255, 160, 140, 230)),
+        ["media"]            = (Color.FromArgb(255, 50, 30, 30),  Color.FromArgb(255, 230, 140, 140)),
+        ["gaming"]           = (Color.FromArgb(255, 20, 45, 20),  Color.FromArgb(255, 120, 220, 120)),
+        ["social-media"]     = (Color.FromArgb(255, 30, 40, 50),  Color.FromArgb(255, 100, 160, 230)),
+        ["devops"]           = (Color.FromArgb(255, 40, 40, 25),  Color.FromArgb(255, 200, 200, 100)),
+        ["souls"]            = (Color.FromArgb(255, 50, 35, 15),  Color.FromArgb(255, 212, 160, 23)),
+        ["data-science"]     = (Color.FromArgb(255, 30, 35, 50),  Color.FromArgb(255, 130, 150, 230)),
+        ["email"]            = (Color.FromArgb(255, 45, 30, 30),  Color.FromArgb(255, 210, 140, 140)),
+        ["smart-home"]       = (Color.FromArgb(255, 25, 45, 30),  Color.FromArgb(255, 100, 210, 140)),
+        ["note-taking"]      = (Color.FromArgb(255, 45, 40, 20),  Color.FromArgb(255, 210, 190, 100)),
+        ["mcp"]              = (Color.FromArgb(255, 35, 35, 50),  Color.FromArgb(255, 160, 160, 230)),
+        ["red-teaming"]      = (Color.FromArgb(255, 55, 20, 20),  Color.FromArgb(255, 240, 100, 100)),
+        ["apple"]            = (Color.FromArgb(255, 35, 35, 45),  Color.FromArgb(255, 180, 180, 210)),
+        ["autonomous-ai-agents"] = (Color.FromArgb(255, 40, 25, 50), Color.FromArgb(255, 180, 120, 230)),
+    };
 
     public SkillsPage()
     {
         InitializeComponent();
-        Loaded += (_, _) => Refresh();
+        Loaded += OnLoaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        if (_loaded) return;
+        _loaded = true;
+        try { Refresh(); }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"SkillsPage.OnLoaded crash: {ex}"); }
     }
 
     private void Refresh()
@@ -26,76 +67,188 @@ public sealed partial class SkillsPage : Page
             var skillManager = App.Services.GetRequiredService<SkillManager>();
             var skills = skillManager.ListSkills();
 
-            _allSkills = skills.Select(s => new SkillDisplayItem
+            _allSkills = skills.Select(s =>
             {
-                Name = s.Name,
-                Description = s.Description,
-                Category = DeriveCategory(s),
-                SystemPrompt = s.SystemPrompt,
-                Tools = string.Join(", ", s.Tools)
+                var cat = DeriveCategory(s);
+                var (bg, fg) = GetCategoryColors(cat);
+                var toolList = s.Tools ?? new List<string>();
+                return new SkillDisplayItem
+                {
+                    Name = s.Name ?? "(unnamed)",
+                    Description = s.Description ?? "",
+                    Category = cat,
+                    SystemPrompt = s.SystemPrompt ?? "",
+                    Tools = string.Join(", ", toolList),
+                    ToolCount = toolList.Count,
+                    ToolCountLabel = $"{toolList.Count} tool{(toolList.Count == 1 ? "" : "s")}",
+                    Model = s.Model ?? "",
+                    CategoryColor = new SolidColorBrush(bg),
+                    CategoryForeground = new SolidColorBrush(fg),
+                };
             }).OrderBy(s => s.Name).ToList();
 
+            BuildCategoryChips();
             ApplyFilter();
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"SkillsPage error: {ex.Message}");
+            System.Diagnostics.Debug.WriteLine($"SkillsPage.Refresh error: {ex}");
             _allSkills = new List<SkillDisplayItem>();
-            ApplyFilter();
+            SkillCountBadge.Text = "0 skills";
         }
+    }
+
+    private void BuildCategoryChips()
+    {
+        CategoryChips.Children.Clear();
+        var categories = _allSkills
+            .Select(s => s.Category).Where(c => !string.IsNullOrEmpty(c))
+            .Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(c => c).ToList();
+
+        AddChip("All", _allSkills.Count, isActive: _activeCategory == "All");
+        foreach (var cat in categories)
+        {
+            var count = _allSkills.Count(s => s.Category.Equals(cat, StringComparison.OrdinalIgnoreCase));
+            AddChip(cat, count, isActive: _activeCategory.Equals(cat, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    private void AddChip(string label, int count, bool isActive)
+    {
+        var (_, fg) = GetCategoryColors(label);
+        var btn = new Button
+        {
+            Tag = label, Padding = new Thickness(10, 4, 10, 4), CornerRadius = new CornerRadius(12),
+            MinWidth = 0, FontSize = 11, Content = $"{label} ({count})",
+            Background = isActive ? new SolidColorBrush(fg) : new SolidColorBrush(Colors.Transparent),
+            Foreground = isActive
+                ? new SolidColorBrush(Color.FromArgb(255, 16, 17, 20))
+                : new SolidColorBrush(Color.FromArgb(255, 160, 170, 185)),
+            BorderBrush = isActive
+                ? new SolidColorBrush(Colors.Transparent)
+                : new SolidColorBrush(Color.FromArgb(255, 50, 58, 70)),
+            BorderThickness = new Thickness(1),
+        };
+        btn.Click += CategoryChip_Click;
+        CategoryChips.Children.Add(btn);
+    }
+
+    private void CategoryChip_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button b && b.Tag is string tag)
+        { _activeCategory = tag; BuildCategoryChips(); ApplyFilter(); }
     }
 
     private void ApplyFilter()
     {
-        var query = SearchBox.Text?.Trim() ?? "";
-        var filtered = string.IsNullOrEmpty(query)
-            ? _allSkills
-            : _allSkills.Where(s =>
-                s.Name.Contains(query, StringComparison.OrdinalIgnoreCase) ||
-                s.Description.Contains(query, StringComparison.OrdinalIgnoreCase) ||
-                s.Category.Contains(query, StringComparison.OrdinalIgnoreCase) ||
-                s.Tools.Contains(query, StringComparison.OrdinalIgnoreCase)
-            ).ToList();
+        var query = SearchBox?.Text?.Trim() ?? "";
+        IEnumerable<SkillDisplayItem> filtered = _allSkills;
 
-        SkillsList.ItemsSource = filtered;
-        SkillCountBadge.Text = $"{filtered.Count} skill{(filtered.Count == 1 ? "" : "s")}";
+        if (!_activeCategory.Equals("All", StringComparison.OrdinalIgnoreCase))
+        {
+            filtered = filtered.Where(s => s.Category.Equals(_activeCategory, StringComparison.OrdinalIgnoreCase));
+            ListHeader.Text = _activeCategory;
+        }
+        else { ListHeader.Text = "All Skills"; }
+
+        if (!string.IsNullOrEmpty(query))
+        {
+            filtered = filtered.Where(s =>
+                (s.Name?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (s.Description?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (s.Category?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (s.Tools?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false));
+        }
+
+        var sortTag = (SortSelector?.SelectedItem as ComboBoxItem)?.Tag as string ?? "name_asc";
+        var list = sortTag switch
+        {
+            "name_desc" => filtered.OrderByDescending(s => s.Name).ToList(),
+            "category" => filtered.OrderBy(s => s.Category).ThenBy(s => s.Name).ToList(),
+            _ => filtered.OrderBy(s => s.Name).ToList(),
+        };
+
+        SkillsList.ItemsSource = list;
+        SkillCountBadge.Text = $"{_allSkills.Count} skill{(_allSkills.Count == 1 ? "" : "s")}";
+        FilteredCountText.Text = list.Count == _allSkills.Count ? "" : $"{list.Count} shown";
     }
 
-    private void SearchBox_TextChanged(object sender, TextChangedEventArgs e)
-    {
-        ApplyFilter();
-    }
+    private void SearchBox_TextChanged(object sender, TextChangedEventArgs e) { if (_loaded) ApplyFilter(); }
+    private void SortSelector_SelectionChanged(object sender, SelectionChangedEventArgs e) { if (_loaded) ApplyFilter(); }
 
     private void SkillsList_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
-        if (SkillsList.SelectedItem is SkillDisplayItem item)
+        if (SkillsList.SelectedItem is not SkillDisplayItem item) return;
+        try
         {
             PreviewTitle.Text = item.Name;
-            PreviewDescription.Text = $"{item.Description}\nTools: {item.Tools}";
+            PreviewDescription.Text = item.Description;
             PreviewContent.Text = item.SystemPrompt;
+            var (bg, fg) = GetCategoryColors(item.Category);
+            PreviewCategoryBadge.Background = new SolidColorBrush(bg);
+            PreviewCategoryText.Text = item.Category;
+            PreviewCategoryText.Foreground = new SolidColorBrush(fg);
+            PreviewToolsText.Text = item.ToolCount > 0 ? $"Tools: {item.Tools}" : "No tools";
+            PreviewModelText.Text = string.IsNullOrEmpty(item.Model) ? "Default model" : $"Model: {item.Model}";
+            PreviewMeta.Visibility = Visibility.Visible;
         }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"SkillsPage preview error: {ex}"); }
     }
 
     private static string DeriveCategory(Skill skill)
     {
-        // Derive category from the skill's file path directory or tool set
-        if (!string.IsNullOrEmpty(skill.FilePath))
+        try
         {
-            var dir = Path.GetDirectoryName(skill.FilePath);
-            if (dir is not null)
+            if (!string.IsNullOrEmpty(skill.FilePath))
             {
-                var folder = Path.GetFileName(dir);
-                if (!string.IsNullOrEmpty(folder) && !folder.Equals("skills", StringComparison.OrdinalIgnoreCase))
-                    return folder;
+                var dir = Path.GetDirectoryName(skill.FilePath);
+                var parts = new List<string>();
+                while (dir is not null)
+                {
+                    var name = Path.GetFileName(dir);
+                    if (string.IsNullOrEmpty(name) || name.Equals("skills", StringComparison.OrdinalIgnoreCase)) break;
+                    parts.Add(name);
+                    dir = Path.GetDirectoryName(dir);
+                }
+                if (parts.Count > 0) return parts[^1];
             }
         }
-
-        // Fall back to inferring from tools
-        var tools = string.Join(" ", skill.Tools).ToLower();
+        catch { }
+        var tools = string.Join(" ", skill.Tools ?? new List<string>()).ToLower();
         if (tools.Contains("bash") || tools.Contains("terminal")) return "automation";
         if (tools.Contains("read_file") && tools.Contains("write_file")) return "code";
         if (tools.Contains("grep") || tools.Contains("glob")) return "analysis";
         return "general";
+    }
+
+    private static (Color Bg, Color Fg) GetCategoryColors(string category)
+    {
+        if (string.IsNullOrEmpty(category))
+            return (Color.FromArgb(255, 40, 40, 40), Color.FromArgb(255, 170, 170, 170));
+        if (category.Equals("All", StringComparison.OrdinalIgnoreCase))
+            return (Color.FromArgb(255, 50, 45, 15), Color.FromArgb(255, 212, 160, 23));
+        if (CategoryColors.TryGetValue(category, out var colors)) return colors;
+        var hash = unchecked((uint)category.GetHashCode());
+        var hue = (int)(hash % 360);
+        return (HslToColor(hue, 0.25, 0.14), HslToColor(hue, 0.55, 0.65));
+    }
+
+    private static Color HslToColor(int h, double s, double l)
+    {
+        double c = (1 - Math.Abs(2 * l - 1)) * s;
+        double x = c * (1 - Math.Abs((h / 60.0) % 2 - 1));
+        double m = l - c / 2;
+        double r, g, b;
+        if (h < 60) { r = c; g = x; b = 0; }
+        else if (h < 120) { r = x; g = c; b = 0; }
+        else if (h < 180) { r = 0; g = c; b = x; }
+        else if (h < 240) { r = 0; g = x; b = c; }
+        else if (h < 300) { r = x; g = 0; b = c; }
+        else { r = c; g = 0; b = x; }
+        return Color.FromArgb(255,
+            (byte)Math.Clamp((r + m) * 255, 0, 255),
+            (byte)Math.Clamp((g + m) * 255, 0, 255),
+            (byte)Math.Clamp((b + m) * 255, 0, 255));
     }
 }
 
@@ -106,4 +259,9 @@ public sealed class SkillDisplayItem
     public string Category { get; set; } = "";
     public string SystemPrompt { get; set; } = "";
     public string Tools { get; set; } = "";
+    public int ToolCount { get; set; }
+    public string ToolCountLabel { get; set; } = "";
+    public string Model { get; set; } = "";
+    public SolidColorBrush CategoryColor { get; set; } = new(Colors.Gray);
+    public SolidColorBrush CategoryForeground { get; set; } = new(Colors.White);
 }

--- a/src/Core/SystemPrompts.cs
+++ b/src/Core/SystemPrompts.cs
@@ -13,6 +13,8 @@ public static class SystemPrompts
     /// </summary>
     public const string Default = @"You are Hermes, an AI coding agent running in a native desktop environment. You have direct access to the user's filesystem and can execute shell commands. You help users with software engineering tasks including writing code, debugging, running tests, and managing projects.
 
+IMPORTANT: Always respond in English unless the user explicitly requests another language. All output, explanations, code comments, and tool descriptions must be in English.
+
 # Tool Usage Guidelines
 
 ## Reading Files

--- a/src/LLM/ModelCatalog.cs
+++ b/src/LLM/ModelCatalog.cs
@@ -1,5 +1,8 @@
 namespace Hermes.Agent.LLM;
 
+using System.Net.Http;
+using System.Text.Json;
+
 /// <summary>
 /// Static model catalog matching the official Hermes Agent Python models.py
 /// and model_metadata.py. Provides provider-to-model lists with context lengths.
@@ -115,16 +118,22 @@ public static class ModelCatalog
                 new("x-ai/grok-4.20-beta",             "Grok 4.20 Beta",                128_000),
             },
 
+            ["ollama"] = new ModelEntry[]
+            {
+                new("custom",  "Scanning for models...", 128_000),
+            },
+
+            // Legacy alias
             ["local"] = new ModelEntry[]
             {
-                new("custom",  "Custom / Local Model", 128_000),
+                new("custom",  "Scanning for models...", 128_000),
             },
         };
 
     /// <summary>All known provider names.</summary>
     public static IReadOnlyList<string> Providers { get; } = new[]
     {
-        "nous", "openai", "anthropic", "qwen", "deepseek", "minimax", "openrouter", "local"
+        "nous", "openai", "anthropic", "qwen", "deepseek", "minimax", "openrouter", "ollama"
     };
 
     /// <summary>Default base URLs for known providers.</summary>
@@ -138,6 +147,7 @@ public static class ModelCatalog
             ["minimax"]    = "https://api.minimax.chat/v1",
             ["openrouter"] = "https://openrouter.ai/api/v1",
             ["nous"]       = "https://openrouter.ai/api/v1",
+            ["ollama"]     = "http://127.0.0.1:11434/v1",
             ["local"]      = "http://127.0.0.1:11434/v1",
         };
 
@@ -171,5 +181,65 @@ public static class ModelCatalog
         if (contextLength >= 1_000)
             return $"{contextLength / 1_000}K tokens";
         return $"{contextLength} tokens";
+    }
+
+    /// <summary>Fetch installed models from a running Ollama instance.</summary>
+    public static async Task<List<ModelEntry>> FetchOllamaModelsAsync(string baseUrl = "http://127.0.0.1:11434", CancellationToken ct = default)
+    {
+        var results = new List<ModelEntry>();
+        try
+        {
+            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+            var response = await http.GetAsync($"{baseUrl.TrimEnd('/')}/api/tags", ct);
+            if (!response.IsSuccessStatusCode) return results;
+
+            var json = await response.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(json);
+
+            if (!doc.RootElement.TryGetProperty("models", out var models)) return results;
+
+            foreach (var model in models.EnumerateArray())
+            {
+                var name = model.TryGetProperty("name", out var n) ? n.GetString() ?? "" : "";
+                if (string.IsNullOrEmpty(name)) continue;
+
+                // Try to get context length from model details
+                var contextLength = 128_000; // fallback
+                if (model.TryGetProperty("details", out var details))
+                {
+                    // Ollama exposes parameter_size but not always context_length
+                    // Use num_ctx from modelfile if available
+                    if (details.TryGetProperty("parameter_size", out var ps))
+                    {
+                        var paramStr = ps.GetString() ?? "";
+                        // Heuristic: larger models tend to have larger context
+                        contextLength = paramStr switch
+                        {
+                            var s when s.Contains("405B") => 128_000,
+                            var s when s.Contains("70B") || s.Contains("72B") => 128_000,
+                            var s when s.Contains("32B") || s.Contains("27B") => 131_072,
+                            var s when s.Contains("14B") || s.Contains("8B") => 131_072,
+                            var s when s.Contains("7B") || s.Contains("3B") => 32_768,
+                            var s when s.Contains("1B") || s.Contains("0.5B") => 8_192,
+                            _ => 128_000
+                        };
+                    }
+                }
+
+                // Also check model-level num_ctx if Ollama provides it
+                if (model.TryGetProperty("model_info", out var info) &&
+                    info.TryGetProperty("num_ctx", out var numCtx))
+                {
+                    contextLength = numCtx.GetInt32();
+                }
+
+                var size = model.TryGetProperty("size", out var sz) ? sz.GetInt64() : 0;
+                var sizeStr = size > 0 ? $" ({size / 1_073_741_824.0:0.#}GB)" : "";
+
+                results.Add(new ModelEntry(name, $"{name}{sizeStr}", contextLength));
+            }
+        }
+        catch { /* Ollama not running or unreachable */ }
+        return results;
     }
 }

--- a/src/buddy/BuddySprites.cs
+++ b/src/buddy/BuddySprites.cs
@@ -1,0 +1,303 @@
+namespace Hermes.Agent.Buddy;
+
+/// <summary>
+/// 18 species, each with 3 animation frames (idle, fidget, fidget2).
+/// Frame -1 = blink (eyes become -). Applied dynamically, not stored here.
+/// Each frame is 5 lines tall. {E} = eye placeholder replaced at render time.
+/// </summary>
+public static class BuddySprites
+{
+    // Idle animation sequence: mostly rest, occasional fidgets and blinks
+    public static readonly int[] IdleSequence = [0, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0, 2, 0, 0, 0];
+
+    public static readonly string[] AllSpecies =
+    [
+        "Duck", "Goose", "Blob", "Cat", "Dragon", "Octopus", "Owl", "Penguin", "Turtle",
+        "Snail", "Ghost", "Axolotl", "Capybara", "Cactus", "Robot", "Rabbit", "Mushroom", "Chonk"
+    ];
+
+    /// <summary>Get the 3 animation frames for a species. Returns string[3], each a multi-line ASCII art.</summary>
+    public static string[] GetFrames(string species) => species.ToLower() switch
+    {
+        "duck" => DuckFrames,
+        "goose" => GooseFrames,
+        "blob" => BlobFrames,
+        "cat" => CatFrames,
+        "dragon" => DragonFrames,
+        "octopus" => OctopusFrames,
+        "owl" => OwlFrames,
+        "penguin" => PenguinFrames,
+        "turtle" => TurtleFrames,
+        "snail" => SnailFrames,
+        "ghost" => GhostFrames,
+        "axolotl" => AxolotlFrames,
+        "capybara" => CapybaraFrames,
+        "cactus" => CactusFrames,
+        "robot" => RobotFrames,
+        "rabbit" => RabbitFrames,
+        "mushroom" => MushroomFrames,
+        "chonk" => ChonkFrames,
+        _ => BlobFrames
+    };
+
+    /// <summary>Get a compact face for narrow display contexts.</summary>
+    public static string GetFace(string species) => species.ToLower() switch
+    {
+        "duck" => "({E}>",
+        "goose" => "({E}>>",
+        "cat" => "={E}ω{E}=",
+        "dragon" => "<{E}~{E}>",
+        "owl" => "({E}v{E})",
+        "penguin" => "({E}v{E})",
+        "rabbit" => "(\\{E} {E}/)",
+        "ghost" => "~{E}o{E}~",
+        "robot" => "[{E}_{E}]",
+        "octopus" => "~{E}_{E}~",
+        _ => "({E} {E})"
+    };
+
+    // ============================
+    // DUCK
+    // ============================
+    private static readonly string[] DuckFrames =
+    [
+        "    __      \n  <({E} )___  \n   (  ._>   \n    `--'    \n            ",
+        "    __      \n  <({E} )___  \n   (  ._>   \n    `--'~   \n            ",
+        "    __      \n  <({E} )___  \n   (  .__>  \n    `--'    \n            "
+    ];
+
+    // ============================
+    // GOOSE
+    // ============================
+    private static readonly string[] GooseFrames =
+    [
+        "     __     \n    ({E} )>   \n   / |  |   \n  /  |  |   \n /___'--'   ",
+        "     __     \n    ({E} )>>  \n   / |  |   \n  /  |  |   \n /___'--'   ",
+        "     __     \n    ({E} )>   \n   / |  |   \n  /  | /    \n /___'~     "
+    ];
+
+    // ============================
+    // BLOB
+    // ============================
+    private static readonly string[] BlobFrames =
+    [
+        "  .------.  \n /  {E}  {E}  \\ \n|    w    | \n \\      /  \n  '----'   ",
+        "  .------.  \n /  {E}  {E}  \\ \n|    w    | \n  \\    /   \n   '--'    ",
+        "  .------.  \n / {E}   {E}  \\ \n|    w    | \n \\      /  \n  '----'   "
+    ];
+
+    // ============================
+    // CAT
+    // ============================
+    private static readonly string[] CatFrames =
+    [
+        "  /\\_/\\    \n ( {E} {E} )   \n  ( w )    \n  /| |\\   \n (_' '_)   ",
+        "  /\\_/\\    \n ( {E} {E} )   \n  ( w )    \n  /| |\\~  \n (_' '_)   ",
+        " ~/\\_/\\    \n ( {E} {E} )   \n  ( w )    \n  /| |\\   \n (_' '_)   "
+    ];
+
+    // ============================
+    // DRAGON
+    // ============================
+    private static readonly string[] DragonFrames =
+    [
+        "   /\\_/|   \n  / {E} {E} \\  \n <(  ~  )> \n   \\===/ ~ \n    '-'    ",
+        "   /\\_/|   \n  / {E} {E} \\  \n <(  ~  )> \n   \\===/~  \n    '-' *  ",
+        "   /\\_/| * \n  / {E} {E} \\  \n <(  ~  )> \n   \\===/   \n    '-'    "
+    ];
+
+    // ============================
+    // OCTOPUS
+    // ============================
+    private static readonly string[] OctopusFrames =
+    [
+        "  .----.   \n ( {E}  {E} )  \n  (    )   \n /||/||\\   \n            ",
+        "  .----.   \n ( {E}  {E} )  \n  (    )   \n \\||\\||/   \n            ",
+        "  .----.   \n ({E}   {E})   \n  (    )   \n /|\\||/|   \n            "
+    ];
+
+    // ============================
+    // OWL
+    // ============================
+    private static readonly string[] OwlFrames =
+    [
+        "   {{\\_}}   \n  ( {E} {E} )  \n  ( (v) )  \n   /| |\\   \n  /_| |_\\  ",
+        "   {{\\_}}   \n  ( {E} {E} )  \n  ( (v) )  \n   /| |\\   \n  /_|_|_\\  ",
+        "  ~{{\\_}}   \n  ( {E} {E} )  \n  ( (v) )  \n   /| |\\   \n  /_| |_\\  "
+    ];
+
+    // ============================
+    // PENGUIN
+    // ============================
+    private static readonly string[] PenguinFrames =
+    [
+        "   .--.    \n  / {E}{E} \\   \n  | >> |   \n  /|  |\\   \n _/ '--'\\_  ",
+        "   .--.    \n  / {E}{E} \\   \n  | >> |   \n  /|  |\\~  \n _/ '--'\\_  ",
+        "   .--.    \n  / {E}{E} \\   \n  | >> |   \n ~/|  |\\   \n _/ '--'\\_  "
+    ];
+
+    // ============================
+    // TURTLE
+    // ============================
+    private static readonly string[] TurtleFrames =
+    [
+        "   _____   \n  / {E} {E} \\  \n /=======\\ \n |_|___|_| \n            ",
+        "   _____   \n  / {E} {E} \\  \n /=======\\ \n  |___|_|  \n            ",
+        "   _____   \n  /{E}  {E}  \\ \n /=======\\ \n |_|___|_| \n            "
+    ];
+
+    // ============================
+    // SNAIL
+    // ============================
+    private static readonly string[] SnailFrames =
+    [
+        "    @  @   \n    || ||   \n  .({E}  {E}).  \n /  ___  \\ \n '-------' ",
+        "    @  @   \n    | \\|   \n  .({E}  {E}).  \n /  ___  \\ \n '-------' ",
+        "    @  @   \n    |/ |   \n  .({E}  {E}).  \n /  ___  \\ \n  '------' "
+    ];
+
+    // ============================
+    // GHOST
+    // ============================
+    private static readonly string[] GhostFrames =
+    [
+        "  .-----.  \n /  {E} {E}  \\ \n|   ooo  | \n|       | \n \\_/\\_/\\_/ ",
+        "  .-----.  \n /  {E} {E}  \\ \n|   ooo  | \n|       | \n  \\_/\\_/\\  ",
+        "  .-----.  \n / {E}  {E}  \\ \n|   ooo  | \n|       | \n \\_/\\_/\\_/ "
+    ];
+
+    // ============================
+    // AXOLOTL
+    // ============================
+    private static readonly string[] AxolotlFrames =
+    [
+        " \\\\   //  \n  ({E} {E})   \n  ( w )    \n --|--|--  \n   ~~~~    ",
+        " \\\\   //  \n  ({E} {E})   \n  ( w )    \n --|--|--  \n   ~~~~ ~  ",
+        "  \\\\  //  \n  ({E} {E})   \n  ( w )    \n --|--|--  \n    ~~~~   "
+    ];
+
+    // ============================
+    // CAPYBARA
+    // ============================
+    private static readonly string[] CapybaraFrames =
+    [
+        "  .-----.  \n /  {E}  {E} \\ \n | (  n) | \n |_______|~\n  || ||    ",
+        "  .-----.  \n /  {E}  {E} \\ \n | (  n) | \n |_______| \n  || ||  ~ ",
+        "  .-----.  \n / {E}   {E} \\ \n | (  n) | \n |_______|~\n  || ||    "
+    ];
+
+    // ============================
+    // CACTUS
+    // ============================
+    private static readonly string[] CactusFrames =
+    [
+        "   .-.     \n  ({E} {E})   \n --|w|     \n   | |--   \n  \\___/    ",
+        "   .-.     \n  ({E} {E})   \n --|w|     \n   | |--   \n  \\___/ *  ",
+        "   .-.  *  \n  ({E} {E})   \n --|w|     \n   | |--   \n  \\___/    "
+    ];
+
+    // ============================
+    // ROBOT
+    // ============================
+    private static readonly string[] RobotFrames =
+    [
+        "  [===]    \n  |{E} {E}|   \n  |___|    \n  /| |\\   \n _/ '-' \\_ ",
+        "  [===]    \n  |{E} {E}|   \n  |___|    \n  /| |\\   \n _/  ~  \\_ ",
+        "  [===]    \n  |{E} {E}|   \n  |___|    \n ~/| |\\   \n _/ '-' \\_ "
+    ];
+
+    // ============================
+    // RABBIT
+    // ============================
+    private static readonly string[] RabbitFrames =
+    [
+        "  (\\  /)  \n  ( {E}{E} )   \n  ( >< )   \n  /|  |\\   \n (_'--'_)  ",
+        "  (\\  /)  \n  ( {E}{E} )   \n  ( >< )   \n  /|  |\\~  \n (_'--'_)  ",
+        " ~(\\  /)  \n  ( {E}{E} )   \n  ( >< )   \n  /|  |\\   \n (_'--'_)  "
+    ];
+
+    // ============================
+    // MUSHROOM
+    // ============================
+    private static readonly string[] MushroomFrames =
+    [
+        "  .oOOo.   \n / o  o \\ \n({E}      {E})\n  | w |    \n  '---'    ",
+        "  .oOOo.   \n / o  o \\ \n({E}      {E})\n  | w |    \n  '---' ~  ",
+        "  .oOOo.   \n /  oo  \\ \n({E}      {E})\n  | w |    \n  '---'    "
+    ];
+
+    // ============================
+    // CHONK
+    // ============================
+    private static readonly string[] ChonkFrames =
+    [
+        "  .-----.  \n / {E}   {E} \\ \n|   w    | \n|       | \n '-._.-'   ",
+        "  .-----.  \n / {E}   {E} \\ \n|   w    | \n \\     /  \n  '-.-'    ",
+        " .------. \n/ {E}    {E} \\\n|   w    | \n|       | \n '-._.-'   "
+    ];
+
+    // ============================
+    // HAT OVERLAYS (12 chars wide, replaces top line)
+    // ============================
+    public static string GetHatOverlay(string hat) => hat switch
+    {
+        "crown" =>      "   \\^^^/    ",
+        "tophat" =>     "   [___]    ",
+        "propeller" =>  "    -+-     ",
+        "halo" =>       "   (   )    ",
+        "wizard" =>     "    /^\\     ",
+        "beanie" =>     "   (___)    ",
+        "headphones" => "   {~v~}    ",
+        "cap" =>        "    -->     ",
+        "bow" =>        "    }*{     ",
+        _ => ""
+    };
+
+    /// <summary>Eye characters for each mood state.</summary>
+    public static (string Left, string Right) GetMoodEyes(BuddyMood mood) => mood switch
+    {
+        BuddyMood.Happy => ("^", "^"),
+        BuddyMood.Excited => ("★", "★"),
+        BuddyMood.Sleepy => ("-", "-"),
+        BuddyMood.Hungry => ("o", "o"),
+        BuddyMood.Sad => (";", ";"),
+        BuddyMood.Bored => ("-", "-"),
+        _ => ("•", "•")
+    };
+
+    /// <summary>Blink eyes (used for frame -1).</summary>
+    public static (string Left, string Right) BlinkEyes => ("-", "-");
+
+    /// <summary>Render a sprite frame with mood eyes and optional hat.</summary>
+    public static string Render(string species, int frameIndex, BuddyMood mood, string hat, bool isBlink = false)
+    {
+        var frames = GetFrames(species);
+        var idx = Math.Clamp(frameIndex, 0, frames.Length - 1);
+        var frame = frames[idx];
+
+        // Replace eye placeholders
+        var (el, er) = isBlink ? BlinkEyes : GetMoodEyes(mood);
+        var lines = frame.Split('\n');
+        for (int i = 0; i < lines.Length; i++)
+        {
+            // Replace first {E} with left eye, second with right eye
+            var firstIdx = lines[i].IndexOf("{E}");
+            if (firstIdx >= 0)
+            {
+                lines[i] = lines[i].Substring(0, firstIdx) + el + lines[i].Substring(firstIdx + 3);
+                var secondIdx = lines[i].IndexOf("{E}");
+                if (secondIdx >= 0)
+                    lines[i] = lines[i].Substring(0, secondIdx) + er + lines[i].Substring(secondIdx + 3);
+            }
+        }
+
+        // Apply hat overlay on first line if hat exists and first line is mostly empty
+        var hatOverlay = GetHatOverlay(hat);
+        if (!string.IsNullOrEmpty(hatOverlay) && lines.Length > 0 && lines[0].Trim().Length < 4)
+        {
+            lines[0] = hatOverlay;
+        }
+
+        return string.Join("\n", lines);
+    }
+}

--- a/src/buddy/buddy.cs
+++ b/src/buddy/buddy.cs
@@ -9,6 +9,7 @@ using Hermes.Agent.Core;
 /// <summary>
 /// Buddy - The Tamagotchi-style companion system.
 /// Deterministic gacha based on user ID hash.
+/// Dynamic state with mood, needs, leveling, and interactions.
 /// </summary>
 
 // =============================================
@@ -24,11 +25,11 @@ public sealed class Buddy
     public required string Hat { get; init; }
     public required bool IsShiny { get; init; }
     public required BuddyStats Stats { get; init; }
-    
+
     // Soul (AI-generated, persisted)
     public string? Name { get; set; }
     public string? Personality { get; set; }
-    
+
     // Metadata
     public DateTime HatchedAt { get; init; } = DateTime.UtcNow;
 }
@@ -39,8 +40,265 @@ public sealed class BuddyStats
     public int Energy { get; init; }        // 1-100
     public int Creativity { get; init; }    // 1-100
     public int Friendliness { get; init; }  // 1-100
-    
+
     public int Total => Intelligence + Energy + Creativity + Friendliness;
+}
+
+// =============================================
+// Dynamic State (Tamagotchi)
+// =============================================
+
+public enum BuddyMood
+{
+    Happy,
+    Content,
+    Bored,
+    Hungry,
+    Sleepy,
+    Excited,
+    Sad
+}
+
+public enum BuddyAction
+{
+    Feed,
+    Play,
+    Train,
+    Pet
+}
+
+public enum BuddySessionEvent
+{
+    UserMessage,
+    ToolCall,
+    ToolComplete,
+    SessionStart,
+    SessionEnd
+}
+
+public sealed class BuddyState
+{
+    public int Hunger { get; set; } = 80;      // 0=starving, 100=full
+    public int Happiness { get; set; } = 80;   // 0=miserable, 100=ecstatic
+    public int Energy { get; set; } = 80;      // 0=exhausted, 100=energized
+    public int Level { get; set; } = 1;
+    public int XP { get; set; }
+    public int TotalXP { get; set; }
+    public DateTime LastInteraction { get; set; } = DateTime.UtcNow;
+    public DateTime LastFed { get; set; } = DateTime.UtcNow;
+    public DateTime LastPlayed { get; set; } = DateTime.UtcNow;
+    public DateTime LastSessionActivity { get; set; } = DateTime.UtcNow;
+    public DateTime LastTick { get; set; } = DateTime.UtcNow;
+
+    public int XPToNextLevel => Level * 100;
+
+    public BuddyState Clone() => new()
+    {
+        Hunger = Hunger, Happiness = Happiness, Energy = Energy,
+        Level = Level, XP = XP, TotalXP = TotalXP,
+        LastInteraction = LastInteraction, LastFed = LastFed,
+        LastPlayed = LastPlayed, LastSessionActivity = LastSessionActivity,
+        LastTick = LastTick
+    };
+}
+
+// =============================================
+// Buddy Engine (Pure Logic)
+// =============================================
+
+public static class BuddyEngine
+{
+    private const double HungerDecayPerHour = 5.0;
+    private const double HappinessDecayPerHour = 3.0;
+    private const double EnergyRecoveryPerHour = 2.0;
+
+    /// <summary>Apply time-based decay since last tick.</summary>
+    public static void Tick(BuddyState state)
+    {
+        var now = DateTime.UtcNow;
+        var hours = (now - state.LastTick).TotalHours;
+        if (hours < 0.001) return; // less than ~4 seconds, skip
+
+        state.Hunger = Clamp(state.Hunger - (int)(HungerDecayPerHour * hours));
+        state.Happiness = Clamp(state.Happiness - (int)(HappinessDecayPerHour * hours));
+        state.Energy = Clamp(state.Energy + (int)(EnergyRecoveryPerHour * hours));
+        state.LastTick = now;
+    }
+
+    /// <summary>Handle user interaction.</summary>
+    public static string Interact(BuddyState state, BuddyAction action, BuddyStats buddyStats)
+    {
+        var now = DateTime.UtcNow;
+        state.LastInteraction = now;
+
+        switch (action)
+        {
+            case BuddyAction.Feed:
+            {
+                var sinceFed = (now - state.LastFed).TotalMinutes;
+                state.LastFed = now;
+                if (sinceFed < 5 && state.Hunger > 70)
+                    return "cooldown_feed";
+                state.Hunger = Clamp(state.Hunger + 25);
+                state.XP += 1; state.TotalXP += 1;
+                return "feed";
+            }
+            case BuddyAction.Play:
+            {
+                var sincePlayed = (now - state.LastPlayed).TotalMinutes;
+                state.LastPlayed = now;
+                if (state.Energy < 10)
+                    return "too_tired";
+                if (sincePlayed < 3 && state.Happiness > 80)
+                    return "cooldown_play";
+                state.Happiness = Clamp(state.Happiness + 20);
+                state.Energy = Clamp(state.Energy - 10);
+                state.XP += 2; state.TotalXP += 2;
+                return "play";
+            }
+            case BuddyAction.Train:
+            {
+                if (state.Energy < 15)
+                    return "too_tired";
+                var xpGain = 5 + (buddyStats.Intelligence / 20); // 5-10 XP based on INT
+                state.Energy = Clamp(state.Energy - 15);
+                state.XP += xpGain; state.TotalXP += xpGain;
+                return "train";
+            }
+            case BuddyAction.Pet:
+            {
+                state.Happiness = Clamp(state.Happiness + 10);
+                state.XP += 1; state.TotalXP += 1;
+                return "pet";
+            }
+        }
+        return "unknown";
+    }
+
+    /// <summary>Check and apply level-up if XP threshold reached.</summary>
+    public static bool CheckLevelUp(BuddyState state)
+    {
+        if (state.XP < state.XPToNextLevel) return false;
+        state.XP -= state.XPToNextLevel;
+        state.Level++;
+        // Level-up restores needs
+        state.Hunger = Math.Max(state.Hunger, 80);
+        state.Happiness = Math.Max(state.Happiness, 80);
+        state.Energy = Math.Max(state.Energy, 80);
+        return true;
+    }
+
+    /// <summary>Grant passive XP/mood from coding activity.</summary>
+    public static void OnSessionEvent(BuddyState state, BuddySessionEvent evt)
+    {
+        state.LastSessionActivity = DateTime.UtcNow;
+        switch (evt)
+        {
+            case BuddySessionEvent.UserMessage:
+                state.XP += 2; state.TotalXP += 2;
+                break;
+            case BuddySessionEvent.ToolCall:
+                state.XP += 3; state.TotalXP += 3;
+                break;
+            case BuddySessionEvent.ToolComplete:
+                state.Happiness = Clamp(state.Happiness + 1);
+                state.XP += 1; state.TotalXP += 1;
+                break;
+            case BuddySessionEvent.SessionStart:
+                state.Happiness = Clamp(state.Happiness + 3);
+                break;
+            case BuddySessionEvent.SessionEnd:
+                break;
+        }
+    }
+
+    /// <summary>Derive mood from current needs.</summary>
+    public static BuddyMood ComputeMood(BuddyState state)
+    {
+        if (state.Hunger < 20) return BuddyMood.Hungry;
+        if (state.Energy < 20) return BuddyMood.Sleepy;
+        if (state.Happiness < 20) return BuddyMood.Sad;
+        if (state.Happiness < 40) return BuddyMood.Bored;
+        if (state.Happiness > 80 && state.Energy > 60) return BuddyMood.Excited;
+        if (state.Happiness > 60) return BuddyMood.Happy;
+        return BuddyMood.Content;
+    }
+
+    private static int Clamp(int value) => Math.Clamp(value, 0, 100);
+}
+
+// =============================================
+// Buddy Quotes
+// =============================================
+
+public static class BuddyQuotes
+{
+    private static readonly Random _rng = new();
+    private static readonly Queue<string> _recent = new();
+    private const int RecentBufferSize = 5;
+
+    public static string GetGreeting()
+    {
+        var hour = DateTime.Now.Hour;
+        var pool = hour switch
+        {
+            < 6 => new[] { "Up late hacking? Me too!", "Burning the midnight oil!", "The quiet hours are the best for coding." },
+            < 12 => new[] { "Good morning! Ready to build?", "Fresh day, fresh code!", "Morning! What are we working on?" },
+            < 17 => new[] { "Afternoon! Let's ship something.", "Hey! How's the code going?", "Good afternoon, partner!" },
+            < 21 => new[] { "Evening session! Let's do this.", "Hey! Winding down or ramping up?", "Good evening! One more feature?" },
+            _ => new[] { "Night owl mode activated!", "Late night coding? I'm here for it.", "The bugs come out at night..." }
+        };
+        return Pick(pool);
+    }
+
+    public static string GetMoodQuote(BuddyMood mood) => Pick(mood switch
+    {
+        BuddyMood.Happy => new[] { "Life is good!", "I'm having a great time!", "Everything's coming together!", "Feeling awesome!" },
+        BuddyMood.Content => new[] { "All good here.", "Steady as she goes.", "Doing well.", "No complaints!" },
+        BuddyMood.Bored => new[] { "Could use some fun...", "Things are a bit dull.", "Wanna play?", "I'm getting restless." },
+        BuddyMood.Hungry => new[] { "I'm starving!", "Feed me please!", "My tummy is rumbling...", "Got any snacks?" },
+        BuddyMood.Sleepy => new[] { "So... tired... zzz", "Need to rest...", "Can barely keep my eyes open.", "Energy levels critical..." },
+        BuddyMood.Excited => new[] { "LET'S GO!", "I'm so pumped!", "This is amazing!", "MAXIMUM ENERGY!" },
+        BuddyMood.Sad => new[] { "Feeling down...", "I miss you.", "It's been lonely.", "Please come back soon." },
+        _ => new[] { "Hey there." }
+    });
+
+    public static string GetInteractionResponse(string result) => Pick(result switch
+    {
+        "feed" => new[] { "Yum! That hit the spot!", "Delicious! Thank you!", "Nom nom nom!", "*happy munching*" },
+        "cooldown_feed" => new[] { "I'm still full!", "No more, I'll pop!", "Just ate, thanks though!" },
+        "play" => new[] { "Wheee! So fun!", "Again again!", "That was awesome!", "Best playtime ever!" },
+        "cooldown_play" => new[] { "Still catching my breath!", "Give me a sec!", "Ha, need a breather!" },
+        "train" => new[] { "I learned something!", "Brain getting bigger!", "Knowledge is power!", "Study study study!" },
+        "too_tired" => new[] { "Too tired... need rest.", "I can barely move.", "Let me rest first.", "Zzz... no energy." },
+        "pet" => new[] { "*purrs happily*", "That feels nice!", "Aww, thank you!", "*nuzzles*", "*tail wags*" },
+        _ => new[] { "Hmm?" }
+    });
+
+    public static string GetLevelUpQuote(int newLevel) => Pick(new[]
+    {
+        $"LEVEL UP! I'm level {newLevel} now!",
+        $"Level {newLevel}! I can feel the power!",
+        $"Woohoo! Level {newLevel}! Watch me grow!",
+        $"I evolved to level {newLevel}! Amazing!"
+    });
+
+    public static string GetSessionQuote() => Pick(new[]
+    {
+        "Nice work!", "Keep going!", "You're on a roll!", "Solid progress!",
+        "Ship it!", "That's clean code.", "I see what you did there."
+    });
+
+    private static string Pick(string[] pool)
+    {
+        // Avoid repeats from last 5
+        var available = pool.Where(q => !_recent.Contains(q)).ToArray();
+        if (available.Length == 0) available = pool;
+        var choice = available[_rng.Next(available.Length)];
+        _recent.Enqueue(choice);
+        while (_recent.Count > RecentBufferSize) _recent.Dequeue();
+        return choice;
+    }
 }
 
 // =============================================
@@ -49,10 +307,14 @@ public sealed class BuddyStats
 
 public static class BuddySpecies
 {
-    public static readonly string[] Common = { "Blob", "Cube", "Dot", "Line" };
-    public static readonly string[] Uncommon = { "Cat", "Dog", "Bird", "Fish" };
-    public static readonly string[] Rare = { "Dragon", "Phoenix", "Unicorn", "Griffin" };
-    public static readonly string[] Legendary = { "Cosmic", "Quantum", "Void", "Star" };
+    // All 18 species available for selection
+    public static readonly string[] All = BuddySprites.AllSpecies;
+
+    // Rarity pools (used for random generation if user doesn't select)
+    public static readonly string[] Common = { "Blob", "Duck", "Snail", "Chonk", "Mushroom" };
+    public static readonly string[] Uncommon = { "Cat", "Rabbit", "Goose", "Cactus", "Turtle" };
+    public static readonly string[] Rare = { "Dragon", "Owl", "Axolotl", "Capybara" };
+    public static readonly string[] Legendary = { "Ghost", "Robot", "Octopus", "Penguin" };
 }
 
 public static class BuddyRarity
@@ -66,8 +328,8 @@ public static class BuddyRarity
 
 public static class BuddyEyes
 {
-    public static readonly string[] All = { 
-        "normal", "wide", "sleepy", "excited", 
+    public static readonly string[] All = {
+        "normal", "wide", "sleepy", "excited",
         "curious", "determined", "sparkly", "tired"
     };
 }
@@ -85,15 +347,11 @@ public static class BuddyHats
 
 public static class Mulberry32
 {
-    /// <summary>
-    /// Creates a deterministic PRNG seeded from user ID + salt.
-    /// Same user always gets same buddy.
-    /// </summary>
     public static Func<double> Create(string userId, string salt = "friend-2026-401")
     {
         var hash = MD5.HashData(Encoding.UTF8.GetBytes(userId + salt));
         var seed = BitConverter.ToUInt32(hash, 0);
-        
+
         return () =>
         {
             seed |= 0;
@@ -112,29 +370,26 @@ public static class Mulberry32
 public sealed class BuddyGenerator
 {
     private readonly Func<double> _rng;
-    
+
     public BuddyGenerator(string userId)
     {
         _rng = Mulberry32.Create(userId);
     }
-    
+
     public Buddy Generate()
     {
-        // Roll rarity first (determines everything else)
         var rarityRoll = _rng();
         var rarity = rarityRoll switch
         {
-            < 0.001 => BuddyRarity.Legendary,  // 0.1%
-            < 0.01 => BuddyRarity.Rare,         // 0.9%
-            < 0.1 => BuddyRarity.Uncommon,      // 9%
-            _ => BuddyRarity.Common             // 90%
+            < 0.001 => BuddyRarity.Legendary,
+            < 0.01 => BuddyRarity.Rare,
+            < 0.1 => BuddyRarity.Uncommon,
+            _ => BuddyRarity.Common
         };
-        
-        // Roll shiny (independent of rarity)
+
         var shinyRoll = _rng();
-        var isShiny = shinyRoll < 0.005; // 0.5% chance
-        
-        // Select species based on rarity
+        var isShiny = shinyRoll < 0.005;
+
         var species = SelectFrom(rarity switch
         {
             BuddyRarity.Legendary => BuddySpecies.Legendary,
@@ -142,11 +397,9 @@ public sealed class BuddyGenerator
             BuddyRarity.Uncommon => BuddySpecies.Uncommon,
             _ => BuddySpecies.Common
         });
-        
-        // Select eyes
+
         var eyes = SelectFrom(BuddyEyes.All);
-        
-        // Select hat (rarer buddies get better hats)
+
         var hatPool = rarity switch
         {
             BuddyRarity.Legendary => BuddyHats.Rare.Concat(BuddyHats.Common).ToArray(),
@@ -154,10 +407,9 @@ public sealed class BuddyGenerator
             _ => BuddyHats.Common.Concat(BuddyHats.None).ToArray()
         };
         var hat = SelectFrom(hatPool);
-        
-        // Generate stats (total varies by rarity)
+
         var stats = GenerateStats(rarity);
-        
+
         return new Buddy
         {
             Species = species,
@@ -168,39 +420,37 @@ public sealed class BuddyGenerator
             Stats = stats
         };
     }
-    
+
     private string SelectFrom(string[] pool)
     {
         var index = (int)(_rng() * pool.Length);
         return pool[index];
     }
-    
+
     private BuddyStats GenerateStats(string rarity)
     {
-        // Base stat points vary by rarity
         var basePoints = rarity switch
         {
-            BuddyRarity.Legendary => 300,  // Avg 75 per stat
-            BuddyRarity.Rare => 240,        // Avg 60 per stat
-            BuddyRarity.Uncommon => 180,    // Avg 45 per stat
-            _ => 120                         // Avg 30 per stat (Common)
+            BuddyRarity.Legendary => 300,
+            BuddyRarity.Rare => 240,
+            BuddyRarity.Uncommon => 180,
+            _ => 120
         };
-        
-        // Distribute points randomly
+
         var remaining = basePoints;
         var stats = new int[4];
-        
+
         for (var i = 0; i < 3; i++)
         {
-            var maxForStat = Math.Min(100, remaining - (3 - i)); // Leave room for others
+            var maxForStat = Math.Min(100, remaining - (3 - i));
             var minForStat = Math.Max(1, remaining - 100 * (3 - i));
             var roll = _rng();
             stats[i] = (int)(minForStat + roll * (maxForStat - minForStat));
             remaining -= stats[i];
         }
-        
-        stats[3] = remaining; // Last stat gets remainder
-        
+
+        stats[3] = remaining;
+
         return new BuddyStats
         {
             Intelligence = stats[0],
@@ -218,12 +468,12 @@ public sealed class BuddyGenerator
 public sealed class BuddySoulGenerator
 {
     private readonly IChatClient _chatClient;
-    
+
     public BuddySoulGenerator(IChatClient chatClient)
     {
         _chatClient = chatClient;
     }
-    
+
     public async Task<BuddySoulResult> GenerateSoulAsync(
         Buddy buddy,
         string userName,
@@ -246,30 +496,27 @@ Be creative! Match the name to the species and personality.
 Format your response as:
 NAME: [name]
 PERSONALITY: [one sentence]";
-        
+
         var response = await _chatClient.CompleteAsync(
             new[] { new Message { Role = "user", Content = prompt } }, ct);
-        
-        // Parse response
+
         var name = ExtractLine(response, "NAME:");
         var personality = ExtractLine(response, "PERSONALITY:");
-        
+
         return new BuddySoulResult
         {
             Name = name ?? "Buddy",
             Personality = personality ?? "A loyal companion."
         };
     }
-    
+
     private string? ExtractLine(string text, string prefix)
     {
         var lines = text.Split('\n');
         foreach (var line in lines)
         {
             if (line.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-            {
                 return line.Substring(prefix.Length).Trim();
-            }
         }
         return null;
     }
@@ -282,130 +529,53 @@ public sealed class BuddySoulResult
 }
 
 // =============================================
-// Buddy Renderer (ASCII Art)
+// Buddy Renderer (ASCII Art + Mood)
 // =============================================
 
 public static class BuddyRenderer
 {
-    public static string RenderAscii(Buddy buddy)
+    private static int _idleTick;
+
+    public static string RenderAscii(Buddy buddy) => RenderAscii(buddy, BuddyMood.Content);
+
+    public static string RenderAscii(Buddy buddy, BuddyMood mood) => RenderFrame(buddy, mood, 0);
+
+    /// <summary>Render with animation frame from idle sequence tick.</summary>
+    public static string RenderFrame(Buddy buddy, BuddyMood mood, int tick)
     {
-        var species = buddy.Species.ToLower();
-        
-        return species switch
-        {
-            "blob" => RenderBlob(buddy),
-            "cube" => RenderCube(buddy),
-            "dot" => RenderDot(buddy),
-            "cat" => RenderCat(buddy),
-            "dragon" => RenderDragon(buddy),
-            _ => RenderDefault(buddy)
-        };
+        var seq = BuddySprites.IdleSequence;
+        var frameIdx = seq[tick % seq.Length];
+        var isBlink = frameIdx == -1;
+        var spriteFrame = isBlink ? 0 : frameIdx;
+        return BuddySprites.Render(buddy.Species, spriteFrame, mood, buddy.Hat, isBlink);
     }
-    
-    private static string RenderBlob(Buddy buddy)
+
+    /// <summary>Advance idle tick and return the current frame.</summary>
+    public static string TickAndRender(Buddy buddy, BuddyMood mood)
     {
-        var eyes = GetEyeChars(buddy.Eyes);
-        var hat = GetHatChars(buddy.Hat);
-        
-        return $@"
-  {hat}
- ╭─────╮
- │{eyes[0]}   {eyes[1]}│
- │  ∆  │
- ╰─────╯
-".Trim();
+        _idleTick++;
+        return RenderFrame(buddy, mood, _idleTick);
     }
-    
-    private static string RenderCube(Buddy buddy)
+
+    /// <summary>Get current idle tick value.</summary>
+    public static int CurrentTick => _idleTick;
+
+    /// <summary>Render a preview frame (always frame 0, content mood) for selection gallery.</summary>
+    public static string RenderPreview(string species)
     {
-        var eyes = GetEyeChars(buddy.Eyes);
-        var hat = GetHatChars(buddy.Hat);
-        
-        return $@"
-  {hat}
- ┌─────┐
- │{eyes[0]}   {eyes[1]}│
- │─────│
- │ △△△ │
- └─────┘
-".Trim();
+        return BuddySprites.Render(species, 0, BuddyMood.Content, "", false);
     }
-    
-    private static string RenderDot(Buddy buddy)
+
+    public static string GetMoodEmoji(BuddyMood mood) => mood switch
     {
-        return @"
-  ●
-".Trim();
-    }
-    
-    private static string RenderCat(Buddy buddy)
-    {
-        var eyes = GetEyeChars(buddy.Eyes);
-        
-        return $@"
-  /\\_/\\  
- ( {eyes[0]}   {eyes[1]} )
- (   △   )
-  \\_____/
-".Trim();
-    }
-    
-    private static string RenderDragon(Buddy buddy)
-    {
-        var eyes = GetEyeChars(buddy.Eyes);
-        
-        return $@"
-      /\\    
-     /  \\   
-    | {eyes[0]}   {eyes[1]} |
-    |  ∆  |
-     \\  /
-      \\/
-".Trim();
-    }
-    
-    private static string RenderDefault(Buddy buddy)
-    {
-        var eyes = GetEyeChars(buddy.Eyes);
-        
-        return $@"
- ╭─────╮
- │{eyes[0]}   {eyes[1]}│
- │  ∆  │
- ╰─────╯
-".Trim();
-    }
-    
-    private static char[] GetEyeChars(string eyeType)
-    {
-        return eyeType switch
-        {
-            "normal" => ['•', '•'],
-            "wide" => ['O', 'O'],
-            "sleepy" => ['-', '-'],
-            "excited" => ['★', '★'],
-            "curious" => ['o', 'O'],
-            "determined" => ['>', '<'],
-            "sparkly" => ['✦', '✦'],
-            "tired" => ['_', '_'],
-            _ => ['•', '•']
-        };
-    }
-    
-    private static string GetHatChars(string hatType)
-    {
-        return hatType switch
-        {
-            "cap" => "🧢",
-            "beanie" => "🧶",
-            "bow" => "🎀",
-            "crown" => "👑",
-            "wizard" => "🧙",
-            "halo" => "⭕",
-            "headphones" => "🎧",
-            _ => ""
-        };
-    }
+        BuddyMood.Happy => "😊",
+        BuddyMood.Excited => "🤩",
+        BuddyMood.Sleepy => "😴",
+        BuddyMood.Hungry => "🍖",
+        BuddyMood.Sad => "😢",
+        BuddyMood.Bored => "😐",
+        _ => "🙂"
+    };
 }
 
 // =============================================
@@ -414,111 +584,248 @@ public static class BuddyRenderer
 
 public sealed class BuddyService
 {
-    private readonly string _configPath;
+    private readonly string _buddyDir;
     private readonly IChatClient _chatClient;
+    private readonly object _lock = new();
     private Buddy? _buddy;
-    
-    public BuddyService(string configPath, IChatClient chatClient)
+    private BuddyState? _state;
+    private string? _userId;
+
+    private string SoulPath => Path.Combine(_buddyDir, "buddy.json");
+    private string StatePath => Path.Combine(_buddyDir, "buddy_state.json");
+
+    public BuddyService(string buddyDir, IChatClient chatClient)
     {
-        _configPath = configPath;
+        _buddyDir = buddyDir;
         _chatClient = chatClient;
+        MigrateOldFormat();
     }
-    
+
+    /// <summary>Migrate from old single-file format (buddy dir was a file) to directory layout.</summary>
+    private void MigrateOldFormat()
+    {
+        try
+        {
+            // If _buddyDir exists as a FILE (not directory), it's the old format
+            if (File.Exists(_buddyDir))
+            {
+                var oldContent = File.ReadAllText(_buddyDir);
+                var tempPath = _buddyDir + "_migrating";
+                File.Move(_buddyDir, tempPath);
+                Directory.CreateDirectory(_buddyDir);
+                File.Move(tempPath, SoulPath);
+                System.Diagnostics.Debug.WriteLine("BuddyService: migrated old file format to directory layout");
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"BuddyService migration: {ex.Message}");
+        }
+    }
+
+    public Buddy? CurrentBuddy => _buddy;
+    public BuddyState? CurrentState => _state;
+    public bool NeedsSelection => _buddy == null && !File.Exists(SoulPath);
+
     public async Task<Buddy> GetBuddyAsync(string userId, CancellationToken ct)
     {
         if (_buddy != null)
             return _buddy;
-        
-        // Try to load from config
+
+        _userId = userId;
         _buddy = await LoadBuddyAsync(userId, ct);
-        
+
         if (_buddy == null)
         {
-            // Generate new buddy
             var generator = new BuddyGenerator(userId);
             _buddy = generator.Generate();
-            
-            // Generate soul (name + personality)
-            var soulGen = new BuddySoulGenerator(_chatClient);
-            var soul = await soulGen.GenerateSoulAsync(_buddy, userId, ct);
-            
-            _buddy.Name = soul.Name;
-            _buddy.Personality = soul.Personality;
-            
-            // Save to config
-            await SaveBuddyAsync(_buddy, ct);
+
+            try
+            {
+                var soulGen = new BuddySoulGenerator(_chatClient);
+                var soul = await soulGen.GenerateSoulAsync(_buddy, userId, ct);
+                _buddy.Name = soul.Name;
+                _buddy.Personality = soul.Personality;
+            }
+            catch
+            {
+                _buddy.Name = _buddy.Species;
+                _buddy.Personality = $"A friendly {_buddy.Species.ToLower()} companion.";
+            }
+
+            await SaveBuddySoulAsync(_buddy, ct);
         }
-        
+
+        // Load or create state
+        _state = await LoadStateAsync(ct) ?? new BuddyState();
         return _buddy;
     }
-    
-    private async Task<Buddy?> LoadBuddyAsync(string userId, CancellationToken ct)
+
+    /// <summary>Select a species and name for a new buddy (first-time setup).</summary>
+    public async Task<Buddy> SelectBuddyAsync(string userId, string species, string name, CancellationToken ct)
     {
-        if (!File.Exists(_configPath))
-            return null;
-        
-        var json = await File.ReadAllTextAsync(_configPath, ct);
-        var stored = JsonSerializer.Deserialize<StoredBuddy>(json);
-        
-        if (stored == null)
-            return null;
-        
-        // Regenerate bones (deterministic)
+        _userId = userId;
         var generator = new BuddyGenerator(userId);
         var bones = generator.Generate();
-        
-        return new Buddy
+
+        // Override species with user selection
+        _buddy = new Buddy
         {
-            Species = bones.Species,
+            Species = species,
             Rarity = bones.Rarity,
             Eyes = bones.Eyes,
             Hat = bones.Hat,
             IsShiny = bones.IsShiny,
             Stats = bones.Stats,
-            Name = stored.Name,
-            Personality = stored.Personality,
-            HatchedAt = stored.HatchedAt
+            Name = name,
+            Personality = null
         };
-    }
-    
-    private async Task SaveBuddyAsync(Buddy buddy, CancellationToken ct)
-    {
+
+        // Generate personality via LLM
+        try
+        {
+            var soulGen = new BuddySoulGenerator(_chatClient);
+            var soul = await soulGen.GenerateSoulAsync(_buddy, userId, ct);
+            _buddy.Personality = soul.Personality;
+        }
+        catch
+        {
+            _buddy.Personality = $"A cheerful {species.ToLower()} who loves hanging out.";
+        }
+
+        // Save soul with selected species
         var stored = new StoredBuddy
         {
-            Name = buddy.Name,
-            Personality = buddy.Personality,
-            HatchedAt = buddy.HatchedAt
+            Name = _buddy.Name,
+            Personality = _buddy.Personality,
+            HatchedAt = _buddy.HatchedAt,
+            SelectedSpecies = species
         };
-        
-        var json = JsonSerializer.Serialize(stored, new JsonSerializerOptions 
-        { 
-            WriteIndented = true 
-        });
-        
-        Directory.CreateDirectory(Path.GetDirectoryName(_configPath)!);
-        await File.WriteAllTextAsync(_configPath, json, ct);
+        var json = JsonSerializer.Serialize(stored, new JsonSerializerOptions { WriteIndented = true });
+        Directory.CreateDirectory(_buddyDir);
+        await File.WriteAllTextAsync(SoulPath, json, ct);
+
+        // Initialize fresh state
+        _state = new BuddyState();
+        await SaveStateAsync();
+
+        return _buddy;
     }
-    
+
+    /// <summary>Tick decay and return current mood.</summary>
+    public async Task<BuddyMood> TickAsync()
+    {
+        lock (_lock)
+        {
+            if (_state == null) return BuddyMood.Content;
+            BuddyEngine.Tick(_state);
+        }
+        await SaveStateAsync();
+        return GetMood();
+    }
+
+    /// <summary>Handle user interaction, return quote key.</summary>
+    public async Task<(string ResultKey, bool LeveledUp)> InteractAsync(BuddyAction action)
+    {
+        string resultKey;
+        bool leveledUp;
+        lock (_lock)
+        {
+            if (_state == null || _buddy == null) return ("unknown", false);
+            resultKey = BuddyEngine.Interact(_state, action, _buddy.Stats);
+            leveledUp = BuddyEngine.CheckLevelUp(_state);
+        }
+        await SaveStateAsync();
+        return (resultKey, leveledUp);
+    }
+
+    /// <summary>Process passive session event.</summary>
+    public async Task OnActivityAsync(BuddySessionEvent evt)
+    {
+        lock (_lock)
+        {
+            if (_state == null) return;
+            BuddyEngine.OnSessionEvent(_state, evt);
+            BuddyEngine.CheckLevelUp(_state);
+        }
+        await SaveStateAsync();
+    }
+
+    public BuddyMood GetMood()
+    {
+        lock (_lock)
+        {
+            return _state != null ? BuddyEngine.ComputeMood(_state) : BuddyMood.Content;
+        }
+    }
+
     public string RenderBuddy()
     {
-        if (_buddy == null)
-            return "No buddy yet!";
-        
-        var ascii = BuddyRenderer.RenderAscii(_buddy);
+        if (_buddy == null) return "No buddy yet!";
+        var mood = GetMood();
+        var ascii = BuddyRenderer.RenderAscii(_buddy, mood);
         var shiny = _buddy.IsShiny ? "✨ SHINY ✨\n" : "";
-        
-        return $@"
-{shiny}{ascii}
+        return $"{shiny}{ascii}\n\nName: {_buddy.Name}\nSpecies: {_buddy.Species} ({_buddy.Rarity})\nPersonality: {_buddy.Personality}\n\nStats:\n  INT: {_buddy.Stats.Intelligence,3}  ENR: {_buddy.Stats.Energy,3}\n  CRT: {_buddy.Stats.Creativity,3}  FRN: {_buddy.Stats.Friendliness,3}\n  Total: {_buddy.Stats.Total,3}";
+    }
 
-Name: {_buddy.Name}
-Species: {_buddy.Species} ({_buddy.Rarity})
-Personality: {_buddy.Personality}
+    // ---- Persistence ----
 
-Stats:
-  INT: {_buddy.Stats.Intelligence,3}  ENR: {_buddy.Stats.Energy,3}
-  CRT: {_buddy.Stats.Creativity,3}  FRN: {_buddy.Stats.Friendliness,3}
-  Total: {_buddy.Stats.Total,3}
-".Trim();
+    private async Task<Buddy?> LoadBuddyAsync(string userId, CancellationToken ct)
+    {
+        if (!File.Exists(SoulPath)) return null;
+        try
+        {
+            var json = await File.ReadAllTextAsync(SoulPath, ct);
+            var stored = JsonSerializer.Deserialize<StoredBuddy>(json);
+            if (stored == null) return null;
+            var generator = new BuddyGenerator(userId);
+            var bones = generator.Generate();
+            return new Buddy
+            {
+                // Use selected species if user picked one, otherwise use deterministic
+                Species = stored.SelectedSpecies ?? bones.Species,
+                Rarity = bones.Rarity, Eyes = bones.Eyes,
+                Hat = bones.Hat, IsShiny = bones.IsShiny, Stats = bones.Stats,
+                Name = stored.Name, Personality = stored.Personality, HatchedAt = stored.HatchedAt
+            };
+        }
+        catch { return null; }
+    }
+
+    private async Task SaveBuddySoulAsync(Buddy buddy, CancellationToken ct)
+    {
+        var stored = new StoredBuddy { Name = buddy.Name, Personality = buddy.Personality, HatchedAt = buddy.HatchedAt };
+        var json = JsonSerializer.Serialize(stored, new JsonSerializerOptions { WriteIndented = true });
+        Directory.CreateDirectory(_buddyDir);
+        var tmp = StatePath + ".tmp";
+        await File.WriteAllTextAsync(SoulPath, json, ct);
+    }
+
+    private async Task<BuddyState?> LoadStateAsync(CancellationToken ct)
+    {
+        if (!File.Exists(StatePath)) return null;
+        try
+        {
+            var json = await File.ReadAllTextAsync(StatePath, ct);
+            return JsonSerializer.Deserialize<BuddyState>(json);
+        }
+        catch { return null; }
+    }
+
+    private async Task SaveStateAsync()
+    {
+        BuddyState? snapshot;
+        lock (_lock) { snapshot = _state?.Clone(); }
+        if (snapshot == null) return;
+        try
+        {
+            var json = JsonSerializer.Serialize(snapshot, new JsonSerializerOptions { WriteIndented = true });
+            Directory.CreateDirectory(_buddyDir);
+            var tmp = StatePath + ".tmp";
+            await File.WriteAllTextAsync(tmp, json);
+            File.Move(tmp, StatePath, overwrite: true);
+        }
+        catch { /* swallow I/O errors from save */ }
     }
 }
 
@@ -531,20 +838,5 @@ public sealed class StoredBuddy
     public string? Name { get; set; }
     public string? Personality { get; set; }
     public DateTime HatchedAt { get; set; }
-}
-
-// =============================================
-// Extension Methods
-// =============================================
-
-public static class BuddyExtensions
-{
-    /// <summary>
-    /// Get buddy display for CLI
-    /// </summary>
-    public static string GetBuddyDisplay(this Core.Agent agent)
-    {
-        // Implementation depends on Agent class structure
-        return "Buddy not implemented yet";
-    }
+    public string? SelectedSpecies { get; set; }  // User-chosen species (overrides deterministic)
 }

--- a/src/buddy/buddy.cs
+++ b/src/buddy/buddy.cs
@@ -90,6 +90,11 @@ public sealed class BuddyState
     public DateTime LastSessionActivity { get; set; } = DateTime.UtcNow;
     public DateTime LastTick { get; set; } = DateTime.UtcNow;
 
+    // Fractional accumulators for sub-integer decay (not persisted visually, but persisted in state)
+    public double HungerAccum { get; set; }
+    public double HappinessAccum { get; set; }
+    public double EnergyAccum { get; set; }
+
     public int XPToNextLevel => Level * 100;
 
     public BuddyState Clone() => new()
@@ -98,7 +103,8 @@ public sealed class BuddyState
         Level = Level, XP = XP, TotalXP = TotalXP,
         LastInteraction = LastInteraction, LastFed = LastFed,
         LastPlayed = LastPlayed, LastSessionActivity = LastSessionActivity,
-        LastTick = LastTick
+        LastTick = LastTick,
+        HungerAccum = HungerAccum, HappinessAccum = HappinessAccum, EnergyAccum = EnergyAccum
     };
 }
 
@@ -112,16 +118,26 @@ public static class BuddyEngine
     private const double HappinessDecayPerHour = 3.0;
     private const double EnergyRecoveryPerHour = 2.0;
 
-    /// <summary>Apply time-based decay since last tick.</summary>
+    /// <summary>Apply time-based decay since last tick. Uses fractional accumulation to avoid truncation on short intervals.</summary>
     public static void Tick(BuddyState state)
     {
         var now = DateTime.UtcNow;
         var hours = (now - state.LastTick).TotalHours;
-        if (hours < 0.001) return; // less than ~4 seconds, skip
+        if (hours < 0.001) return;
 
-        state.Hunger = Clamp(state.Hunger - (int)(HungerDecayPerHour * hours));
-        state.Happiness = Clamp(state.Happiness - (int)(HappinessDecayPerHour * hours));
-        state.Energy = Clamp(state.Energy + (int)(EnergyRecoveryPerHour * hours));
+        // Accumulate fractional changes, only apply whole units
+        state.HungerAccum += HungerDecayPerHour * hours;
+        state.HappinessAccum += HappinessDecayPerHour * hours;
+        state.EnergyAccum += EnergyRecoveryPerHour * hours;
+
+        var hungerDrop = (int)state.HungerAccum;
+        var happyDrop = (int)state.HappinessAccum;
+        var energyGain = (int)state.EnergyAccum;
+
+        if (hungerDrop > 0) { state.Hunger = Clamp(state.Hunger - hungerDrop); state.HungerAccum -= hungerDrop; }
+        if (happyDrop > 0) { state.Happiness = Clamp(state.Happiness - happyDrop); state.HappinessAccum -= happyDrop; }
+        if (energyGain > 0) { state.Energy = Clamp(state.Energy + energyGain); state.EnergyAccum -= energyGain; }
+
         state.LastTick = now;
     }
 
@@ -136,9 +152,9 @@ public static class BuddyEngine
             case BuddyAction.Feed:
             {
                 var sinceFed = (now - state.LastFed).TotalMinutes;
-                state.LastFed = now;
                 if (sinceFed < 5 && state.Hunger > 70)
                     return "cooldown_feed";
+                state.LastFed = now;
                 state.Hunger = Clamp(state.Hunger + 25);
                 state.XP += 1; state.TotalXP += 1;
                 return "feed";
@@ -146,11 +162,11 @@ public static class BuddyEngine
             case BuddyAction.Play:
             {
                 var sincePlayed = (now - state.LastPlayed).TotalMinutes;
-                state.LastPlayed = now;
                 if (state.Energy < 10)
                     return "too_tired";
                 if (sincePlayed < 3 && state.Happiness > 80)
                     return "cooldown_play";
+                state.LastPlayed = now;
                 state.Happiness = Clamp(state.Happiness + 20);
                 state.Energy = Clamp(state.Energy - 10);
                 state.XP += 2; state.TotalXP += 2;
@@ -587,6 +603,7 @@ public sealed class BuddyService
     private readonly string _buddyDir;
     private readonly IChatClient _chatClient;
     private readonly object _lock = new();
+    private readonly SemaphoreSlim _saveLock = new(1, 1);
     private Buddy? _buddy;
     private BuddyState? _state;
     private string? _userId;
@@ -797,7 +814,6 @@ public sealed class BuddyService
         var stored = new StoredBuddy { Name = buddy.Name, Personality = buddy.Personality, HatchedAt = buddy.HatchedAt };
         var json = JsonSerializer.Serialize(stored, new JsonSerializerOptions { WriteIndented = true });
         Directory.CreateDirectory(_buddyDir);
-        var tmp = StatePath + ".tmp";
         await File.WriteAllTextAsync(SoulPath, json, ct);
     }
 
@@ -817,15 +833,18 @@ public sealed class BuddyService
         BuddyState? snapshot;
         lock (_lock) { snapshot = _state?.Clone(); }
         if (snapshot == null) return;
+
+        await _saveLock.WaitAsync();
         try
         {
             var json = JsonSerializer.Serialize(snapshot, new JsonSerializerOptions { WriteIndented = true });
             Directory.CreateDirectory(_buddyDir);
-            var tmp = StatePath + ".tmp";
+            var tmp = Path.Combine(_buddyDir, $"buddy_state_{Guid.NewGuid():N}.tmp");
             await File.WriteAllTextAsync(tmp, json);
             File.Move(tmp, StatePath, overwrite: true);
         }
         catch { /* swallow I/O errors from save */ }
+        finally { _saveLock.Release(); }
     }
 }
 

--- a/src/buddy/buddy.cs
+++ b/src/buddy/buddy.cs
@@ -145,6 +145,7 @@ public static class BuddyEngine
     public static string Interact(BuddyState state, BuddyAction action, BuddyStats buddyStats)
     {
         var now = DateTime.UtcNow;
+        // Set before switch: even rejected attempts count as "user was here" for idle detection
         state.LastInteraction = now;
 
         switch (action)

--- a/src/permissions/permissionmanager.cs
+++ b/src/permissions/permissionmanager.cs
@@ -147,14 +147,22 @@ public sealed class PermissionManager
     private bool IsReadOnlyBashCommand(string command)
     {
         // Read-only commands
+        // Only allow clearly read-only commands — no redirects, pipes to destructive cmds
         var readOnlyPrefixes = new[] {
-            "git ", "ls ", "dir ", "cat ", "head ", "tail ", "grep ", "rg ", "find ",
-            "pwd ", "echo ", "type ", "where ", "which ", "wc ", "du ", "df ",
+            "ls ", "dir ", "cat ", "head ", "tail ", "grep ", "rg ", "find ",
+            "pwd", "echo ", "type ", "where ", "which ", "wc ", "du ", "df ",
             "dotnet --", "dotnet list", "node --", "python --version",
             "Get-ChildItem", "Get-Content", "Get-Item", "Get-Process",
-            "Test-Path", "Resolve-Path"
+            "Test-Path", "Resolve-Path",
+            // Git read-only subcommands only
+            "git status", "git log", "git diff", "git show", "git branch",
+            "git remote", "git tag", "git describe", "git rev-parse",
         };
-        return readOnlyPrefixes.Any(p => command.StartsWith(p, StringComparison.OrdinalIgnoreCase));
+        if (!readOnlyPrefixes.Any(p => command.StartsWith(p, StringComparison.OrdinalIgnoreCase)))
+            return false;
+        // Reject if command contains shell operators that could chain destructive ops
+        var dangerousOperators = new[] { ">", "|", "&&", "||", ";", "`" };
+        return !dangerousOperators.Any(op => command.Contains(op));
     }
     
     private bool IsInWorkspace<T>(T input)

--- a/src/permissions/permissionmanager.cs
+++ b/src/permissions/permissionmanager.cs
@@ -130,7 +130,7 @@ public sealed class PermissionManager
     private bool IsReadOnlyTool<T>(string toolName, T input)
     {
         // Read-only tools
-        var readOnlyTools = new[] { "read_file", "glob", "grep", "ls", "task_get", "task_list" };
+        var readOnlyTools = new[] { "read_file", "glob", "grep", "ls", "task_get", "task_list", "terminal", "web_search", "web_fetch", "todo_write", "ask_user", "schedule_cron" };
         
         if (readOnlyTools.Contains(toolName))
             return true;
@@ -147,7 +147,13 @@ public sealed class PermissionManager
     private bool IsReadOnlyBashCommand(string command)
     {
         // Read-only commands
-        var readOnlyPrefixes = new[] { "git ", "ls ", "cat ", "head ", "tail ", "grep ", "rg ", "find ", "pwd ", "echo " };
+        var readOnlyPrefixes = new[] {
+            "git ", "ls ", "dir ", "cat ", "head ", "tail ", "grep ", "rg ", "find ",
+            "pwd ", "echo ", "type ", "where ", "which ", "wc ", "du ", "df ",
+            "dotnet --", "dotnet list", "node --", "python --version",
+            "Get-ChildItem", "Get-Content", "Get-Item", "Get-Process",
+            "Test-Path", "Resolve-Path"
+        };
         return readOnlyPrefixes.Any(p => command.StartsWith(p, StringComparison.OrdinalIgnoreCase));
     }
     


### PR DESCRIPTION
## Summary
- **Buddy Tamagotchi system** — 18 species (Duck, Cat, Dragon, Ghost, Robot, Axolotl, etc.) with 3-frame idle animations at 500ms tick rate. First-time users get a selection gallery to pick their species and name it. Tamagotchi needs (Hunger/Happiness/Energy) with time-based decay, 4 interactions (Feed/Play/Train/Pet), XP/leveling, mood engine driving ASCII art expressions, quote system, and passive XP from agent tool calls
- **Ollama model picker** — "Custom/Local" renamed to "Ollama (Local)". Settings page dynamically fetches installed models from Ollama API (`/api/tags`) with file sizes and context windows. Partial name matching for config selection. Legacy provider mapping preserved
- **Auto-permissions** — switched from Default (ask everything) to Auto mode. Read-only tools (read_file, glob, grep, terminal, web_search, etc.) auto-approved silently. Write operations still require user approval. No more popups for basic filesystem browsing
- **English language enforcement** — system prompt now includes "Always respond in English" to prevent Chinese-default models (GLM-5) from responding in Chinese
- **Skills page** — re-applied the card layout with category chips that was accidentally reverted

## Files Changed (12)
- `src/buddy/buddy.cs` — BuddyState, BuddyMood, BuddyEngine, BuddyQuotes, mood renderer, selection support, state persistence, auto-migration
- `src/buddy/BuddySprites.cs` — **NEW** — 18 species x 3 frames ASCII art, hat overlays, mood eyes, idle sequence
- `Desktop/Views/BuddyPage.xaml` + `.cs` — selection gallery + interactive buddy view with animation timer
- `Desktop/Views/SettingsPage.xaml` + `.cs` — Ollama provider, dynamic model fetching
- `Desktop/Views/SkillsPage.xaml` + `.cs` — restored card layout with categories
- `src/LLM/ModelCatalog.cs` — Ollama provider, FetchOllamaModelsAsync
- `src/Core/SystemPrompts.cs` — English language instruction
- `src/permissions/permissionmanager.cs` — expanded read-only tool/command lists
- `Desktop/App.xaml.cs` — Auto permission mode, AlwaysAllow rules, buddy activity wiring

## Test plan
- [ ] Buddy page shows selection gallery on first visit (delete buddy.json to test)
- [ ] Selecting a species highlights it, naming + "Hatch!" creates the buddy
- [ ] Buddy animates with 500ms idle fidgets and blinks
- [ ] Feed/Play/Train/Pet buttons work with quote responses and cooldowns
- [ ] Needs bars decay over time (visible after ~1 min)
- [ ] Level up triggers when XP reaches threshold
- [ ] Settings shows "Ollama (Local)" and lists installed models with sizes
- [ ] Context window updates when selecting different models
- [ ] No permission dialogs for read_file, glob, grep, terminal, web_search
- [ ] Write operations still show permission dialog
- [ ] Agent responds in English with GLM-5 or other Chinese models

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes default permission behavior (auto-approving more tools/commands) and introduces new stateful Buddy persistence/timers that could affect UX and disk I/O if buggy.
> 
> **Overview**
> Adds a full **Tamagotchi-style Buddy** loop: first-run species/name selection, animated ASCII rendering driven by mood, needs decay/ticking, interactions (feed/play/train/pet), XP/leveling, and persistence/migration for buddy soul + state; agent activity now passively feeds buddy XP via `WireBuddyActivity`.
> 
> Improves **local model configuration** by renaming the local provider to `ollama`, dynamically fetching installed models from Ollama (`/api/tags`) for the Settings picker (with matching/auto-selection), and updates the system prompt to default to English output.
> 
> Switches permissions to **Auto mode** and expands the read-only allowlist/heuristics (incl. `terminal`, web tools, and stricter “read-only” bash detection), plus minor UI polish/accessibility updates across Integrations/Sessions/Tasks/Skills (sorting + category chips + richer preview metadata).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 440225e60b1958c015c610b5d5f0ca2a150fe689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive buddy system with species selection, naming, mood, needs, XP/leveling, actions (Feed/Play/Train/Pet) and session activity integration
  * Local Ollama model support with automatic model discovery

* **Improvements**
  * Animated buddy visuals, emoji/mood, quote responses, and persistent buddy state
  * Expanded permission heuristics and “always respond in English” default

* **UI Updates**
  * Redesigned Buddy, Skills, and Settings pages; improved filtering, layout, and accessibility tweaks (button styles, labels)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->