### PR TITLE
[codex] add oauth proxy auth support

### DIFF
--- a/Desktop/HermesDesktop.Tests/LLM/OpenAiClientAuthTests.cs
+++ b/Desktop/HermesDesktop.Tests/LLM/OpenAiClientAuthTests.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using Hermes.Agent.Core;
+using Hermes.Agent.LLM;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HermesDesktop.Tests.LLM;
+
+[TestClass]
+public class OpenAiClientAuthTests
+{
+    [TestMethod]
+    public async Task CompleteAsync_UsesEnvBackedOAuthProxyHeader()
+    {
+        const string envVarName = "HERMES_TEST_PROXY_TOKEN";
+        Environment.SetEnvironmentVariable(envVarName, "oauth-token");
+
+        try
+        {
+            HttpRequestMessage? capturedRequest = null;
+            using var httpClient = new HttpClient(new CaptureHandler(request =>
+            {
+                capturedRequest = request;
+                return CreateSuccessResponse();
+            }));
+
+            var client = new OpenAiClient(
+                new LlmConfig
+                {
+                    Provider = "openai",
+                    Model = "gpt-5.4",
+                    BaseUrl = "https://proxy.example/v1",
+                    AuthMode = "oauth_proxy_env",
+                    AuthHeader = "Authorization",
+                    AuthScheme = "Bearer",
+                    AuthTokenEnv = envVarName
+                },
+                httpClient);
+
+            var result = await client.CompleteAsync(
+                new[] { new Message { Role = "user", Content = "hello" } },
+                CancellationToken.None);
+
+            Assert.AreEqual("ok", result);
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual("Bearer oauth-token", capturedRequest!.Headers.Authorization!.ToString());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envVarName, null);
+        }
+    }
+
+    [TestMethod]
+    public async Task CompleteAsync_UsesCommandBackedOAuthProxyCustomHeader()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        using var httpClient = new HttpClient(new CaptureHandler(request =>
+        {
+            capturedRequest = request;
+            return CreateSuccessResponse();
+        }));
+
+        var client = new OpenAiClient(
+            new LlmConfig
+            {
+                Provider = "openai",
+                Model = "gpt-5.4",
+                BaseUrl = "https://proxy.example/v1",
+                AuthMode = "oauth_proxy_command",
+                AuthHeader = "X-Proxy-Auth",
+                AuthScheme = "",
+                AuthTokenCommand = "echo cmd-token"
+            },
+            httpClient);
+
+        var result = await client.CompleteAsync(
+            new[] { new Message { Role = "user", Content = "hello" } },
+            CancellationToken.None);
+
+        Assert.AreEqual("ok", result);
+        Assert.IsNotNull(capturedRequest);
+        Assert.IsTrue(capturedRequest!.Headers.TryGetValues("X-Proxy-Auth", out var headerValues));
+        CollectionAssert.AreEqual(new[] { "cmd-token" }, headerValues!.ToArray());
+        Assert.IsNull(capturedRequest.Headers.Authorization);
+    }
+
+    private static HttpResponseMessage CreateSuccessResponse()
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                """
+                {"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}
+                """,
+                Encoding.UTF8,
+                "application/json")
+        };
+    }
+
+    private sealed class CaptureHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(responseFactory(request));
+        }
+    }
+}

--- a/Desktop/HermesDesktop/Services/HermesEnvironment.cs
+++ b/Desktop/HermesDesktop/Services/HermesEnvironment.cs
@@ -54,6 +54,7 @@ internal static class HermesEnvironment
         AuthMode = ModelAuthMode,
         AuthHeader = ModelAuthHeader,
         AuthScheme = ModelAuthScheme,
+        ApiKeyEnv = ModelApiKeyEnv,
         AuthTokenEnv = ModelAuthTokenEnv,
         AuthTokenCommand = ModelAuthTokenCommand
     };
@@ -449,6 +450,8 @@ internal static class HermesEnvironment
 
     internal static string? ModelApiKey => ReadModelSetting("api_key");
 
+    internal static string? ModelApiKeyEnv => ReadModelSetting("api_key_env");
+
     internal static string ModelAuthMode => ReadModelSetting("auth_mode") ?? "api_key";
 
     internal static string ModelAuthHeader => ReadModelSetting("auth_header") ?? "Authorization";
@@ -573,6 +576,7 @@ internal static class HermesEnvironment
         string baseUrl,
         string model,
         string apiKey,
+        string apiKeyEnv,
         string authMode,
         string authHeader,
         string authScheme,
@@ -595,6 +599,10 @@ internal static class HermesEnvironment
         if (!string.IsNullOrWhiteSpace(apiKey) &&
             string.Equals(authMode, "api_key", StringComparison.OrdinalIgnoreCase))
             settings["api_key"] = apiKey;
+
+        if (string.Equals(authMode, "api_key_env", StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrWhiteSpace(apiKeyEnv))
+            settings["api_key_env"] = apiKeyEnv;
 
         if (string.Equals(authMode, "oauth_proxy_env", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(authMode, "oauth_proxy_command", StringComparison.OrdinalIgnoreCase))

--- a/Desktop/HermesDesktop/Services/HermesEnvironment.cs
+++ b/Desktop/HermesDesktop/Services/HermesEnvironment.cs
@@ -50,7 +50,12 @@ internal static class HermesEnvironment
         Provider = ModelProvider,
         Model = DefaultModel,
         BaseUrl = ModelBaseUrl,
-        ApiKey = ModelApiKey ?? ""
+        ApiKey = ModelApiKey ?? "",
+        AuthMode = ModelAuthMode,
+        AuthHeader = ModelAuthHeader,
+        AuthScheme = ModelAuthScheme,
+        AuthTokenEnv = ModelAuthTokenEnv,
+        AuthTokenCommand = ModelAuthTokenCommand
     };
 
     /// <summary>
@@ -444,6 +449,16 @@ internal static class HermesEnvironment
 
     internal static string? ModelApiKey => ReadModelSetting("api_key");
 
+    internal static string ModelAuthMode => ReadModelSetting("auth_mode") ?? "api_key";
+
+    internal static string ModelAuthHeader => ReadModelSetting("auth_header") ?? "Authorization";
+
+    internal static string ModelAuthScheme => ReadModelSetting("auth_scheme") ?? "Bearer";
+
+    internal static string? ModelAuthTokenEnv => ReadModelSetting("auth_token_env");
+
+    internal static string? ModelAuthTokenCommand => ReadModelSetting("auth_token_command");
+
     internal static string AgentWorkingDirectory
     {
         get
@@ -553,7 +568,16 @@ internal static class HermesEnvironment
     }
 
     /// <summary>Write model configuration to config.yaml.</summary>
-    internal static async Task SaveModelConfigAsync(string provider, string baseUrl, string model, string apiKey)
+    internal static async Task SaveModelConfigAsync(
+        string provider,
+        string baseUrl,
+        string model,
+        string apiKey,
+        string authMode,
+        string authHeader,
+        string authScheme,
+        string authTokenEnv,
+        string authTokenCommand)
     {
         var configPath = HermesConfigPath;
         var dir = Path.GetDirectoryName(configPath);
@@ -565,10 +589,34 @@ internal static class HermesEnvironment
             ["provider"] = provider,
             ["base_url"] = baseUrl,
             ["default"] = model,
+            ["auth_mode"] = authMode,
         };
 
-        if (!string.IsNullOrWhiteSpace(apiKey))
+        if (!string.IsNullOrWhiteSpace(apiKey) &&
+            string.Equals(authMode, "api_key", StringComparison.OrdinalIgnoreCase))
             settings["api_key"] = apiKey;
+
+        if (string.Equals(authMode, "oauth_proxy_env", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(authMode, "oauth_proxy_command", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!string.IsNullOrWhiteSpace(authHeader))
+                settings["auth_header"] = authHeader;
+
+            if (authScheme is not null)
+                settings["auth_scheme"] = authScheme;
+        }
+
+        if (string.Equals(authMode, "oauth_proxy_env", StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrWhiteSpace(authTokenEnv))
+        {
+            settings["auth_token_env"] = authTokenEnv;
+        }
+
+        if (string.Equals(authMode, "oauth_proxy_command", StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrWhiteSpace(authTokenCommand))
+        {
+            settings["auth_token_command"] = authTokenCommand;
+        }
 
         await WriteYamlSectionAsync(configPath, "model", settings);
     }

--- a/Desktop/HermesDesktop/Views/SettingsPage.xaml
+++ b/Desktop/HermesDesktop/Views/SettingsPage.xaml
@@ -49,6 +49,7 @@
                                           SelectionChanged="ProviderCombo_SelectionChanged">
                                     <ComboBoxItem Content="Nous (OpenRouter)" Tag="nous"/>
                                     <ComboBoxItem Content="OpenAI" Tag="openai"/>
+                                    <ComboBoxItem Content="Google Gemini" Tag="google"/>
                                     <ComboBoxItem Content="Anthropic" Tag="anthropic"/>
                                     <ComboBoxItem Content="Qwen (Alibaba)" Tag="qwen"/>
                                     <ComboBoxItem Content="DeepSeek" Tag="deepseek"/>
@@ -99,10 +100,19 @@
                                           BorderBrush="{StaticResource AppStrokeBrush}"
                                           SelectionChanged="AuthModeCombo_SelectionChanged">
                                     <ComboBoxItem Content="API Key" Tag="api_key"/>
+                                    <ComboBoxItem Content="API Key (Env Var)" Tag="api_key_env"/>
                                     <ComboBoxItem Content="OAuth Proxy (Env Token)" Tag="oauth_proxy_env"/>
                                     <ComboBoxItem Content="OAuth Proxy (Command Token)" Tag="oauth_proxy_command"/>
                                     <ComboBoxItem Content="No Auth Header" Tag="none"/>
                                 </ComboBox>
+                            </StackPanel>
+
+                            <StackPanel Spacing="4">
+                                <TextBlock Text="API KEY ENV VAR" Style="{StaticResource LabelTextStyle}"/>
+                                <TextBox x:Name="ApiKeyEnvBox" PlaceholderText="GOOGLE_API_KEY"
+                                         Background="{StaticResource AppInsetBrush}"
+                                         BorderBrush="{StaticResource AppStrokeBrush}"
+                                         Foreground="White"/>
                             </StackPanel>
 
                             <Grid ColumnSpacing="12">

--- a/Desktop/HermesDesktop/Views/SettingsPage.xaml
+++ b/Desktop/HermesDesktop/Views/SettingsPage.xaml
@@ -92,6 +92,63 @@
                                              Foreground="White"/>
                             </StackPanel>
 
+                            <StackPanel Spacing="4">
+                                <TextBlock Text="AUTH MODE" Style="{StaticResource LabelTextStyle}"/>
+                                <ComboBox x:Name="AuthModeCombo" HorizontalAlignment="Stretch"
+                                          Background="{StaticResource AppInsetBrush}"
+                                          BorderBrush="{StaticResource AppStrokeBrush}"
+                                          SelectionChanged="AuthModeCombo_SelectionChanged">
+                                    <ComboBoxItem Content="API Key" Tag="api_key"/>
+                                    <ComboBoxItem Content="OAuth Proxy (Env Token)" Tag="oauth_proxy_env"/>
+                                    <ComboBoxItem Content="OAuth Proxy (Command Token)" Tag="oauth_proxy_command"/>
+                                    <ComboBoxItem Content="No Auth Header" Tag="none"/>
+                                </ComboBox>
+                            </StackPanel>
+
+                            <Grid ColumnSpacing="12">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+
+                                <StackPanel Grid.Column="0" Spacing="4">
+                                    <TextBlock Text="AUTH HEADER" Style="{StaticResource LabelTextStyle}"/>
+                                    <TextBox x:Name="AuthHeaderBox" PlaceholderText="Authorization"
+                                             Background="{StaticResource AppInsetBrush}"
+                                             BorderBrush="{StaticResource AppStrokeBrush}"
+                                             Foreground="White"/>
+                                </StackPanel>
+
+                                <StackPanel Grid.Column="1" Spacing="4">
+                                    <TextBlock Text="AUTH SCHEME" Style="{StaticResource LabelTextStyle}"/>
+                                    <TextBox x:Name="AuthSchemeBox" PlaceholderText="Bearer"
+                                             Background="{StaticResource AppInsetBrush}"
+                                             BorderBrush="{StaticResource AppStrokeBrush}"
+                                             Foreground="White"/>
+                                </StackPanel>
+                            </Grid>
+
+                            <StackPanel Spacing="4">
+                                <TextBlock Text="TOKEN ENV VAR" Style="{StaticResource LabelTextStyle}"/>
+                                <TextBox x:Name="AuthTokenEnvBox" PlaceholderText="OPENAI_OAUTH_ACCESS_TOKEN"
+                                         Background="{StaticResource AppInsetBrush}"
+                                         BorderBrush="{StaticResource AppStrokeBrush}"
+                                         Foreground="White"/>
+                            </StackPanel>
+
+                            <StackPanel Spacing="4">
+                                <TextBlock Text="TOKEN COMMAND" Style="{StaticResource LabelTextStyle}"/>
+                                <TextBox x:Name="AuthTokenCommandBox" PlaceholderText="oauth-proxy-helper print-access-token"
+                                         Background="{StaticResource AppInsetBrush}"
+                                         BorderBrush="{StaticResource AppStrokeBrush}"
+                                         Foreground="White"/>
+                            </StackPanel>
+
+                            <TextBlock Text="OAuth proxy modes let Hermes fetch a short-lived token from an environment variable or refresh command and attach it to an OpenAI-compatible proxy request."
+                                       TextWrapping="Wrap"
+                                       Foreground="{StaticResource AppTextSecondaryBrush}"
+                                       FontSize="12"/>
+
                             <!-- Save + Feedback -->
                             <StackPanel Orientation="Horizontal" Spacing="12">
                                 <Button x:Name="SaveModelBtn" Content="Save Model Config" Click="SaveModelConfig_Click"

--- a/Desktop/HermesDesktop/Views/SettingsPage.xaml.cs
+++ b/Desktop/HermesDesktop/Views/SettingsPage.xaml.cs
@@ -40,27 +40,20 @@ public sealed partial class SettingsPage : Page
     {
         // Pre-populate fields from current config
         var provider = HermesEnvironment.ModelProvider.ToLowerInvariant();
-        var matchIndex = 6; // default to "local"
-        for (int i = 0; i < ProviderCombo.Items.Count; i++)
-        {
-            if (ProviderCombo.Items[i] is ComboBoxItem item &&
-                string.Equals(item.Tag?.ToString(), provider, StringComparison.OrdinalIgnoreCase))
-            {
-                matchIndex = i;
-                break;
-            }
-        }
-        // Handle legacy "custom" tag mapping to "local"
-        if (provider == "custom")
-            matchIndex = 6;
-
-        ProviderCombo.SelectedIndex = matchIndex;
+        var normalizedProvider = provider == "custom" ? "local" : provider;
+        SelectComboByTag(ProviderCombo, normalizedProvider, fallbackIndex: 6);
 
         BaseUrlBox.Text = HermesEnvironment.ModelBaseUrl;
         ModelBox.Text = HermesEnvironment.DefaultModel;
         ApiKeyBox.Password = HermesEnvironment.ModelApiKey ?? "";
+        AuthHeaderBox.Text = HermesEnvironment.ModelAuthHeader;
+        AuthSchemeBox.Text = HermesEnvironment.ModelAuthScheme;
+        AuthTokenEnvBox.Text = HermesEnvironment.ModelAuthTokenEnv ?? "";
+        AuthTokenCommandBox.Text = HermesEnvironment.ModelAuthTokenCommand ?? "";
+        SelectComboByTag(AuthModeCombo, HermesEnvironment.ModelAuthMode, fallbackIndex: 0);
+        UpdateAuthFieldState(HermesEnvironment.ModelAuthMode);
 
-        PopulateModelCombo(provider);
+        PopulateModelCombo(normalizedProvider);
         SelectCurrentModel(HermesEnvironment.DefaultModel);
     }
 
@@ -133,6 +126,12 @@ public sealed partial class SettingsPage : Page
         }
     }
 
+    private void AuthModeCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        var authMode = (AuthModeCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "api_key";
+        UpdateAuthFieldState(authMode);
+    }
+
     private async void SaveModelConfig_Click(object sender, RoutedEventArgs e)
     {
         try
@@ -141,6 +140,11 @@ public sealed partial class SettingsPage : Page
             var baseUrl = BaseUrlBox.Text.Trim();
             var model = ModelBox.Text.Trim();
             var apiKey = ApiKeyBox.Password.Trim();
+            var authMode = (AuthModeCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "api_key";
+            var authHeader = AuthHeaderBox.Text.Trim();
+            var authScheme = AuthSchemeBox.Text.Trim();
+            var authTokenEnv = AuthTokenEnvBox.Text.Trim();
+            var authTokenCommand = AuthTokenCommandBox.Text.Trim();
 
             if (string.IsNullOrEmpty(model))
             {
@@ -149,7 +153,30 @@ public sealed partial class SettingsPage : Page
                 return;
             }
 
-            await HermesEnvironment.SaveModelConfigAsync(providerTag, baseUrl, model, apiKey);
+            if (authMode == "oauth_proxy_env" && string.IsNullOrWhiteSpace(authTokenEnv))
+            {
+                ModelSaveStatus.Text = "Token env var is required for OAuth Proxy (Env Token).";
+                ModelSaveStatus.Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["ConnectionOfflineBrush"];
+                return;
+            }
+
+            if (authMode == "oauth_proxy_command" && string.IsNullOrWhiteSpace(authTokenCommand))
+            {
+                ModelSaveStatus.Text = "Token command is required for OAuth Proxy (Command Token).";
+                ModelSaveStatus.Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["ConnectionOfflineBrush"];
+                return;
+            }
+
+            await HermesEnvironment.SaveModelConfigAsync(
+                providerTag,
+                baseUrl,
+                model,
+                apiKey,
+                authMode,
+                authHeader,
+                authScheme,
+                authTokenEnv,
+                authTokenCommand);
             ModelSaveStatus.Text = "Saved successfully. Restart to apply.";
             ModelSaveStatus.Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["ConnectionOnlineBrush"];
         }
@@ -178,5 +205,32 @@ public sealed partial class SettingsPage : Page
     private void OpenWorkspace_Click(object sender, RoutedEventArgs e)
     {
         HermesEnvironment.OpenWorkspace();
+    }
+
+    private static void SelectComboByTag(ComboBox combo, string? tag, int fallbackIndex)
+    {
+        for (int i = 0; i < combo.Items.Count; i++)
+        {
+            if (combo.Items[i] is ComboBoxItem item &&
+                string.Equals(item.Tag?.ToString(), tag, StringComparison.OrdinalIgnoreCase))
+            {
+                combo.SelectedIndex = i;
+                return;
+            }
+        }
+
+        combo.SelectedIndex = fallbackIndex;
+    }
+
+    private void UpdateAuthFieldState(string? authMode)
+    {
+        var mode = (authMode ?? "api_key").ToLowerInvariant();
+        var usesProxyToken = mode is "oauth_proxy_env" or "oauth_proxy_command";
+
+        ApiKeyBox.IsEnabled = mode == "api_key";
+        AuthHeaderBox.IsEnabled = usesProxyToken;
+        AuthSchemeBox.IsEnabled = usesProxyToken;
+        AuthTokenEnvBox.IsEnabled = mode == "oauth_proxy_env";
+        AuthTokenCommandBox.IsEnabled = mode == "oauth_proxy_command";
     }
 }

--- a/Desktop/HermesDesktop/Views/SettingsPage.xaml.cs
+++ b/Desktop/HermesDesktop/Views/SettingsPage.xaml.cs
@@ -46,6 +46,7 @@ public sealed partial class SettingsPage : Page
         BaseUrlBox.Text = HermesEnvironment.ModelBaseUrl;
         ModelBox.Text = HermesEnvironment.DefaultModel;
         ApiKeyBox.Password = HermesEnvironment.ModelApiKey ?? "";
+        ApiKeyEnvBox.Text = HermesEnvironment.ModelApiKeyEnv ?? "";
         AuthHeaderBox.Text = HermesEnvironment.ModelAuthHeader;
         AuthSchemeBox.Text = HermesEnvironment.ModelAuthScheme;
         AuthTokenEnvBox.Text = HermesEnvironment.ModelAuthTokenEnv ?? "";
@@ -140,6 +141,7 @@ public sealed partial class SettingsPage : Page
             var baseUrl = BaseUrlBox.Text.Trim();
             var model = ModelBox.Text.Trim();
             var apiKey = ApiKeyBox.Password.Trim();
+            var apiKeyEnv = ApiKeyEnvBox.Text.Trim();
             var authMode = (AuthModeCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "api_key";
             var authHeader = AuthHeaderBox.Text.Trim();
             var authScheme = AuthSchemeBox.Text.Trim();
@@ -149,6 +151,13 @@ public sealed partial class SettingsPage : Page
             if (string.IsNullOrEmpty(model))
             {
                 ModelSaveStatus.Text = "Model name is required.";
+                ModelSaveStatus.Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["ConnectionOfflineBrush"];
+                return;
+            }
+
+            if (authMode == "api_key_env" && string.IsNullOrWhiteSpace(apiKeyEnv))
+            {
+                ModelSaveStatus.Text = "API key env var is required for API Key (Env Var).";
                 ModelSaveStatus.Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["ConnectionOfflineBrush"];
                 return;
             }
@@ -172,6 +181,7 @@ public sealed partial class SettingsPage : Page
                 baseUrl,
                 model,
                 apiKey,
+                apiKeyEnv,
                 authMode,
                 authHeader,
                 authScheme,
@@ -228,6 +238,7 @@ public sealed partial class SettingsPage : Page
         var usesProxyToken = mode is "oauth_proxy_env" or "oauth_proxy_command";
 
         ApiKeyBox.IsEnabled = mode == "api_key";
+        ApiKeyEnvBox.IsEnabled = mode == "api_key_env";
         AuthHeaderBox.IsEnabled = usesProxyToken;
         AuthSchemeBox.IsEnabled = usesProxyToken;
         AuthTokenEnvBox.IsEnabled = mode == "oauth_proxy_env";

--- a/readme.md
+++ b/readme.md
@@ -173,17 +173,21 @@ Add-AppxPackage -Register AppxManifest.xml
 Create `%LOCALAPPDATA%\hermes\config.yaml`:
 
 ```yaml
-llm:
+model:
   provider: openai
-  model: minimax-m2.7:cloud
-  baseUrl: http://localhost:11434/v1
-  apiKey: ""
+  base_url: https://api.openai.com/v1
+  default: gpt-5.4
+  api_key: sk-your-key-here
 
-# Or use a cloud provider
-# llm:
-#   provider: anthropic
-#   model: claude-sonnet-4-20250514
-#   apiKey: sk-your-key-here
+# Or point Hermes at an OpenAI-compatible OAuth proxy
+# model:
+#   provider: openai
+#   base_url: https://your-proxy.example/v1
+#   default: gpt-5.4
+#   auth_mode: oauth_proxy_command
+#   auth_header: Authorization
+#   auth_scheme: Bearer
+#   auth_token_command: oauth-proxy-helper print-access-token
 
 messaging:
   telegram:

--- a/src/LLM/ModelCatalog.cs
+++ b/src/LLM/ModelCatalog.cs
@@ -52,6 +52,18 @@ public static class ModelCatalog
                 new("gpt-4o-mini",        "GPT-4o Mini",         128_000),
             },
 
+            ["google"] = new ModelEntry[]
+            {
+                new("models/gemini-3.1-pro-preview",             "Gemini 3.1 Pro Preview",              1_048_576),
+                new("models/gemini-3.1-pro-preview-customtools", "Gemini 3.1 Pro Preview Custom Tools", 1_048_576),
+                new("models/gemini-3.1-flash-lite-preview",      "Gemini 3.1 Flash Lite Preview",       1_048_576),
+                new("models/gemini-3-pro-preview",               "Gemini 3 Pro Preview",                1_048_576),
+                new("models/gemini-3-flash-preview",             "Gemini 3 Flash Preview",              1_048_576),
+                new("models/gemini-2.5-pro",                     "Gemini 2.5 Pro",                      1_048_576),
+                new("models/gemini-2.5-flash",                   "Gemini 2.5 Flash",                    1_048_576),
+                new("models/gemini-pro-latest",                  "Gemini Pro Latest",                   1_048_576),
+            },
+
             ["anthropic"] = new ModelEntry[]
             {
                 new("claude-opus-4-6",              "Claude Opus 4.6",             1_000_000),
@@ -124,7 +136,7 @@ public static class ModelCatalog
     /// <summary>All known provider names.</summary>
     public static IReadOnlyList<string> Providers { get; } = new[]
     {
-        "nous", "openai", "anthropic", "qwen", "deepseek", "minimax", "openrouter", "local"
+        "nous", "openai", "google", "anthropic", "qwen", "deepseek", "minimax", "openrouter", "local"
     };
 
     /// <summary>Default base URLs for known providers.</summary>
@@ -132,6 +144,7 @@ public static class ModelCatalog
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             ["openai"]     = "https://api.openai.com/v1",
+            ["google"]     = "https://generativelanguage.googleapis.com/v1beta/openai",
             ["anthropic"]  = "https://api.anthropic.com",
             ["qwen"]       = "https://dashscope.aliyuncs.com/compatible-mode/v1",
             ["deepseek"]   = "https://api.deepseek.com/v1",

--- a/src/LLM/ichatclient.cs
+++ b/src/LLM/ichatclient.cs
@@ -32,6 +32,11 @@ public sealed class LlmConfig
     public required string Model { get; init; }
     public string? BaseUrl { get; init; }
     public string? ApiKey { get; init; }
+    public string? AuthMode { get; init; }
+    public string? AuthHeader { get; init; }
+    public string? AuthScheme { get; init; }
+    public string? AuthTokenEnv { get; init; }
+    public string? AuthTokenCommand { get; init; }
     public double Temperature { get; init; } = 0.7;
     public int MaxTokens { get; init; } = 4096;
 }

--- a/src/LLM/ichatclient.cs
+++ b/src/LLM/ichatclient.cs
@@ -35,6 +35,7 @@ public sealed class LlmConfig
     public string? AuthMode { get; init; }
     public string? AuthHeader { get; init; }
     public string? AuthScheme { get; init; }
+    public string? ApiKeyEnv { get; init; }
     public string? AuthTokenEnv { get; init; }
     public string? AuthTokenCommand { get; init; }
     public double Temperature { get; init; } = 0.7;

--- a/src/LLM/openaiclient.cs
+++ b/src/LLM/openaiclient.cs
@@ -246,6 +246,20 @@ public sealed class OpenAiClient : IChatClient
                     AddHeader(request, "Authorization", "Bearer", _config.ApiKey.Trim());
                 return;
 
+            case "api_key_env":
+            {
+                var envName = _config.ApiKeyEnv?.Trim();
+                if (string.IsNullOrWhiteSpace(envName))
+                    throw new InvalidOperationException("model.api_key_env is required for auth_mode=api_key_env.");
+
+                var apiKey = Environment.GetEnvironmentVariable(envName);
+                if (string.IsNullOrWhiteSpace(apiKey))
+                    throw new InvalidOperationException($"Environment variable '{envName}' is not set for API key auth.");
+
+                AddHeader(request, "Authorization", "Bearer", apiKey.Trim());
+                return;
+            }
+
             case "none":
                 return;
 

--- a/src/LLM/openaiclient.cs
+++ b/src/LLM/openaiclient.cs
@@ -1,6 +1,7 @@
 namespace Hermes.Agent.LLM;
 
 using Hermes.Agent.Core;
+using System.Diagnostics;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -22,12 +23,6 @@ public sealed class OpenAiClient : IChatClient
         _config = config;
         _httpClient = httpClient;
         _credentialPool = credentialPool;
-
-        if (_credentialPool is null && !string.IsNullOrEmpty(config.ApiKey))
-        {
-            _httpClient.DefaultRequestHeaders.Authorization =
-                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", config.ApiKey);
-        }
     }
 
     // ── Simple completion (backwards compatible) ──
@@ -94,10 +89,7 @@ public sealed class OpenAiClient : IChatClient
     {
         var payload = BuildPayload(messages, tools: null, stream: true);
         var json = JsonSerializer.Serialize(payload);
-        using var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.BaseUrl}/chat/completions")
-        {
-            Content = new StringContent(json, Encoding.UTF8, "application/json")
-        };
+        using var request = await CreateRequestAsync($"{_config.BaseUrl}/chat/completions", json, ct);
 
         using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
         response.EnsureSuccessStatusCode();
@@ -185,7 +177,7 @@ public sealed class OpenAiClient : IChatClient
         var url = $"{_config.BaseUrl}/chat/completions";
 
         // If credential pool is available, use it with retry on 401
-        if (_credentialPool is not null && _credentialPool.HasHealthyCredentials)
+        if (UsesApiKeyAuth && _credentialPool is not null && _credentialPool.HasHealthyCredentials)
         {
             const int maxRetries = 3;
             for (int attempt = 0; attempt < maxRetries; attempt++)
@@ -193,13 +185,7 @@ public sealed class OpenAiClient : IChatClient
                 var apiKey = _credentialPool.GetNext();
                 if (apiKey is null) break;
 
-                var request = new HttpRequestMessage(HttpMethod.Post, url)
-                {
-                    Content = new StringContent(json, Encoding.UTF8, "application/json")
-                };
-                request.Headers.Authorization =
-                    new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiKey);
-
+                using var request = await CreateRequestAsync(url, json, ct, apiKey);
                 var response = await _httpClient.SendAsync(request, ct);
                 if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized ||
                     response.StatusCode == System.Net.HttpStatusCode.Forbidden)
@@ -215,10 +201,131 @@ public sealed class OpenAiClient : IChatClient
         }
 
         // Fallback: use default header auth
-        var content = new StringContent(json, Encoding.UTF8, "application/json");
-        var fallbackResponse = await _httpClient.PostAsync(url, content, ct);
+        using var fallbackRequest = await CreateRequestAsync(url, json, ct);
+        var fallbackResponse = await _httpClient.SendAsync(fallbackRequest, ct);
         fallbackResponse.EnsureSuccessStatusCode();
         return fallbackResponse;
+    }
+
+    private bool UsesApiKeyAuth =>
+        string.IsNullOrWhiteSpace(_config.AuthMode) ||
+        string.Equals(_config.AuthMode, "api_key", StringComparison.OrdinalIgnoreCase);
+
+    private async Task<HttpRequestMessage> CreateRequestAsync(
+        string url,
+        string json,
+        CancellationToken ct,
+        string? apiKeyOverride = null)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+
+        await ApplyAuthenticationAsync(request, apiKeyOverride, ct);
+        return request;
+    }
+
+    private async Task ApplyAuthenticationAsync(
+        HttpRequestMessage request,
+        string? apiKeyOverride,
+        CancellationToken ct)
+    {
+        if (!string.IsNullOrWhiteSpace(apiKeyOverride))
+        {
+            AddHeader(request, "Authorization", "Bearer", apiKeyOverride.Trim());
+            return;
+        }
+
+        var authMode = (_config.AuthMode ?? "api_key").Trim().ToLowerInvariant();
+        switch (authMode)
+        {
+            case "":
+            case "api_key":
+                if (!string.IsNullOrWhiteSpace(_config.ApiKey))
+                    AddHeader(request, "Authorization", "Bearer", _config.ApiKey.Trim());
+                return;
+
+            case "none":
+                return;
+
+            case "oauth_proxy_env":
+            {
+                var envName = _config.AuthTokenEnv?.Trim();
+                if (string.IsNullOrWhiteSpace(envName))
+                    throw new InvalidOperationException("model.auth_token_env is required for auth_mode=oauth_proxy_env.");
+
+                var token = Environment.GetEnvironmentVariable(envName);
+                if (string.IsNullOrWhiteSpace(token))
+                    throw new InvalidOperationException($"Environment variable '{envName}' is not set for OAuth proxy auth.");
+
+                AddConfiguredProxyHeader(request, token.Trim());
+                return;
+            }
+
+            case "oauth_proxy_command":
+            {
+                var command = _config.AuthTokenCommand?.Trim();
+                if (string.IsNullOrWhiteSpace(command))
+                    throw new InvalidOperationException("model.auth_token_command is required for auth_mode=oauth_proxy_command.");
+
+                var token = await ExecuteTokenCommandAsync(command, ct);
+                AddConfiguredProxyHeader(request, token);
+                return;
+            }
+
+            default:
+                throw new InvalidOperationException($"Unsupported model.auth_mode '{_config.AuthMode}'.");
+        }
+    }
+
+    private void AddConfiguredProxyHeader(HttpRequestMessage request, string token)
+    {
+        var headerName = string.IsNullOrWhiteSpace(_config.AuthHeader)
+            ? "Authorization"
+            : _config.AuthHeader.Trim();
+        var authScheme = _config.AuthScheme ?? "Bearer";
+        AddHeader(request, headerName, authScheme, token);
+    }
+
+    private static void AddHeader(HttpRequestMessage request, string headerName, string? scheme, string token)
+    {
+        var headerValue = string.IsNullOrWhiteSpace(scheme)
+            ? token
+            : $"{scheme.Trim()} {token}";
+
+        request.Headers.Remove(headerName);
+        request.Headers.TryAddWithoutValidation(headerName, headerValue);
+    }
+
+    private static async Task<string> ExecuteTokenCommandAsync(string command, CancellationToken ct)
+    {
+        var startInfo = OperatingSystem.IsWindows()
+            ? new ProcessStartInfo("cmd.exe", $"/d /s /c \"{command}\"")
+            : new ProcessStartInfo("/bin/sh", $"-lc \"{command.Replace("\"", "\\\"", StringComparison.Ordinal)}\"");
+
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+        startInfo.UseShellExecute = false;
+        startInfo.CreateNoWindow = true;
+
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(ct);
+        var stderrTask = process.StandardError.ReadToEndAsync(ct);
+        await process.WaitForExitAsync(ct);
+
+        var stdout = (await stdoutTask).Trim();
+        var stderr = (await stderrTask).Trim();
+
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException($"OAuth proxy token command failed with exit code {process.ExitCode}: {stderr}");
+
+        if (string.IsNullOrWhiteSpace(stdout))
+            throw new InvalidOperationException("OAuth proxy token command returned an empty token.");
+
+        return stdout;
     }
 
     public async IAsyncEnumerable<StreamEvent> StreamAsync(


### PR DESCRIPTION
## Summary

This PR adds first-class support for OpenAI-compatible OAuth-backed proxies in Hermes Desktop.

## What changed

- added `auth_mode` support for OpenAI-compatible requests
- added env-backed and command-backed token retrieval for short-lived OAuth proxy tokens
- added configurable auth header and auth scheme fields for proxy integrations
- exposed the new auth settings in the Hermes Desktop Settings page
- updated the README configuration example to match the app's actual `model:` schema and documented OAuth proxy usage
- added focused tests covering env-token and command-token auth header behavior

## Why

Hermes previously assumed OpenAI-compatible providers could only be authenticated with a static `api_key`. That made it awkward to use OAuth-backed proxies that mint short-lived access tokens and expect Hermes to forward them as request headers.

## Validation

- `dotnet build`
- `dotnet build Desktop/HermesDesktop/HermesDesktop.csproj`
- `dotnet test Desktop/HermesDesktop.Tests/HermesDesktop.Tests.csproj --filter OpenAiClientAuthTests`

## Notes

The full test suite still has one unrelated pre-existing failing test in this repo:

- `SkillsSearchFilterTests.Filter_MatchingName_ReturnsMatchingSkills`
