### PR TITLE
fix(desktop): address v2.3.1 user feedback (security, UX, bug)

### DIFF
--- a/Desktop/HermesDesktop.Tests/Services/AgentTests.cs
+++ b/Desktop/HermesDesktop.Tests/Services/AgentTests.cs
@@ -1036,6 +1036,134 @@ public class AgentActivityLogTests
             "beta_tool entry should be in ActivityLog");
     }
 
+    // ── PermissionPromptCallback regression tests ──
+    //
+    // These pin the contract that PermissionBehavior.Ask invokes
+    // PermissionPromptCallback with the toolCall.Arguments string as the
+    // third parameter. The PR that added the third argument (audit-the-
+    // command-before-running fix for v2.3.1 user feedback #1) is the only
+    // path through which the desktop UI sees what's about to execute, so a
+    // regression that silently drops the parameter would re-hide command
+    // auditing without any compile error.
+
+    [TestMethod]
+    public async Task PermissionPromptCallback_OnAsk_ReceivesToolNameMessageAndArguments()
+    {
+        // PermissionContext.Mode = Default → CheckPermissionsAsync returns
+        // Ask("Default: requires permission") for every tool that doesn't
+        // match an always_allow / always_deny / always_ask rule. That is the
+        // simplest way to force the Ask path without depending on rule DSL.
+        var permissions = new Hermes.Agent.Permissions.PermissionManager(
+            new Hermes.Agent.Permissions.PermissionContext
+            {
+                Mode = Hermes.Agent.Permissions.PermissionMode.Default
+            },
+            NullLogger<Hermes.Agent.Permissions.PermissionManager>.Instance);
+
+        var agent = new Agent(
+            _mockChatClient.Object,
+            NullLogger<Agent>.Instance,
+            permissions: permissions);
+
+        var tool = CreateMockTool("audited_tool");
+        tool.Setup(t => t.ExecuteAsync(It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ToolResult.Ok("ran"));
+        agent.RegisterTool(tool.Object);
+
+        // The exact arguments string the prompt UI must surface.
+        const string expectedArgs = "{\"command\":\"whoami\"}";
+
+        string? capturedToolName = null;
+        string? capturedMessage = null;
+        string? capturedToolArguments = null;
+        agent.PermissionPromptCallback = (toolName, message, toolArguments) =>
+        {
+            capturedToolName = toolName;
+            capturedMessage = message;
+            capturedToolArguments = toolArguments;
+            return Task.FromResult(true); // allow so the loop completes
+        };
+
+        var toolCall = new ToolCall
+        {
+            Id = "call-audit",
+            Name = "audited_tool",
+            Arguments = expectedArgs
+        };
+        var callSequence = new Queue<ChatResponse>(new[]
+        {
+            new ChatResponse { Content = null, ToolCalls = new List<ToolCall> { toolCall }, FinishReason = "tool_calls" },
+            new ChatResponse { Content = "done", FinishReason = "stop" }
+        });
+
+        _mockChatClient
+            .Setup(c => c.CompleteWithToolsAsync(
+                It.IsAny<IEnumerable<Message>>(),
+                It.IsAny<IEnumerable<ToolDefinition>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => callSequence.Dequeue());
+
+        await agent.ChatAsync("run audited tool", new Session { Id = "audit-sess" }, CancellationToken.None);
+
+        Assert.AreEqual("audited_tool", capturedToolName,
+            "Callback should receive the literal tool name being prompted for.");
+        Assert.IsFalse(string.IsNullOrEmpty(capturedMessage),
+            "Callback should receive a non-empty permission message.");
+        Assert.AreEqual(expectedArgs, capturedToolArguments,
+            "Callback must receive the raw toolCall.Arguments JSON so the UI can " +
+            "show the user the actual command before they approve. Regression in " +
+            "this assertion means the agent stopped forwarding the third parameter " +
+            "and the desktop dialog will silently fall back to hiding the command.");
+    }
+
+    [TestMethod]
+    public async Task PermissionPromptCallback_WhenCallbackDenies_ToolIsNotExecuted()
+    {
+        // Sanity check the deny path — the callback returning false should
+        // skip ExecuteAsync entirely and inject a denial tool message.
+        var permissions = new Hermes.Agent.Permissions.PermissionManager(
+            new Hermes.Agent.Permissions.PermissionContext
+            {
+                Mode = Hermes.Agent.Permissions.PermissionMode.Default
+            },
+            NullLogger<Hermes.Agent.Permissions.PermissionManager>.Instance);
+
+        var agent = new Agent(
+            _mockChatClient.Object,
+            NullLogger<Agent>.Instance,
+            permissions: permissions);
+
+        var executed = false;
+        var tool = CreateMockTool("denied_tool");
+        tool.Setup(t => t.ExecuteAsync(It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback(() => executed = true)
+            .ReturnsAsync(ToolResult.Ok("should not run"));
+        agent.RegisterTool(tool.Object);
+
+        agent.PermissionPromptCallback = (_, _, _) => Task.FromResult(false);
+
+        var toolCall = new ToolCall { Id = "call-deny", Name = "denied_tool", Arguments = "{}" };
+        var callSequence = new Queue<ChatResponse>(new[]
+        {
+            new ChatResponse { Content = null, ToolCalls = new List<ToolCall> { toolCall }, FinishReason = "tool_calls" },
+            new ChatResponse { Content = "stopped", FinishReason = "stop" }
+        });
+
+        _mockChatClient
+            .Setup(c => c.CompleteWithToolsAsync(
+                It.IsAny<IEnumerable<Message>>(),
+                It.IsAny<IEnumerable<ToolDefinition>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => callSequence.Dequeue());
+
+        await agent.ChatAsync("try denied tool", new Session { Id = "deny-sess" }, CancellationToken.None);
+
+        Assert.IsFalse(executed,
+            "Tool ExecuteAsync should not have been invoked when the permission callback returned false.");
+        Assert.IsTrue(agent.ActivityLog.Any(e => e.ToolName == "denied_tool" && e.Status == ActivityStatus.Denied),
+            "ActivityLog should contain a Denied entry for the user-denied tool call.");
+    }
+
     private sealed class EmptyToolParams { }
 }
 

--- a/Desktop/HermesDesktop/App.xaml.cs
+++ b/Desktop/HermesDesktop/App.xaml.cs
@@ -616,11 +616,15 @@ public partial class App : Application
 
     /// <summary>
     /// Wire the Agent's permission callback to show a WinUI ContentDialog when Ask is returned.
+    /// The dialog body shows the human-readable permission message followed by a
+    /// monospace block containing the actual tool arguments (for the bash tool that
+    /// is the literal shell command), so technical users can audit exactly what the
+    /// agent is about to run *before* approving.
     /// </summary>
     private static void WirePermissionCallback(IServiceProvider services)
     {
         var agent = services.GetRequiredService<Hermes.Agent.Core.Agent>();
-        agent.PermissionPromptCallback = async (toolName, message) =>
+        agent.PermissionPromptCallback = async (toolName, message, toolArguments) =>
         {
             // Must dispatch to UI thread for ContentDialog
             var tcs = new System.Threading.Tasks.TaskCompletionSource<bool>();
@@ -631,12 +635,59 @@ public partial class App : Application
                 {
                     try
                     {
+                        // Build a dialog body that shows: (1) the permission rule's
+                        // human-readable message, then (2) a monospace "Command"
+                        // section containing the actual tool arguments JSON. For
+                        // bash that JSON looks like {"command":"whoami"}, which is
+                        // the literal shell command — exactly what an auditor needs
+                        // to see before granting permission.
+                        var body = new Microsoft.UI.Xaml.Controls.StackPanel
+                        {
+                            Spacing = 12,
+                            Orientation = Microsoft.UI.Xaml.Controls.Orientation.Vertical
+                        };
+                        body.Children.Add(new Microsoft.UI.Xaml.Controls.TextBlock
+                        {
+                            Text = message,
+                            TextWrapping = Microsoft.UI.Xaml.TextWrapping.WrapWholeWords,
+                            IsTextSelectionEnabled = true
+                        });
+
+                        var formattedCommand = FormatToolArgumentsForPrompt(toolName, toolArguments);
+                        if (!string.IsNullOrEmpty(formattedCommand))
+                        {
+                            body.Children.Add(new Microsoft.UI.Xaml.Controls.TextBlock
+                            {
+                                Text = "Command",
+                                FontSize = 11,
+                                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+                                Opacity = 0.7,
+                                Margin = new Microsoft.UI.Xaml.Thickness(0, 4, 0, 0)
+                            });
+                            // Use a read-only, multiline TextBox so the user can copy the
+                            // command — TextBlock would still allow selection but TextBox
+                            // gives a familiar Ctrl+A / Ctrl+C affordance and scrolls
+                            // gracefully when the command is long.
+                            body.Children.Add(new Microsoft.UI.Xaml.Controls.TextBox
+                            {
+                                Text = formattedCommand,
+                                IsReadOnly = true,
+                                AcceptsReturn = true,
+                                TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap,
+                                FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Cascadia Mono, Consolas"),
+                                FontSize = 12,
+                                MinHeight = 60,
+                                MaxHeight = 240
+                            });
+                        }
+
                         var dialog = new Microsoft.UI.Xaml.Controls.ContentDialog
                         {
                             Title = $"Permission Required: {toolName}",
-                            Content = message,
+                            Content = body,
                             PrimaryButtonText = "Allow",
                             CloseButtonText = "Deny",
+                            DefaultButton = Microsoft.UI.Xaml.Controls.ContentDialogButton.Close,
                             XamlRoot = app._window.Content.XamlRoot
                         };
                         var result = await dialog.ShowAsync();
@@ -656,6 +707,46 @@ public partial class App : Application
 
             return await tcs.Task;
         };
+    }
+
+    /// <summary>
+    /// Format raw tool arguments for display in the permission dialog. For the
+    /// bash tool, parse the JSON and surface the literal command string so the
+    /// user sees `whoami` rather than `{"command":"whoami"}`. For other tools
+    /// pretty-print the JSON if possible, otherwise show the raw string.
+    /// Returns an empty string when there is nothing useful to display so the
+    /// caller can omit the Command section entirely.
+    /// </summary>
+    private static string FormatToolArgumentsForPrompt(string toolName, string? toolArguments)
+    {
+        if (string.IsNullOrWhiteSpace(toolArguments))
+            return string.Empty;
+
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(toolArguments);
+            var root = doc.RootElement;
+
+            // bash tool: surface the actual shell command verbatim so the user
+            // sees what will run, not the JSON wrapper around it.
+            if (string.Equals(toolName, "bash", StringComparison.OrdinalIgnoreCase) &&
+                root.ValueKind == System.Text.Json.JsonValueKind.Object &&
+                root.TryGetProperty("command", out var commandProp) &&
+                commandProp.ValueKind == System.Text.Json.JsonValueKind.String)
+            {
+                return commandProp.GetString() ?? string.Empty;
+            }
+
+            // Everything else: pretty-print the JSON for readability.
+            return System.Text.Json.JsonSerializer.Serialize(
+                root,
+                new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            // Not JSON — show the raw string verbatim. Better than hiding it.
+            return toolArguments;
+        }
     }
 
     /// <summary>

--- a/Desktop/HermesDesktop/App.xaml.cs
+++ b/Desktop/HermesDesktop/App.xaml.cs
@@ -621,11 +621,20 @@ public partial class App : Application
     private static void WirePermissionCallback(IServiceProvider services)
     {
         var agent = services.GetRequiredService<Hermes.Agent.Core.Agent>();
+        // Resolve the dialog service once; it captures the active window's
+        // DispatcherQueue and XamlRoot internally and is safe to reuse across
+        // many permission prompts. PermissionDialogService is the dedicated
+        // dialog view + formatter extracted from this code-behind so this
+        // file stays focused on app lifecycle / DI orchestration only —
+        // see PermissionDialogService.cs for the construction logic plus the
+        // dispatcher-shutdown deadlock guard.
         agent.PermissionPromptCallback = async (toolName, message, toolArguments) =>
         {
             if (App.Current is App app && app._window is not null)
             {
-                var dialogService = new PermissionDialogService(app._window);
+                var dialogService = new HermesDesktop.Services.PermissionDialogService(
+                    app._window,
+                    TryGetAppLogger());
                 return await dialogService.ShowPermissionDialogAsync(message, toolName, toolArguments);
             }
             return false;

--- a/Desktop/HermesDesktop/App.xaml.cs
+++ b/Desktop/HermesDesktop/App.xaml.cs
@@ -616,137 +616,20 @@ public partial class App : Application
 
     /// <summary>
     /// Wire the Agent's permission callback to show a WinUI ContentDialog when Ask is returned.
-    /// The dialog body shows the human-readable permission message followed by a
-    /// monospace block containing the actual tool arguments (for the bash tool that
-    /// is the literal shell command), so technical users can audit exactly what the
-    /// agent is about to run *before* approving.
+    /// Delegates UI construction to PermissionDialogService for separation of concerns.
     /// </summary>
     private static void WirePermissionCallback(IServiceProvider services)
     {
         var agent = services.GetRequiredService<Hermes.Agent.Core.Agent>();
         agent.PermissionPromptCallback = async (toolName, message, toolArguments) =>
         {
-            // Must dispatch to UI thread for ContentDialog
-            var tcs = new System.Threading.Tasks.TaskCompletionSource<bool>();
-
             if (App.Current is App app && app._window is not null)
             {
-                app._window.DispatcherQueue.TryEnqueue(async () =>
-                {
-                    try
-                    {
-                        // Build a dialog body that shows: (1) the permission rule's
-                        // human-readable message, then (2) a monospace "Command"
-                        // section containing the actual tool arguments JSON. For
-                        // bash that JSON looks like {"command":"whoami"}, which is
-                        // the literal shell command — exactly what an auditor needs
-                        // to see before granting permission.
-                        var body = new Microsoft.UI.Xaml.Controls.StackPanel
-                        {
-                            Spacing = 12,
-                            Orientation = Microsoft.UI.Xaml.Controls.Orientation.Vertical
-                        };
-                        body.Children.Add(new Microsoft.UI.Xaml.Controls.TextBlock
-                        {
-                            Text = message,
-                            TextWrapping = Microsoft.UI.Xaml.TextWrapping.WrapWholeWords,
-                            IsTextSelectionEnabled = true
-                        });
-
-                        var formattedCommand = FormatToolArgumentsForPrompt(toolName, toolArguments);
-                        if (!string.IsNullOrEmpty(formattedCommand))
-                        {
-                            body.Children.Add(new Microsoft.UI.Xaml.Controls.TextBlock
-                            {
-                                Text = "Command",
-                                FontSize = 11,
-                                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
-                                Opacity = 0.7,
-                                Margin = new Microsoft.UI.Xaml.Thickness(0, 4, 0, 0)
-                            });
-                            // Use a read-only, multiline TextBox so the user can copy the
-                            // command — TextBlock would still allow selection but TextBox
-                            // gives a familiar Ctrl+A / Ctrl+C affordance and scrolls
-                            // gracefully when the command is long.
-                            body.Children.Add(new Microsoft.UI.Xaml.Controls.TextBox
-                            {
-                                Text = formattedCommand,
-                                IsReadOnly = true,
-                                AcceptsReturn = true,
-                                TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap,
-                                FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Cascadia Mono, Consolas"),
-                                FontSize = 12,
-                                MinHeight = 60,
-                                MaxHeight = 240
-                            });
-                        }
-
-                        var dialog = new Microsoft.UI.Xaml.Controls.ContentDialog
-                        {
-                            Title = $"Permission Required: {toolName}",
-                            Content = body,
-                            PrimaryButtonText = "Allow",
-                            CloseButtonText = "Deny",
-                            DefaultButton = Microsoft.UI.Xaml.Controls.ContentDialogButton.Close,
-                            XamlRoot = app._window.Content.XamlRoot
-                        };
-                        var result = await dialog.ShowAsync();
-                        tcs.TrySetResult(result == Microsoft.UI.Xaml.Controls.ContentDialogResult.Primary);
-                    }
-                    catch (Exception ex)
-                    {
-                        BestEffort.LogFailure(TryGetAppLogger(), ex, "showing permission prompt dialog", $"tool={toolName}");
-                        tcs.TrySetResult(false);
-                    }
-                });
+                var dialogService = new PermissionDialogService(app._window);
+                return await dialogService.ShowPermissionDialogAsync(message, toolName, toolArguments);
             }
-            else
-            {
-                tcs.TrySetResult(false);
-            }
-
-            return await tcs.Task;
+            return false;
         };
-    }
-
-    /// <summary>
-    /// Format raw tool arguments for display in the permission dialog. For the
-    /// bash tool, parse the JSON and surface the literal command string so the
-    /// user sees `whoami` rather than `{"command":"whoami"}`. For other tools
-    /// pretty-print the JSON if possible, otherwise show the raw string.
-    /// Returns an empty string when there is nothing useful to display so the
-    /// caller can omit the Command section entirely.
-    /// </summary>
-    private static string FormatToolArgumentsForPrompt(string toolName, string? toolArguments)
-    {
-        if (string.IsNullOrWhiteSpace(toolArguments))
-            return string.Empty;
-
-        try
-        {
-            using var doc = System.Text.Json.JsonDocument.Parse(toolArguments);
-            var root = doc.RootElement;
-
-            // bash tool: surface the actual shell command verbatim so the user
-            // sees what will run, not the JSON wrapper around it.
-            if (string.Equals(toolName, "bash", StringComparison.OrdinalIgnoreCase) &&
-                root.ValueKind == System.Text.Json.JsonValueKind.Object &&
-                root.TryGetProperty("command", out var commandProp) &&
-                commandProp.ValueKind == System.Text.Json.JsonValueKind.String)
-            {
-                return commandProp.GetString() ?? string.Empty;
-            }
-
-            // Everything else: pretty-print the JSON for readability.
-            return System.Text.Json.JsonSerializer.Serialize(
-                root,
-                new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
-        }
-        catch (System.Text.Json.JsonException)
-        {
-            // Not JSON — show the raw string verbatim. Better than hiding it.
-            return toolArguments;
-        }
     }
 
     /// <summary>

--- a/Desktop/HermesDesktop/Models/ActivityDisplayItem.cs
+++ b/Desktop/HermesDesktop/Models/ActivityDisplayItem.cs
@@ -40,7 +40,15 @@ public sealed class ActivityDisplayItem : INotifyPropertyChanged
 
     public string Id { get; }
     public DateTime Timestamp { get; }
+
+    /// <summary>
+    /// Process-monotonic creation sequence inherited from the source
+    /// ActivityEntry. ReplayPanel uses this as a stable secondary sort key
+    /// when ordering by Timestamp for chronological playback so two entries
+    /// with the same UTC tick still play back in insertion order.
+    /// </summary>
     public long Sequence { get; }
+
     public string ToolName { get; }
     public string? ToolCallId { get; }
     public string InputSummary { get; }

--- a/Desktop/HermesDesktop/Models/ActivityDisplayItem.cs
+++ b/Desktop/HermesDesktop/Models/ActivityDisplayItem.cs
@@ -15,6 +15,7 @@ public sealed class ActivityDisplayItem : INotifyPropertyChanged
     private ActivityStatus _status;
     private long _durationMs;
     private string _outputSummary = "";
+    private string _outputFull = "";
     private bool _isExpanded;
     private string? _diffPreview;
     private string? _screenshotPath;
@@ -29,7 +30,7 @@ public sealed class ActivityDisplayItem : INotifyPropertyChanged
         InputSummary = entry.InputSummary;
         InputFull = entry.InputSummary;
         _outputSummary = entry.OutputSummary;
-        OutputFull = entry.OutputSummary;
+        _outputFull = entry.OutputSummary;
         _status = entry.Status;
         _durationMs = entry.DurationMs;
         _diffPreview = entry.DiffPreview;
@@ -42,7 +43,25 @@ public sealed class ActivityDisplayItem : INotifyPropertyChanged
     public string? ToolCallId { get; }
     public string InputSummary { get; }
     public string InputFull { get; set; }
-    public string OutputFull { get; set; }
+
+    /// <summary>
+    /// Full tool result text shown in the expanded activity row. Notifies on
+    /// change so x:Bind OneWay updates fire when the agent finishes a tool call
+    /// and the row transitions from Running → Success/Failed via UpdateFrom.
+    /// Without PropertyChanged here the expanded "Output" panel stays empty
+    /// even when the tool returned data (the original "missing terminal output"
+    /// bug — InputFull/OutputFull were plain auto-properties so the OneWay
+    /// binding only saw the empty initial value).
+    /// </summary>
+    public string OutputFull
+    {
+        get => _outputFull;
+        set
+        {
+            _outputFull = value;
+            OnPropertyChanged();
+        }
+    }
 
     public string FormattedTime => Timestamp.ToLocalTime().ToString("HH:mm:ss");
 

--- a/Desktop/HermesDesktop/Models/ActivityDisplayItem.cs
+++ b/Desktop/HermesDesktop/Models/ActivityDisplayItem.cs
@@ -25,6 +25,7 @@ public sealed class ActivityDisplayItem : INotifyPropertyChanged
     {
         Id = entry.Id;
         Timestamp = entry.Timestamp;
+        Sequence = entry.Sequence;
         ToolName = entry.ToolName;
         ToolCallId = entry.ToolCallId;
         InputSummary = entry.InputSummary;
@@ -39,6 +40,7 @@ public sealed class ActivityDisplayItem : INotifyPropertyChanged
 
     public string Id { get; }
     public DateTime Timestamp { get; }
+    public long Sequence { get; }
     public string ToolName { get; }
     public string? ToolCallId { get; }
     public string InputSummary { get; }

--- a/Desktop/HermesDesktop/Services/PermissionDialogService.cs
+++ b/Desktop/HermesDesktop/Services/PermissionDialogService.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Diagnostics;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.UI.Text;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+
+namespace HermesDesktop.Services;
+
+/// <summary>
+/// Renders the WinUI permission prompt that fires when the agent's
+/// PermissionManager returns <c>PermissionBehavior.Ask</c>. Extracted from
+/// <c>App.xaml.cs</c> so the code-behind stays focused on lifecycle / DI
+/// orchestration and the dialog body / argument formatting / dispatcher
+/// safety live in one auditable place.
+///
+/// Responsibilities:
+/// <list type="number">
+///   <item>Marshal to the UI thread via the owning window's DispatcherQueue.</item>
+///   <item>Format the raw tool arguments for human review (bash command
+///         extraction + JSON pretty-print fallback).</item>
+///   <item>Build the ContentDialog body with a selectable monospace command
+///         block so technical users can audit (and Ctrl-C) what the agent
+///         is about to run before approving.</item>
+///   <item>Defend against dispatcher-shutdown races so the agent loop
+///         never hangs awaiting a TaskCompletionSource that nobody is going
+///         to complete.</item>
+/// </list>
+///
+/// This class is stateless beyond the captured window + logger references
+/// and is safe to instantiate per call, but it can also be reused across
+/// many permission prompts within the same window's lifetime.
+/// </summary>
+public sealed class PermissionDialogService
+{
+    private readonly Window _window;
+    private readonly ILogger? _logger;
+
+    public PermissionDialogService(Window window, ILogger? logger = null)
+    {
+        _window = window ?? throw new ArgumentNullException(nameof(window));
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Show a modal permission prompt for the given tool and return whether
+    /// the user approved it. Returns <c>false</c> on any failure (window
+    /// gone, dispatcher shutting down, dialog throws) so the agent loop
+    /// always gets a definite answer instead of hanging on an uncompleted
+    /// task.
+    /// </summary>
+    /// <param name="message">
+    /// Human-readable explanation of why permission is being requested.
+    /// Comes from <c>PermissionDecision.Message</c> on the agent side.
+    /// </param>
+    /// <param name="toolName">
+    /// The tool the agent wants to invoke (e.g. <c>"bash"</c>, <c>"write_file"</c>).
+    /// Surfaced in both the dialog title and passed to
+    /// <see cref="FormatToolArgumentsForPrompt"/> for tool-specific formatting.
+    /// </param>
+    /// <param name="toolArguments">
+    /// The raw JSON arguments string from the model's tool call. For the
+    /// bash tool that is <c>{"command":"whoami"}</c>; the Command section
+    /// of the dialog will surface the literal <c>whoami</c> instead of the
+    /// JSON wrapper. May be null/empty if the host doesn't have it, in
+    /// which case the Command section is omitted entirely.
+    /// </param>
+    public Task<bool> ShowPermissionDialogAsync(string message, string toolName, string? toolArguments)
+    {
+        // RunContinuationsAsynchronously: when the dialog completes on the UI
+        // thread, the awaiting agent loop must NOT pick up its continuation
+        // synchronously on that same UI thread — otherwise the next iteration
+        // of the agent loop would run inside the dispatcher callback and
+        // create a re-entrancy hazard for subsequent permission prompts.
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // TryEnqueue can fail (return false) if the dispatcher has already
+        // started shutting down — e.g. the user closed the window while the
+        // agent loop was mid-iteration. If we ignore the return value the
+        // queued lambda never runs, tcs is never completed, and the agent
+        // loop hangs forever on `await tcs.Task`. Capture it and deny by
+        // default if dispatch failed.
+        var enqueued = _window.DispatcherQueue.TryEnqueue(async () =>
+        {
+            try
+            {
+                var dialog = BuildDialog(message, toolName, toolArguments);
+                var result = await dialog.ShowAsync();
+                tcs.TrySetResult(result == ContentDialogResult.Primary);
+            }
+            catch (Exception ex)
+            {
+                if (_logger is not null)
+                    _logger.LogWarning(ex,
+                        "Permission prompt dialog failed for tool {Tool}; denying",
+                        toolName);
+                else
+                    Debug.WriteLine($"Permission prompt dialog failed for tool {toolName}: {ex}");
+                tcs.TrySetResult(false);
+            }
+        });
+
+        if (!enqueued)
+        {
+            if (_logger is not null)
+                _logger.LogWarning(
+                    "DispatcherQueue.TryEnqueue refused permission prompt for tool {Tool}; denying by default",
+                    toolName);
+            else
+                Debug.WriteLine(
+                    $"DispatcherQueue.TryEnqueue refused permission prompt for tool {toolName}; denying by default");
+            tcs.TrySetResult(false);
+        }
+
+        return tcs.Task;
+    }
+
+    /// <summary>
+    /// Build the ContentDialog body. Vertical StackPanel containing the
+    /// human-readable message followed (when args are present) by a
+    /// "Command" header and a read-only monospace TextBox the user can
+    /// Ctrl-A / Ctrl-C from. DefaultButton is Close so an accidental Enter
+    /// keypress on the dialog denies rather than approves — never let
+    /// muscle memory grant permissions.
+    /// </summary>
+    private ContentDialog BuildDialog(string message, string toolName, string? toolArguments)
+    {
+        var body = new StackPanel
+        {
+            Spacing = 12,
+            Orientation = Orientation.Vertical
+        };
+        body.Children.Add(new TextBlock
+        {
+            Text = message,
+            TextWrapping = TextWrapping.WrapWholeWords,
+            IsTextSelectionEnabled = true
+        });
+
+        var formattedCommand = FormatToolArgumentsForPrompt(toolName, toolArguments);
+        if (!string.IsNullOrEmpty(formattedCommand))
+        {
+            body.Children.Add(new TextBlock
+            {
+                Text = "Command",
+                FontSize = 11,
+                FontWeight = FontWeights.SemiBold,
+                Opacity = 0.7,
+                Margin = new Thickness(0, 4, 0, 0)
+            });
+            // Read-only multiline TextBox rather than another TextBlock: the
+            // TextBox gives the user a familiar Ctrl+A / Ctrl+C affordance,
+            // shows a caret on focus so it's obvious the field is selectable,
+            // and scrolls gracefully when the command is long.
+            body.Children.Add(new TextBox
+            {
+                Text = formattedCommand,
+                IsReadOnly = true,
+                AcceptsReturn = true,
+                TextWrapping = TextWrapping.Wrap,
+                FontFamily = new FontFamily("Cascadia Mono, Consolas"),
+                FontSize = 12,
+                MinHeight = 60,
+                MaxHeight = 240
+            });
+        }
+
+        return new ContentDialog
+        {
+            Title = $"Permission Required: {toolName}",
+            Content = body,
+            PrimaryButtonText = "Allow",
+            CloseButtonText = "Deny",
+            DefaultButton = ContentDialogButton.Close,
+            XamlRoot = _window.Content.XamlRoot
+        };
+    }
+
+    /// <summary>
+    /// Format raw tool arguments for display in the permission dialog. For
+    /// the bash tool, parse the JSON and surface the literal command string
+    /// so the user sees <c>whoami</c> rather than <c>{"command":"whoami"}</c>.
+    /// For other tools, pretty-print the JSON. Returns an empty string when
+    /// there is nothing useful to display so the caller can omit the Command
+    /// section entirely.
+    /// </summary>
+    /// <remarks>
+    /// Internal so it can be unit-tested. Static so it has no instance state
+    /// to mock.
+    /// </remarks>
+    internal static string FormatToolArgumentsForPrompt(string toolName, string? toolArguments)
+    {
+        if (string.IsNullOrWhiteSpace(toolArguments))
+            return string.Empty;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(toolArguments);
+            var root = doc.RootElement;
+
+            // bash tool: surface the actual shell command verbatim so the user
+            // sees what will run, not the JSON wrapper around it.
+            if (string.Equals(toolName, "bash", StringComparison.OrdinalIgnoreCase) &&
+                root.ValueKind == JsonValueKind.Object &&
+                root.TryGetProperty("command", out var commandProp) &&
+                commandProp.ValueKind == JsonValueKind.String)
+            {
+                return commandProp.GetString() ?? string.Empty;
+            }
+
+            // Everything else: pretty-print the JSON for readability.
+            return JsonSerializer.Serialize(root, new JsonSerializerOptions { WriteIndented = true });
+        }
+        catch (JsonException)
+        {
+            // Not JSON — show the raw string verbatim. Better than hiding it.
+            return toolArguments;
+        }
+    }
+}

--- a/Desktop/HermesDesktop/Views/ChatPage.xaml
+++ b/Desktop/HermesDesktop/Views/ChatPage.xaml
@@ -78,10 +78,12 @@
                                             </Expander.Header>
                                             <TextBlock Text="{x:Bind ThinkingContent, Mode=OneWay}" TextWrapping="WrapWholeWords"
                                                        FontSize="12" Foreground="{StaticResource AppTextSecondaryBrush}"
-                                                       FontStyle="Italic" Padding="8,4"/>
+                                                       FontStyle="Italic" Padding="8,4"
+                                                       IsTextSelectionEnabled="True"/>
                                         </Expander>
 
-                                        <TextBlock Text="{x:Bind Content, Mode=OneWay}" TextWrapping="WrapWholeWords" />
+                                        <TextBlock Text="{x:Bind Content, Mode=OneWay}" TextWrapping="WrapWholeWords"
+                                                   IsTextSelectionEnabled="True"/>
                                     </StackPanel>
                                 </Border>
                             </Grid>

--- a/Desktop/HermesDesktop/Views/Panels/ReplayPanel.xaml
+++ b/Desktop/HermesDesktop/Views/Panels/ReplayPanel.xaml
@@ -83,7 +83,8 @@
                                     <TextBlock Text="{x:Bind InputFull}" FontSize="10"
                                                FontFamily="Cascadia Mono, Consolas" TextWrapping="Wrap"
                                                Foreground="{StaticResource AppTextSecondaryBrush}"
-                                               MaxLines="10"/>
+                                               MaxLines="10"
+                                               IsTextSelectionEnabled="True"/>
                                 </Border>
                             </StackPanel>
 
@@ -95,7 +96,8 @@
                                     <TextBlock Text="{x:Bind OutputFull, Mode=OneWay}" FontSize="10"
                                                FontFamily="Cascadia Mono, Consolas" TextWrapping="Wrap"
                                                Foreground="{StaticResource AppTextSecondaryBrush}"
-                                               MaxLines="10"/>
+                                               MaxLines="10"
+                                               IsTextSelectionEnabled="True"/>
                                 </Border>
                             </StackPanel>
 
@@ -107,7 +109,8 @@
                                     <TextBlock Text="{x:Bind DiffPreview, Mode=OneWay}" FontSize="10"
                                                FontFamily="Cascadia Mono, Consolas" TextWrapping="Wrap"
                                                Foreground="{StaticResource AppAccentTextBrush}"
-                                               MaxLines="20"/>
+                                               MaxLines="20"
+                                               IsTextSelectionEnabled="True"/>
                                 </Border>
                             </StackPanel>
 

--- a/Desktop/HermesDesktop/Views/Panels/ReplayPanel.xaml
+++ b/Desktop/HermesDesktop/Views/Panels/ReplayPanel.xaml
@@ -76,15 +76,22 @@
                         <StackPanel Grid.Row="1" Spacing="6" Margin="18,6,0,4"
                                     Visibility="{x:Bind IsExpanded, Mode=OneWay}">
                             <!-- Input args -->
+                            <!-- Each detail block uses a constrained-height ScrollViewer instead of
+                                 TextBlock.MaxLines: MaxLines visually truncates so text past the cap
+                                 is unreachable for selection / Ctrl-C, defeating the copy-paste fix.
+                                 ScrollViewer keeps the row size bounded but lets the user scroll AND
+                                 select the entire output. -->
                             <StackPanel Spacing="2">
                                 <TextBlock Text="Input" FontSize="10" FontWeight="SemiBold"
                                            Foreground="{StaticResource AppTextSecondaryBrush}"/>
                                 <Border Background="{StaticResource AppInsetBrush}" CornerRadius="4" Padding="8,6">
-                                    <TextBlock Text="{x:Bind InputFull}" FontSize="10"
-                                               FontFamily="Cascadia Mono, Consolas" TextWrapping="Wrap"
-                                               Foreground="{StaticResource AppTextSecondaryBrush}"
-                                               MaxLines="10"
-                                               IsTextSelectionEnabled="True"/>
+                                    <ScrollViewer MaxHeight="160" VerticalScrollBarVisibility="Auto"
+                                                  HorizontalScrollBarVisibility="Disabled">
+                                        <TextBlock Text="{x:Bind InputFull}" FontSize="10"
+                                                   FontFamily="Cascadia Mono, Consolas" TextWrapping="Wrap"
+                                                   Foreground="{StaticResource AppTextSecondaryBrush}"
+                                                   IsTextSelectionEnabled="True"/>
+                                    </ScrollViewer>
                                 </Border>
                             </StackPanel>
 
@@ -93,11 +100,13 @@
                                 <TextBlock Text="Output" FontSize="10" FontWeight="SemiBold"
                                            Foreground="{StaticResource AppTextSecondaryBrush}"/>
                                 <Border Background="{StaticResource AppInsetBrush}" CornerRadius="4" Padding="8,6">
-                                    <TextBlock Text="{x:Bind OutputFull, Mode=OneWay}" FontSize="10"
-                                               FontFamily="Cascadia Mono, Consolas" TextWrapping="Wrap"
-                                               Foreground="{StaticResource AppTextSecondaryBrush}"
-                                               MaxLines="10"
-                                               IsTextSelectionEnabled="True"/>
+                                    <ScrollViewer MaxHeight="220" VerticalScrollBarVisibility="Auto"
+                                                  HorizontalScrollBarVisibility="Disabled">
+                                        <TextBlock Text="{x:Bind OutputFull, Mode=OneWay}" FontSize="10"
+                                                   FontFamily="Cascadia Mono, Consolas" TextWrapping="Wrap"
+                                                   Foreground="{StaticResource AppTextSecondaryBrush}"
+                                                   IsTextSelectionEnabled="True"/>
+                                    </ScrollViewer>
                                 </Border>
                             </StackPanel>
 
@@ -106,11 +115,13 @@
                                 <TextBlock Text="Diff" FontSize="10" FontWeight="SemiBold"
                                            Foreground="{StaticResource AppTextSecondaryBrush}"/>
                                 <Border Background="{StaticResource AppInsetBrush}" CornerRadius="4" Padding="8,6">
-                                    <TextBlock Text="{x:Bind DiffPreview, Mode=OneWay}" FontSize="10"
-                                               FontFamily="Cascadia Mono, Consolas" TextWrapping="Wrap"
-                                               Foreground="{StaticResource AppAccentTextBrush}"
-                                               MaxLines="20"
-                                               IsTextSelectionEnabled="True"/>
+                                    <ScrollViewer MaxHeight="320" VerticalScrollBarVisibility="Auto"
+                                                  HorizontalScrollBarVisibility="Disabled">
+                                        <TextBlock Text="{x:Bind DiffPreview, Mode=OneWay}" FontSize="10"
+                                                   FontFamily="Cascadia Mono, Consolas" TextWrapping="Wrap"
+                                                   Foreground="{StaticResource AppAccentTextBrush}"
+                                                   IsTextSelectionEnabled="True"/>
+                                    </ScrollViewer>
                                 </Border>
                             </StackPanel>
 

--- a/Desktop/HermesDesktop/Views/Panels/ReplayPanel.xaml.cs
+++ b/Desktop/HermesDesktop/Views/Panels/ReplayPanel.xaml.cs
@@ -82,22 +82,30 @@ public sealed partial class ReplayPanel : UserControl
         }
         else
         {
-            Activities.Add(new ActivityDisplayItem(entry));
+            // Newest activity is inserted at index 0 so the most recent tool call
+            // sits at the top of the panel without the user having to scroll. This
+            // matches conventional dev tool log ordering (terminal scrollback,
+            // browser devtools network panel, etc.). PlaybackAsync below iterates
+            // the collection in chronological order via OrderBy(Timestamp) so the
+            // replay still plays oldest → newest regardless of display order.
+            Activities.Insert(0, new ActivityDisplayItem(entry));
         }
         UpdateEmptyState();
 
-        // Auto-scroll to latest
+        // Auto-scroll to the newest entry, which is now at index 0 (top).
         if (Activities.Count > 0)
-            ActivityList.ScrollIntoView(Activities[^1]);
+            ActivityList.ScrollIntoView(Activities[0]);
     }
 
     /// <summary>
-    /// Load a full session's activity entries.
+    /// Load a full session's activity entries. Entries are inserted in
+    /// descending-timestamp order so the most recent tool call ends up at index
+    /// 0 (top of the panel), matching live-add ordering.
     /// </summary>
     public void LoadSession(List<ActivityEntry> entries)
     {
         Activities.Clear();
-        foreach (var entry in entries)
+        foreach (var entry in entries.OrderByDescending(e => e.Timestamp))
             Activities.Add(new ActivityDisplayItem(entry));
         UpdateEmptyState();
     }
@@ -167,7 +175,12 @@ public sealed partial class ReplayPanel : UserControl
 
     private async Task PlaybackAsync(CancellationToken ct)
     {
-        foreach (var item in Activities)
+        // Display order is newest-first, but playback should always run
+        // chronologically (oldest → newest) so the user watches the agent's
+        // work unfold in the same order it actually happened. Snapshot to a
+        // local list so an Activities mutation mid-playback can't desync us.
+        var ordered = Activities.OrderBy(a => a.Timestamp).ToList();
+        foreach (var item in ordered)
         {
             ct.ThrowIfCancellationRequested();
 

--- a/Desktop/HermesDesktop/Views/Panels/ReplayPanel.xaml.cs
+++ b/Desktop/HermesDesktop/Views/Panels/ReplayPanel.xaml.cs
@@ -100,13 +100,20 @@ public sealed partial class ReplayPanel : UserControl
     /// <summary>
     /// Load a full session's activity entries. Entries are inserted in
     /// descending-timestamp order so the most recent tool call ends up at index
-    /// 0 (top of the panel), matching live-add ordering.
+    /// 0 (top of the panel), matching live-add ordering. Sequence is the stable
+    /// secondary key — DateTime.UtcNow has ~16ms tick resolution on Windows so
+    /// two parallel tool entries can collide on Timestamp; without the
+    /// secondary sort the order between them would be implementation-defined.
     /// </summary>
     public void LoadSession(List<ActivityEntry> entries)
     {
         Activities.Clear();
-        foreach (var entry in entries.OrderByDescending(e => e.Timestamp))
+        foreach (var entry in entries
+            .OrderByDescending(e => e.Timestamp)
+            .ThenByDescending(e => e.Sequence))
+        {
             Activities.Add(new ActivityDisplayItem(entry));
+        }
         UpdateEmptyState();
     }
 
@@ -177,11 +184,15 @@ public sealed partial class ReplayPanel : UserControl
     {
         // Display order is newest-first, but playback should always run
         // chronologically (oldest → newest) so the user watches the agent's
-        // work unfold in the same order it actually happened. Snapshot to a
-        // local list so an Activities mutation mid-playback can't desync us.
-        // Sort by Timestamp first, then by Sequence to resolve collisions and
-        // maintain stable insertion order.
-        var ordered = Activities.OrderBy(a => a.Timestamp).ThenBy(a => a.Sequence).ToList();
+        // work unfold in the same order it actually happened. Sequence is the
+        // stable secondary key because DateTime.UtcNow has ~16ms tick
+        // resolution on Windows — two parallel tool entries created in the
+        // same tick would otherwise play in non-deterministic order. Snapshot
+        // to a local list so an Activities mutation mid-playback can't desync.
+        var ordered = Activities
+            .OrderBy(a => a.Timestamp)
+            .ThenBy(a => a.Sequence)
+            .ToList();
         foreach (var item in ordered)
         {
             ct.ThrowIfCancellationRequested();

--- a/Desktop/HermesDesktop/Views/Panels/ReplayPanel.xaml.cs
+++ b/Desktop/HermesDesktop/Views/Panels/ReplayPanel.xaml.cs
@@ -179,7 +179,9 @@ public sealed partial class ReplayPanel : UserControl
         // chronologically (oldest → newest) so the user watches the agent's
         // work unfold in the same order it actually happened. Snapshot to a
         // local list so an Activities mutation mid-playback can't desync us.
-        var ordered = Activities.OrderBy(a => a.Timestamp).ToList();
+        // Sort by Timestamp first, then by Sequence to resolve collisions and
+        // maintain stable insertion order.
+        var ordered = Activities.OrderBy(a => a.Timestamp).ThenBy(a => a.Sequence).ToList();
         foreach (var item in ordered)
         {
             ct.ThrowIfCancellationRequested();

--- a/Desktop/HermesDesktop/docs/VISION-SUPPORT-DESIGN.md
+++ b/Desktop/HermesDesktop/docs/VISION-SUPPORT-DESIGN.md
@@ -1,0 +1,336 @@
+# Vision / Multimodal Image Support — Design
+
+**Status:** Design only — not yet implemented.
+**Trigger:** Feedback item #5 from v2.3.1 portable testing — users want to
+upload or paste images into the chat for the agent to analyze with multimodal
+models (Claude 3.5 Sonnet vision, GPT-4o vision, Qwen-VL, Llama 3.2 Vision,
+etc.).
+**Scope:** This document maps out the implementation across the existing
+codebase so the work can be picked up in a follow-up branch with confidence.
+
+---
+
+## Why this is not a single-commit fix
+
+The chat model in `src/Core/models.cs` currently holds messages as
+`Message { string Content }` — a flat string. Every provider client
+(`AnthropicClient`, `OpenAiClient`, `OllamaClient`, `QwenClient`, etc.)
+serializes that string into its own wire format. Adding images means:
+
+1. Extending the in-memory message model to carry attachments.
+2. Updating every provider client's serializer to emit content blocks
+   (Anthropic) or `image_url`/`input_image` (OpenAI) or whatever Ollama and
+   Qwen want.
+3. Updating the chat UI to accept images via paste / file picker / drag-drop.
+4. Updating the chat bubble template to render attached images.
+5. Persisting attachments in the transcript store so loaded sessions
+   reproduce correctly.
+6. Deciding image storage policy: temp files? `%LOCALAPPDATA%\hermes\images\`?
+   Inline base64 in the transcript JSON? Each option has tradeoffs around
+   disk usage, transcript portability, and provider request size.
+
+That's ~15 file touches minimum and the kind of change that needs a real
+build + test loop on Windows before shipping. Hence this design doc instead
+of a half-finished implementation.
+
+---
+
+## Provider wire formats (the constraint)
+
+### Anthropic (`AnthropicClient.cs`)
+
+Anthropic uses content blocks. A user message with an image becomes:
+
+```json
+{
+  "role": "user",
+  "content": [
+    { "type": "text", "text": "what's in this screenshot?" },
+    {
+      "type": "image",
+      "source": {
+        "type": "base64",
+        "media_type": "image/png",
+        "data": "<base64 bytes>"
+      }
+    }
+  ]
+}
+```
+
+Source type can also be `"url"` if we're sending a hosted URL, but the
+feedback explicitly asked for base64, which keeps the agent self-contained
+and avoids an upload-to-cloud step.
+
+### OpenAI (`OpenAiClient.cs`)
+
+OpenAI uses `image_url` with a data URI:
+
+```json
+{
+  "role": "user",
+  "content": [
+    { "type": "text", "text": "what's in this screenshot?" },
+    {
+      "type": "image_url",
+      "image_url": {
+        "url": "data:image/png;base64,<base64 bytes>",
+        "detail": "auto"
+      }
+    }
+  ]
+}
+```
+
+Note the difference: Anthropic separates `media_type` and `data`, OpenAI
+folds them into a `data:image/png;base64,...` URI in a single string field.
+A shared `ImageAttachment` type that exposes both `MediaType` and
+`Base64Data` lets each serializer pick the form it needs without forcing the
+core model to know about provider details.
+
+### Ollama (multimodal models like `llama3.2-vision`)
+
+Ollama's chat API accepts an `images` array on the message, with each image
+as a raw base64 string (no data URI prefix, no `media_type`):
+
+```json
+{
+  "role": "user",
+  "content": "what's in this screenshot?",
+  "images": ["<base64 bytes>"]
+}
+```
+
+The shared model needs to hand each client the bytes in whatever envelope
+the client wants.
+
+### Qwen-VL / DeepSeek / others
+
+Similar to OpenAI's `image_url` form. The same `ImageAttachment` shape works.
+
+---
+
+## Proposed model changes (`src/Core/models.cs`)
+
+Add a new type and a new optional field on `Message`. Do NOT change
+`Content` — that would break every provider client and every transcript on
+disk.
+
+```csharp
+public sealed class ImageAttachment
+{
+    /// <summary>MIME type, e.g. "image/png" or "image/jpeg".</summary>
+    public required string MediaType { get; init; }
+
+    /// <summary>Raw base64 string (no "data:" prefix, no padding rules).</summary>
+    public required string Base64Data { get; init; }
+
+    /// <summary>Optional source filename for display in the UI / logs.</summary>
+    public string? FileName { get; init; }
+
+    /// <summary>Build a data URI string for OpenAI / Qwen / DeepSeek wire formats.</summary>
+    public string ToDataUri() => $"data:{MediaType};base64,{Base64Data}";
+}
+
+public sealed class Message
+{
+    public required string Role { get; init; }
+    public required string Content { get; init; }
+    public DateTime Timestamp { get; init; } = DateTime.UtcNow;
+    public string? ToolCallId { get; init; }
+    public string? ToolName { get; init; }
+    public List<ToolCall>? ToolCalls { get; init; }
+
+    /// <summary>
+    /// Optional images attached to a user message. Provider clients that
+    /// support vision serialize these into content blocks; clients that
+    /// don't simply ignore them (and the model never sees the image).
+    /// </summary>
+    public List<ImageAttachment>? Attachments { get; init; }
+}
+```
+
+`Attachments` is `List<>?` so existing code that constructs `Message`
+without attachments needs zero changes.
+
+---
+
+## Per-client serializer updates
+
+Each provider client currently builds its request body from
+`IEnumerable<Message>`. Find the loop that converts each `Message` to the
+provider's JSON shape. Pseudo-template for all of them:
+
+```csharp
+foreach (var msg in messages)
+{
+    if (msg.Attachments is { Count: > 0 } && SupportsVision(currentModel))
+    {
+        // Emit a content-block array combining msg.Content and the images.
+    }
+    else
+    {
+        // Existing single-string content path — unchanged.
+    }
+}
+```
+
+Files to touch (find each one's `BuildRequest` / `Serialize` / equivalent
+method):
+
+- `src/LLM/AnthropicClient.cs` — emit `content` as an array of `text` and
+  `image` blocks.
+- `src/LLM/OpenAiClient.cs` — emit `content` as an array of `text` and
+  `image_url` blocks (look for `openaiclient.cs`).
+- `src/LLM/OllamaClient.cs` (if present) — emit `images` array alongside
+  the existing string `content`.
+- `src/LLM/QwenClient.cs` (if present) — same shape as OpenAI.
+- Any other clients in `src/LLM/`.
+
+Add a `SupportsVision(string modelId)` helper in each client (or in a
+shared `ModelCatalog` / `IChatClient` extension). Models that don't support
+vision should silently drop attachments — never throw, the user already
+clicked send. The chat UI should warn ahead of time if the currently
+selected model doesn't support images (use a small badge near the
+attachment thumbnail).
+
+---
+
+## UI changes (`Desktop/HermesDesktop/Views/ChatPage.xaml(.cs)`)
+
+### Input area
+
+The chat input lives in `ChatPage.xaml` around line 112-145 (the "Input
+Area — Claude Code style" StackPanel). Changes:
+
+1. **Attach button**: add a small icon button inside the input border, to
+   the left of the existing Send button. Glyph: paperclip (`\uE723` from
+   Segoe MDL2 Assets) or image icon (`\uEB9F`). Click handler:
+   `AttachImage_Click`.
+
+2. **Paste handler**: subscribe to `PromptTextBox.Paste` event. Inspect
+   `Clipboard.GetContent()` for `StandardDataFormats.Bitmap`. If present,
+   read the bitmap, encode to PNG base64, create an `ImageAttachment`, and
+   add to the pending-attachments list. Cancel the default paste so the
+   image bytes don't end up as garbage text in the prompt box.
+
+3. **Drag-drop handler**: subscribe `PromptTextBox.DragOver` and
+   `PromptTextBox.Drop`. Accept files with image extensions, read them,
+   base64-encode.
+
+4. **Pending attachments strip**: a horizontal `ItemsRepeater` above the
+   prompt textbox showing thumbnails of attachments staged for the next
+   message, each with a small "x" button to remove. Bound to a
+   `ObservableCollection<PendingAttachment>` field on `ChatPage`.
+
+5. **Send**: when the user clicks Send, copy the pending attachments into
+   the outgoing `Message`'s `Attachments` list, then clear the pending
+   collection.
+
+### Message bubbles
+
+The chat bubble template in `ChatPage.xaml` lines 60-87 needs an
+`ItemsControl` showing attachment thumbnails inside the bubble, above the
+text content. Each thumbnail is an `<Image>` whose `Source` is a
+`BitmapImage` constructed from the base64 bytes. Click to open
+full-size in a flyout.
+
+`ChatMessageItem` (in `Desktop/HermesDesktop/Models/`) needs an
+`Attachments` collection synced from the `Message` it wraps.
+
+---
+
+## Storage policy
+
+**Recommendation: inline base64 in the transcript JSON, with a soft
+size cap.**
+
+Pros: transcripts stay portable (single file, no external image directory
+to keep in sync), session export/import works without extra steps, no
+cleanup logic needed when sessions are deleted.
+
+Cons: transcript files get bigger. A typical screenshot is ~100-500 KB
+base64; ten screenshots in a session = ~5 MB JSON. Acceptable for normal
+use; the soft cap below catches abuse.
+
+**Soft cap:** reject any single attachment over **5 MB** decoded with a
+toast "Image too large — please resize before sending". Reject the message
+send if total attachments for the message exceed **20 MB** decoded. These
+are arbitrary but generous defaults; expose them in `config.yaml` under a
+new `vision:` section if users complain.
+
+**Alternative (rejected):** writing images to
+`%LOCALAPPDATA%\hermes\images\` with a content hash and storing only the
+path in the transcript. Adds GC complexity (when do we delete orphaned
+files?), breaks transcript portability across machines, and forces the
+agent loop to read from disk on every turn that includes an image. The
+inline approach trades disk size for simplicity and that's the right call
+at this stage.
+
+---
+
+## Implementation order (to minimize broken intermediate states)
+
+1. **Model**: add `ImageAttachment` and `Message.Attachments` to
+   `src/Core/models.cs`. Compile is unaffected — every existing call site
+   keeps working because the field is nullable.
+
+2. **Persistence**: extend `src/transcript/transcriptstore.cs` to round-trip
+   `Attachments` through JSON. Test by manually loading an old session
+   (no attachments) and a new session (with attachments).
+
+3. **One provider — `AnthropicClient`**: implement vision content blocks
+   end-to-end against Claude Sonnet. This is the easiest provider to test
+   (clean content-block API). Verify with a hand-built `Message` containing
+   an attachment via a unit test or a `dotnet run` smoke test.
+
+4. **UI input**: add the attach button and paste handler in `ChatPage`.
+   Wire it to a `_pendingAttachments` collection. On Send, pass into the
+   outgoing `Message`.
+
+5. **UI bubble rendering**: add the attachment thumbnail row to the
+   chat bubble template.
+
+6. **Other providers**: `OpenAiClient`, `OllamaClient`, `QwenClient`. Each
+   one is self-contained — no cross-file changes.
+
+7. **`SupportsVision(modelId)` helper** in each client + a UI affordance
+   that disables the attach button (or shows a tooltip) when the
+   currently-selected model doesn't support vision.
+
+8. **Soft size caps** in the input handler.
+
+Each step compiles and runs on its own. Step 3 alone makes vision work
+for Claude users; everything after step 3 broadens compatibility.
+
+---
+
+## Testing checklist (before merging the feature)
+
+- [ ] Paste a screenshot into the chat input — thumbnail appears in the
+      pending strip.
+- [ ] Send a message with one attachment to Claude Sonnet — Claude
+      describes the image accurately.
+- [ ] Send to a non-vision model (e.g. Llama 3.1 8B text-only) — UI shows
+      "model does not support vision" warning, attachment is dropped.
+- [ ] Reload the session from disk — the message renders with the
+      attachment intact.
+- [ ] Drag-drop a `.png` and a `.jpg` from Explorer — both attach.
+- [ ] Try a 6 MB image — rejected with toast.
+- [ ] Try ten 1 MB images on one message — rejected at the 20 MB total.
+- [ ] Run `publish-portable.ps1 -Zip`, smoke test the resulting
+      `HermesDesktop-portable-x64.zip` against the same checklist.
+
+---
+
+## Out of scope for the first vision PR
+
+- **Video/audio attachments** — different content blocks, different size
+  envelope, different model support. Defer.
+- **Generated images going *back* into the chat** — image-out from
+  DALL-E 3 / Imagen / Stable Diffusion is a separate feature.
+- **OCR fallback for non-vision models** — tempting (run images through a
+  cheap OCR tool and inject text), but it changes semantics in a way users
+  might not expect. Defer until someone explicitly asks.
+- **Image editing / annotation in the chat UI** — adds a whole subsystem.
+  If asked for, treat as a separate feature request.

--- a/Desktop/HermesDesktop/docs/VISION-SUPPORT-DESIGN.md
+++ b/Desktop/HermesDesktop/docs/VISION-SUPPORT-DESIGN.md
@@ -123,8 +123,12 @@ public sealed class ImageAttachment
     public required string MediaType { get; init; }
 
     /// <summary>
-    /// Raw base64 string (no "data:" prefix) following RFC 4648 with standard '=' padding preserved.
-    /// The value must be properly padded Base64 compatible with Convert.FromBase64String (length divisible by 4).
+    /// Raw RFC 4648 base64 string with standard '=' padding preserved (no "data:" prefix).
+    /// Producers MUST keep the trailing '=' characters: .NET's
+    /// `Convert.FromBase64String` requires either valid padding or a length
+    /// divisible by 4 and throws `FormatException` otherwise, and the
+    /// Anthropic / OpenAI / Ollama image APIs all expect standard
+    /// (padded) base64 — base64url is not interchangeable here.
     /// </summary>
     public required string Base64Data { get; init; }
 
@@ -218,19 +222,27 @@ Area — Claude Code style" StackPanel). Changes:
    image bytes don't end up as garbage text in the prompt box.
 
 3. **Drag-drop handler**: subscribe `PromptTextBox.DragOver` and
-   `PromptTextBox.Drop`. SECURITY: Do NOT rely on file extensions alone.
-   The Drop handler must:
-   - First enforce a raw-byte size cap before reading the full file
-   - Validate file type by inspecting magic bytes/MIME signature (PNG/JPEG/GIF headers)
-     before any base64 or full in-memory operations
-   - Perform safe/streaming decode to read image dimensions and enforce maximum
-     pixel count and dimension limits (reject if width*height or either side exceeds
-     thresholds) to prevent decompression-bomb attacks
-   - Strip/validate metadata
-   - Only then perform the in-memory/base64 encode
-   - Log all failures with clear error states
-   - Centralize these checks into a reusable validation helper used by
-     PromptTextBox.Drop and any related image intake code for consistency
+   `PromptTextBox.Drop`. **Do not trust the file extension** — an attacker
+   can rename a malicious file `pwn.png`. Validate intake in this order:
+   1. **Raw byte size cap first** — reject anything over the
+      single-attachment cap *before* reading the whole file into memory.
+   2. **Magic-byte signature check** — read the first 8 bytes and verify
+      against the canonical headers: PNG (`89 50 4E 47 0D 0A 1A 0A`), JPEG
+      (`FF D8 FF`), GIF (`47 49 46 38 37/39 61`), WebP (`52 49 46 46 ?? ?? ?? ?? 57 45 42 50`).
+      Reject anything that doesn't match a supported image format.
+   3. **Decoder probe + pixel-dimension cap** — use `BitmapDecoder.CreateAsync`
+      to read just the header / pixel dimensions without decoding the full
+      bitmap. Reject if `width * height > 50_000_000` (≈50 megapixels) or
+      if either dimension exceeds 16384 px. This is the decompression-bomb
+      defense — a 1 KB GIF can declare a 100,000 × 100,000 canvas that
+      blows out memory at decode time.
+   4. **Then** base64-encode and add to the pending-attachments list.
+
+   Centralize all four checks into a `ImageAttachmentIntake.TryAcceptAsync(stream, fileName)`
+   helper so the paste handler, drag-drop handler, and any future file-picker
+   path all use the same validation. Failures should return a structured
+   `ValidationFailureReason` enum (TooLarge, UnsupportedFormat, TooManyPixels,
+   DecodeError) and surface a toast to the user — never silently drop.
 
 4. **Pending attachments strip**: a horizontal `ItemsRepeater` above the
    prompt textbox showing thumbnails of attachments staged for the next
@@ -271,44 +283,46 @@ use; the soft cap below catches abuse.
 toast "Image too large — please resize before sending". Reject the message
 send if total attachments for the message exceed **20 MB** decoded. These
 are arbitrary but generous defaults; expose them in `config.yaml` under a
-new `vision:` section if users complain.
+new `vision:` section.
 
 ### Privacy & Retention
 
-Screenshots may contain PII, secrets, or sensitive data. The following
-protections and policies apply:
+Inlining base64 in the transcript is operationally simple, but screenshots
+routinely capture passwords, API keys, terminal sessions, browser tabs,
+and PII. Treat persisted attachments as sensitive-by-default and require:
 
-- **Encryption at rest**: Optional toggle (`vision.encryption_enabled` in
-  `config.yaml`) to encrypt inline base64 attachments in the transcript JSON
-  using platform-native credential storage (Windows DPAPI / macOS Keychain).
-  Default: disabled (plain base64) for simplicity and portability.
+1. **Encryption at rest (opt-in):** add `vision.encryption_enabled` to
+   `config.yaml`. When true, the transcript writer wraps the attachment
+   payload with an AES-GCM envelope keyed off a per-install key stored in
+   `%LOCALAPPDATA%\hermes\keys\` (Windows DPAPI for the key file, so it's
+   bound to the OS user). Default OFF for v1 because it adds load-time
+   cost and key-rotation work; flip the default ON once the key
+   management UX is in place.
+2. **Retention policy:** add `vision.retention_days` (default `0` = keep
+   forever, matches today's transcript behavior). When > 0, a periodic
+   sweep in `TranscriptStore` rewrites old transcript files dropping
+   attachment payloads while keeping the message scaffolding (so the
+   chat history still renders, just without the image). Document the
+   sweep cadence and surface "this image was retention-evicted" in the
+   chat bubble where the thumbnail used to be.
+3. **Single-attachment / total-message size caps:**
+   `vision.max_attachment_size_mb` (default 5) and
+   `vision.max_total_attachment_size_mb` (default 20) — these mirror the
+   intake caps above so config and code agree.
+4. **Export warning:** when the user exports a session (transcript copy,
+   share dialog, "send to support" feature), show a one-time confirm:
+   "This session contains N embedded images. Images may include sensitive
+   information visible on your screen at capture time. Continue?". Don't
+   ask every time — store the per-session decision in session state.
+5. **Cross-reference:** see `security.instructions.md` (no hard-coded
+   secrets, validate inputs, least privilege) when implementing the
+   intake helper and the encryption-at-rest path.
 
-- **Retention policy**: Configurable GC for transcript attachments via
-  `vision.retention_days` in `config.yaml`. Attachments older than the
-  retention window are stripped from transcripts during periodic cleanup.
-  Default: no automatic deletion (manual session management).
-
-- **Maximum attachment size**: `vision.max_attachment_size_mb` in
-  `config.yaml` controls the per-image size cap. Default: 5 MB decoded.
-
-- **Export warning**: Session export UI must display a clear warning that
-  exported transcripts may contain screenshots with PII/secrets. Users
-  should review attachments before sharing.
-
-- **Security guidance**: See `security.instructions.md` for additional
-  guidance on input validation, avoiding hard-coded secrets, and least
-  privilege when handling user-provided images.
-
-**Proposed config.yaml keys:**
-```yaml
-vision:
-  encryption_enabled: false        # Encrypt attachments at rest
-  retention_days: 0                # Auto-delete attachments older than N days (0 = never)
-  max_attachment_size_mb: 5        # Per-image size cap
-```
-
-Cross-reference: `security.instructions.md` (no hard-coded secrets, input
-validation, least privilege).
+The four new `config.yaml` keys to wire through are
+`vision.encryption_enabled`, `vision.retention_days`,
+`vision.max_attachment_size_mb`, and `vision.max_total_attachment_size_mb`
+— grep for these names when implementing so the schema, env loader, and
+defaults stay aligned.
 
 **Alternative (rejected):** writing images to
 `%LOCALAPPDATA%\hermes\images\` with a content hash and storing only the

--- a/Desktop/HermesDesktop/docs/VISION-SUPPORT-DESIGN.md
+++ b/Desktop/HermesDesktop/docs/VISION-SUPPORT-DESIGN.md
@@ -122,7 +122,10 @@ public sealed class ImageAttachment
     /// <summary>MIME type, e.g. "image/png" or "image/jpeg".</summary>
     public required string MediaType { get; init; }
 
-    /// <summary>Raw base64 string (no "data:" prefix, no padding rules).</summary>
+    /// <summary>
+    /// Raw base64 string (no "data:" prefix) following RFC 4648 with standard '=' padding preserved.
+    /// The value must be properly padded Base64 compatible with Convert.FromBase64String (length divisible by 4).
+    /// </summary>
     public required string Base64Data { get; init; }
 
     /// <summary>Optional source filename for display in the UI / logs.</summary>
@@ -215,8 +218,19 @@ Area — Claude Code style" StackPanel). Changes:
    image bytes don't end up as garbage text in the prompt box.
 
 3. **Drag-drop handler**: subscribe `PromptTextBox.DragOver` and
-   `PromptTextBox.Drop`. Accept files with image extensions, read them,
-   base64-encode.
+   `PromptTextBox.Drop`. SECURITY: Do NOT rely on file extensions alone.
+   The Drop handler must:
+   - First enforce a raw-byte size cap before reading the full file
+   - Validate file type by inspecting magic bytes/MIME signature (PNG/JPEG/GIF headers)
+     before any base64 or full in-memory operations
+   - Perform safe/streaming decode to read image dimensions and enforce maximum
+     pixel count and dimension limits (reject if width*height or either side exceeds
+     thresholds) to prevent decompression-bomb attacks
+   - Strip/validate metadata
+   - Only then perform the in-memory/base64 encode
+   - Log all failures with clear error states
+   - Centralize these checks into a reusable validation helper used by
+     PromptTextBox.Drop and any related image intake code for consistency
 
 4. **Pending attachments strip**: a horizontal `ItemsRepeater` above the
    prompt textbox showing thumbnails of attachments staged for the next
@@ -258,6 +272,43 @@ toast "Image too large — please resize before sending". Reject the message
 send if total attachments for the message exceed **20 MB** decoded. These
 are arbitrary but generous defaults; expose them in `config.yaml` under a
 new `vision:` section if users complain.
+
+### Privacy & Retention
+
+Screenshots may contain PII, secrets, or sensitive data. The following
+protections and policies apply:
+
+- **Encryption at rest**: Optional toggle (`vision.encryption_enabled` in
+  `config.yaml`) to encrypt inline base64 attachments in the transcript JSON
+  using platform-native credential storage (Windows DPAPI / macOS Keychain).
+  Default: disabled (plain base64) for simplicity and portability.
+
+- **Retention policy**: Configurable GC for transcript attachments via
+  `vision.retention_days` in `config.yaml`. Attachments older than the
+  retention window are stripped from transcripts during periodic cleanup.
+  Default: no automatic deletion (manual session management).
+
+- **Maximum attachment size**: `vision.max_attachment_size_mb` in
+  `config.yaml` controls the per-image size cap. Default: 5 MB decoded.
+
+- **Export warning**: Session export UI must display a clear warning that
+  exported transcripts may contain screenshots with PII/secrets. Users
+  should review attachments before sharing.
+
+- **Security guidance**: See `security.instructions.md` for additional
+  guidance on input validation, avoiding hard-coded secrets, and least
+  privilege when handling user-provided images.
+
+**Proposed config.yaml keys:**
+```yaml
+vision:
+  encryption_enabled: false        # Encrypt attachments at rest
+  retention_days: 0                # Auto-delete attachments older than N days (0 = never)
+  max_attachment_size_mb: 5        # Per-image size cap
+```
+
+Cross-reference: `security.instructions.md` (no hard-coded secrets, input
+validation, least privilege).
 
 **Alternative (rejected):** writing images to
 `%LOCALAPPDATA%\hermes\images\` with a content hash and storing only the

--- a/src/Core/ActivityEntry.cs
+++ b/src/Core/ActivityEntry.cs
@@ -6,11 +6,25 @@ public enum ActivityStatus { Running, Success, Failed, Denied }
 
 public sealed class ActivityEntry
 {
-    private static long _nextActivitySequence = 0;
+    // Process-wide monotonically increasing counter used as a stable secondary
+    // sort key when two ActivityEntry instances share the same Timestamp.
+    // DateTime.UtcNow only has ~16ms tick resolution on Windows and parallel
+    // tool execution can produce two entries in the same tick, so sorting by
+    // Timestamp alone is not deterministic — Sequence guarantees insertion
+    // order is preserved when ReplayPanel sorts for chronological playback.
+    private static long _nextSequence;
 
     public string Id { get; init; } = Guid.NewGuid().ToString("N")[..8];
     public DateTime Timestamp { get; init; } = DateTime.UtcNow;
-    public long Sequence { get; init; } = Interlocked.Increment(ref _nextActivitySequence);
+
+    /// <summary>
+    /// Process-monotonic creation sequence number. Used by ReplayPanel as a
+    /// tie-breaker when sorting by Timestamp for playback so two activities
+    /// created in the same tick still play back in the order they were
+    /// recorded. Assigned automatically; do not set explicitly.
+    /// </summary>
+    public long Sequence { get; init; } = Interlocked.Increment(ref _nextSequence);
+
     public long DurationMs { get; set; }
     public required string ToolName { get; init; }
     public string? ToolCallId { get; init; }

--- a/src/Core/ActivityEntry.cs
+++ b/src/Core/ActivityEntry.cs
@@ -1,11 +1,16 @@
+using System.Threading;
+
 namespace Hermes.Agent.Core;
 
 public enum ActivityStatus { Running, Success, Failed, Denied }
 
 public sealed class ActivityEntry
 {
+    private static long _nextActivitySequence = 0;
+
     public string Id { get; init; } = Guid.NewGuid().ToString("N")[..8];
     public DateTime Timestamp { get; init; } = DateTime.UtcNow;
+    public long Sequence { get; init; } = Interlocked.Increment(ref _nextActivitySequence);
     public long DurationMs { get; set; }
     public required string ToolName { get; init; }
     public string? ToolCallId { get; init; }

--- a/src/Core/agent.cs
+++ b/src/Core/agent.cs
@@ -66,10 +66,18 @@ public sealed class Agent : IAgent
 
     /// <summary>
     /// Optional callback for interactive permission prompts.
-    /// When PermissionBehavior.Ask is returned, this callback is invoked with (toolName, message).
-    /// Returns true to allow, false to deny. If null, Ask defaults to deny.
+    /// When PermissionBehavior.Ask is returned, this callback is invoked with
+    /// (toolName, message, toolArguments). The third argument is the raw JSON
+    /// arguments string the model passed to the tool — for the bash tool that
+    /// is the actual shell command about to run, for read/write/edit it is the
+    /// path and contents, etc. Surfacing it in the prompt UI lets technical
+    /// users audit exactly what the agent is about to execute *before*
+    /// approving it, instead of only seeing it after the fact in the activity
+    /// log. May be null if the host did not capture the arguments.
+    /// Returns true to allow, false to deny. If the callback itself is null,
+    /// Ask defaults to deny.
     /// </summary>
-    public Func<string, string, Task<bool>>? PermissionPromptCallback { get; set; }
+    public Func<string, string, string?, Task<bool>>? PermissionPromptCallback { get; set; }
 
     public Agent(
         IChatClient chatClient,
@@ -370,7 +378,11 @@ public sealed class Agent : IAgent
                             {
                                 try
                                 {
-                                    allowed = await PermissionPromptCallback(toolCall.Name, permissionMessage);
+                                    // Pass the raw tool arguments (the actual command/path/payload
+                                    // the model wants the tool to run) to the prompt UI so the user
+                                    // can audit it before approving — see PermissionPromptCallback
+                                    // doc above.
+                                    allowed = await PermissionPromptCallback(toolCall.Name, permissionMessage, toolCall.Arguments);
                                 }
                                 catch (Exception promptEx)
                                 {
@@ -689,7 +701,7 @@ public sealed class Agent : IAgent
                             {
                                 try
                                 {
-                                    allowed = await PermissionPromptCallback(toolCall.Name, permissionMessage);
+                                    allowed = await PermissionPromptCallback(toolCall.Name, permissionMessage, toolCall.Arguments);
                                 }
                                 catch (Exception promptEx)
                                 {

--- a/wiki/entities/agent-class.md
+++ b/wiki/entities/agent-class.md
@@ -48,7 +48,7 @@ Only `chatClient` and `logger` are required. All subsystems are optional -- Agen
 ## Key Properties
 
 - `MaxToolIterations` -- default 25, safety limit for tool loops
-- `PermissionPromptCallback` -- `Func<string, string, Task<bool>>?` for interactive permission prompts
+- `PermissionPromptCallback` -- `Func<string, string, string?, Task<bool>>?` for interactive permission prompts. Receives `(toolName, message, toolArguments)` so the host UI can surface the literal command/args being audited.
 - `ActivityLog` -- `List<ActivityEntry>` for current agent lifetime
 - `ActivityEntryAdded` -- `event Action<ActivityEntry>?`
 - `Tools` -- `IReadOnlyDictionary<string, ITool>`

--- a/wiki/systems/agent-loop.md
+++ b/wiki/systems/agent-loop.md
@@ -38,7 +38,7 @@ The Agent class (`src/Core/agent.cs`, ~1040 lines) is the central orchestrator. 
 Three outcomes from `PermissionManager.CheckPermissionsAsync`:
 - **Allow** -- execute immediately
 - **Deny** -- log denial, inject denial message as tool result, skip
-- **Ask** -- invoke `PermissionPromptCallback(toolName, message)`. Null callback = deny.
+- **Ask** -- invoke `PermissionPromptCallback(toolName, message, toolArguments)` where `toolArguments` is the raw JSON args (e.g. the literal `command` for bash). Null callback = deny.
 
 ## Activity Logging
 


### PR DESCRIPTION
Addresses 4 of 5 items from the v2.3.1 portable testing feedback: command audit before approval, missing terminal output bug, reverse activity order, and copy-paste support. Item 5 (vision/multimodal) is documented as a design but deferred — it touches the message model and every provider client and is too much surface area to ship blind without a real Windows build+test loop.

[#1 Security] Show actual command in permission dialog ───────────────────────────────────────────────────── Previously the WinUI ContentDialog only showed `decision.Message` ("This operation requires permission" or similar), with no visibility into the literal shell command the model wanted to run. Technical users had to wait until *after* execution to see what happened in the activity log — exactly the wrong order for an audit.

- src/Core/agent.cs: extend `PermissionPromptCallback` from `Func<string, string, Task<bool>>?` to `Func<string, string, string?, Task<bool>>?` adding a `toolArguments` parameter (the raw JSON args from `toolCall.Arguments`). Both call sites — sequential ChatAsync at line ~373 and streaming StreamChatAsync at line ~692 — pass `toolCall.Arguments` through.
- Desktop/HermesDesktop/App.xaml.cs: rebuild the prompt body as a vertical StackPanel with the human-readable message followed by a monospace, read-only TextBox containing the formatted command. New helper `FormatToolArgumentsForPrompt(toolName, toolArguments)` parses the JSON; for the bash tool it surfaces the literal `command` field verbatim (so the user sees `whoami` not `{"command":"whoami"}`), for other tools it pretty-prints the JSON, and falls back to the raw string on parse failure rather than hiding the audit information. DefaultButton = Close so an accidental Enter denies rather than approves — never let muscle memory grant permissions.
- wiki/entities/agent-class.md, wiki/systems/agent-loop.md: update the documented callback signature to match.

[#2 Bug] Missing terminal output in activity log
────────────────────────────────────────────────
Root cause: `ActivityDisplayItem.OutputFull` was a plain `{ get; set; }` auto-property with no PropertyChanged notification. The expanded "Output" TextBlock in ReplayPanel.xaml binds with `{x:Bind OutputFull, Mode=OneWay}`, which requires INotifyPropertyChanged to update. When the agent created the activity entry (status = Running, output = ""), the binding evaluated against an empty string. When the tool finished and `UpdateFrom` ran, `OutputFull = entry.OutputSummary` silently updated the backing field but the TextBlock never repainted — so quick commands like `whoami` and `date` looked like they returned nothing even though the data was right there in the model.

- Desktop/HermesDesktop/Models/ActivityDisplayItem.cs: convert `OutputFull` to a backed property with `_outputFull` field and `OnPropertyChanged()` in the setter. UpdateFrom unchanged — it was already setting the property, the property just wasn't broadcasting.

[#3 UX] Reverse activity order — newest on top
──────────────────────────────────────────────
- Desktop/HermesDesktop/Views/Panels/ReplayPanel.xaml.cs:
  - `AddOrUpdateInternal` now `Activities.Insert(0, …)` instead of `.Add(…)`, and ScrollIntoView targets `Activities[0]`.
  - `LoadSession` orders entries by `OrderByDescending(e => e.Timestamp)` before adding so reloading a transcript matches live ordering.
  - `PlaybackAsync` now snapshots `Activities.OrderBy(a => a.Timestamp)` so the Play button still walks the activity stream in chronological order regardless of display order — replay should always show actions in the order they actually happened.

[#4 UX] Copy-paste support
──────────────────────────
WinUI 3 TextBlocks default to non-selectable; setting `IsTextSelectionEnabled="True"` exposes Ctrl+C / drag-select without needing any C# changes.

- Desktop/HermesDesktop/Views/ChatPage.xaml: enable selection on the chat message body TextBlock and on the reasoning Expander content.
- Desktop/HermesDesktop/Views/Panels/ReplayPanel.xaml: enable selection on the activity Input, Output, and Diff blocks. PromptTextBox is already a TextBox and supports selection natively.

[#5 Feature] Image / vision support — designed, not implemented ─────────────────────────────────────────────────────────────── Desktop/HermesDesktop/docs/VISION-SUPPORT-DESIGN.md: complete design doc covering the per-provider wire formats (Anthropic content blocks, OpenAI image_url data URIs, Ollama images array, Qwen-style), the proposed `ImageAttachment` model and `Message.Attachments` extension, storage policy (inline base64 in transcript with 5MB single / 20MB total soft caps), an 8-step implementation order chosen to minimize broken intermediate states (one provider at a time, each step compiles standalone), and a testing checklist. Not coded in this commit because it touches the core message model, every provider client, and the chat input/render pipeline — too much surface area to ship without a real Windows build+test loop. The doc is precise enough that the next session (or another contributor) can pick it up and execute confidently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the security-sensitive permission gating flow by changing `PermissionPromptCallback`’s signature and wiring new UI prompt behavior; mistakes here could block tools or allow unintended execution. Additional UI/binding and ordering changes are moderate risk but mostly isolated to desktop presentation logic.
> 
> **Overview**
> **Permission prompts now include auditable tool arguments.** The core agent extends `PermissionPromptCallback` to receive `(toolName, message, toolArguments)` and forwards `toolCall.Arguments` in both non-streaming and streaming tool loops; the desktop app wires this into a new `PermissionDialogService` that renders a richer dialog (including formatted command/args) and avoids dispatcher-shutdown hangs.
> 
> **Replay/Chat UX and logging fixes.** Activity items gain a stable `Sequence` tie-breaker and the Replay panel displays newest-first while still replaying chronologically; `ActivityDisplayItem.OutputFull` now notifies on change to fix missing expanded output. Chat and replay text blocks are made selectable and replay detail sections switch to scrollable, selectable blocks. A vision/multimodal support plan is added as a *design doc only* (no implementation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e48e5fd21970511b4638d2cbd78e9c9ad2b03451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->