### PR TITLE
Reduce repeated permission prompts with always-allow tool choice

### DIFF
--- a/Desktop/HermesDesktop.Tests/Services/PermissionManagerTests.cs
+++ b/Desktop/HermesDesktop.Tests/Services/PermissionManagerTests.cs
@@ -257,4 +257,18 @@ public class PermissionManagerTests
 
         Assert.IsTrue(manager.HasAlwaysAllowRule("WRITE_FILE"));
     }
+
+    [TestMethod]
+    public void ClearAlwaysAllowRules_RemovesAllRememberedRules()
+    {
+        var manager = CreateManager(PermissionMode.Default);
+        manager.AddAlwaysAllowRule("write_file");
+        manager.AddAlwaysAllowRule("bash");
+
+        manager.ClearAlwaysAllowRules();
+
+        Assert.IsFalse(manager.HasAlwaysAllowRule("write_file"));
+        Assert.IsFalse(manager.HasAlwaysAllowRule("bash"));
+        Assert.AreEqual(0, manager.GetAlwaysAllowRulesSnapshot().Count);
+    }
 }

--- a/Desktop/HermesDesktop.Tests/Services/PermissionManagerTests.cs
+++ b/Desktop/HermesDesktop.Tests/Services/PermissionManagerTests.cs
@@ -216,4 +216,45 @@ public class PermissionManagerTests
         Assert.AreEqual(PermissionBehavior.Ask, decision.Behavior);
         StringAssert.Contains(decision.Message ?? string.Empty, "Unknown mode");
     }
+
+    [TestMethod]
+    public async Task AddAlwaysAllowRule_DefaultMode_PreventsFuturePermissionPrompts()
+    {
+        var manager = CreateManager(PermissionMode.Default);
+        var added = manager.AddAlwaysAllowRule("write_file");
+
+        var decision = await manager.CheckPermissionsAsync("write_file", "{\"path\":\"x.txt\"}", CancellationToken.None);
+
+        Assert.IsTrue(added);
+        Assert.AreEqual(PermissionBehavior.Allow, decision.Behavior);
+    }
+
+    [TestMethod]
+    public void AddAlwaysAllowRule_DuplicateRule_ReturnsFalse()
+    {
+        var manager = CreateManager(PermissionMode.Default);
+
+        var first = manager.AddAlwaysAllowRule("bash");
+        var second = manager.AddAlwaysAllowRule("bash");
+
+        Assert.IsTrue(first);
+        Assert.IsFalse(second);
+    }
+
+    [TestMethod]
+    public void AddAlwaysAllowRule_InvalidToolName_ThrowsArgumentException()
+    {
+        var manager = CreateManager(PermissionMode.Default);
+
+        Assert.ThrowsException<ArgumentException>(() => manager.AddAlwaysAllowRule("   "));
+    }
+
+    [TestMethod]
+    public void HasAlwaysAllowRule_RespectsCaseInsensitiveRuleMatching()
+    {
+        var manager = CreateManager(PermissionMode.Default);
+        manager.AddAlwaysAllowRule("write_file");
+
+        Assert.IsTrue(manager.HasAlwaysAllowRule("WRITE_FILE"));
+    }
 }

--- a/Desktop/HermesDesktop.Tests/Services/WorkspacePermissionRuleStoreTests.cs
+++ b/Desktop/HermesDesktop.Tests/Services/WorkspacePermissionRuleStoreTests.cs
@@ -1,0 +1,151 @@
+using Hermes.Agent.Permissions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HermesDesktop.Tests.Services;
+
+[TestClass]
+public sealed class WorkspacePermissionRuleStoreTests
+{
+    [TestMethod]
+    public void LoadAlwaysAllowRules_MissingFile_ReturnsEmptyList()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var store = CreateStore(root, "/tmp/workspace-a");
+
+            var rules = store.LoadAlwaysAllowRules();
+
+            Assert.AreEqual(0, rules.Count);
+        }
+        finally
+        {
+            DeleteDirectory(root);
+        }
+    }
+
+    [TestMethod]
+    public void SaveAlwaysAllowRules_ThenLoad_ReturnsPersistedRules()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var store = CreateStore(root, "/tmp/workspace-a");
+            var rules = new[]
+            {
+                new PermissionRule { ToolName = "bash" },
+                new PermissionRule { ToolName = "write_file", Pattern = "**/*.md" }
+            };
+
+            store.SaveAlwaysAllowRules(rules);
+            var reloaded = store.LoadAlwaysAllowRules();
+
+            Assert.AreEqual(2, reloaded.Count);
+            Assert.AreEqual("bash", reloaded[0].ToolName);
+            Assert.AreEqual("write_file", reloaded[1].ToolName);
+            Assert.AreEqual("**/*.md", reloaded[1].Pattern);
+        }
+        finally
+        {
+            DeleteDirectory(root);
+        }
+    }
+
+    [TestMethod]
+    public void SaveAlwaysAllowRules_DuplicateEntries_AreDeduplicated()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var store = CreateStore(root, "/tmp/workspace-a");
+            var rules = new[]
+            {
+                new PermissionRule { ToolName = "bash" },
+                new PermissionRule { ToolName = "BASH" },
+                new PermissionRule { ToolName = "write_file", Pattern = "**/*.md" },
+                new PermissionRule { ToolName = "write_file", Pattern = "  **/*.md  " }
+            };
+
+            store.SaveAlwaysAllowRules(rules);
+            var reloaded = store.LoadAlwaysAllowRules();
+
+            Assert.AreEqual(2, reloaded.Count);
+        }
+        finally
+        {
+            DeleteDirectory(root);
+        }
+    }
+
+    [TestMethod]
+    public void SaveAlwaysAllowRules_DifferentWorkspaces_AreIsolated()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var workspaceAStore = CreateStore(root, "/tmp/workspace-a");
+            var workspaceBStore = CreateStore(root, "/tmp/workspace-b");
+            workspaceAStore.SaveAlwaysAllowRules(new[]
+            {
+                new PermissionRule { ToolName = "bash" }
+            });
+            workspaceBStore.SaveAlwaysAllowRules(new[]
+            {
+                new PermissionRule { ToolName = "write_file" }
+            });
+
+            var rulesA = workspaceAStore.LoadAlwaysAllowRules();
+            var rulesB = workspaceBStore.LoadAlwaysAllowRules();
+
+            Assert.AreEqual(1, rulesA.Count);
+            Assert.AreEqual("bash", rulesA[0].ToolName);
+            Assert.AreEqual(1, rulesB.Count);
+            Assert.AreEqual("write_file", rulesB[0].ToolName);
+        }
+        finally
+        {
+            DeleteDirectory(root);
+        }
+    }
+
+    [TestMethod]
+    public void LoadAlwaysAllowRules_InvalidJson_ReturnsEmptyList()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var store = CreateStore(root, "/tmp/workspace-a");
+            File.WriteAllText(store.WorkspaceFilePath, "{invalid-json");
+
+            var rules = store.LoadAlwaysAllowRules();
+
+            Assert.AreEqual(0, rules.Count);
+        }
+        finally
+        {
+            DeleteDirectory(root);
+        }
+    }
+
+    private static WorkspacePermissionRuleStore CreateStore(string root, string workspacePath)
+    {
+        return new WorkspacePermissionRuleStore(
+            root,
+            workspacePath,
+            NullLogger<WorkspacePermissionRuleStore>.Instance);
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "WorkspacePermissionRuleStoreTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void DeleteDirectory(string path)
+    {
+        if (Directory.Exists(path))
+            Directory.Delete(path, recursive: true);
+    }
+}

--- a/Desktop/HermesDesktop.Tests/Services/WorkspacePermissionRuleStoreTests.cs
+++ b/Desktop/HermesDesktop.Tests/Services/WorkspacePermissionRuleStoreTests.cs
@@ -128,6 +128,32 @@ public sealed class WorkspacePermissionRuleStoreTests
         }
     }
 
+    [TestMethod]
+    public void ClearAlwaysAllowRules_RemovesWorkspaceFile_AndReturnsNoRules()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var store = CreateStore(root, "/tmp/workspace-a");
+            store.SaveAlwaysAllowRules(new[]
+            {
+                new PermissionRule { ToolName = "bash" }
+            });
+
+            Assert.IsTrue(File.Exists(store.WorkspaceFilePath));
+
+            store.ClearAlwaysAllowRules();
+            var reloaded = store.LoadAlwaysAllowRules();
+
+            Assert.IsFalse(File.Exists(store.WorkspaceFilePath));
+            Assert.AreEqual(0, reloaded.Count);
+        }
+        finally
+        {
+            DeleteDirectory(root);
+        }
+    }
+
     private static WorkspacePermissionRuleStore CreateStore(string root, string workspacePath)
     {
         return new WorkspacePermissionRuleStore(

--- a/Desktop/HermesDesktop/App.xaml.cs
+++ b/Desktop/HermesDesktop/App.xaml.cs
@@ -365,10 +365,26 @@ public partial class App : Application
             skillsDir,
             sp.GetRequiredService<ILogger<SkillManager>>()));
 
-        // Permission manager
-        services.AddSingleton(sp => new PermissionManager(
-            new PermissionContext(),
-            sp.GetRequiredService<ILogger<PermissionManager>>()));
+        // Permission manager + workspace-scoped permission memory
+        var permissionMemoryDir = Path.Combine(projectDir, "permissions");
+        var workspacePath = HermesEnvironment.AgentWorkingDirectory;
+        services.AddSingleton(sp => new WorkspacePermissionRuleStore(
+            permissionMemoryDir,
+            workspacePath,
+            sp.GetRequiredService<ILogger<WorkspacePermissionRuleStore>>()));
+        services.AddSingleton(sp =>
+        {
+            var store = sp.GetRequiredService<WorkspacePermissionRuleStore>();
+            var context = new PermissionContext();
+            foreach (var rule in store.LoadAlwaysAllowRules())
+            {
+                context.AlwaysAllow.Add(rule);
+            }
+
+            return new PermissionManager(
+                context,
+                sp.GetRequiredService<ILogger<PermissionManager>>());
+        });
 
         // Task manager
         var tasksDir = Path.Combine(projectDir, "tasks");
@@ -622,6 +638,7 @@ public partial class App : Application
     {
         var agent = services.GetRequiredService<Hermes.Agent.Core.Agent>();
         var permissionManager = services.GetRequiredService<PermissionManager>();
+        var permissionStore = services.GetRequiredService<WorkspacePermissionRuleStore>();
         // Resolve the dialog service once; it captures the active window's
         // DispatcherQueue and XamlRoot internally and is safe to reuse across
         // many permission prompts. PermissionDialogService is the dedicated
@@ -640,9 +657,12 @@ public partial class App : Application
                 switch (decision)
                 {
                     case PermissionPromptDecision.AlwaysAllowTool:
-                        // Persist in-memory for the app lifetime so repeated tool calls
-                        // no longer prompt during this run.
-                        permissionManager.AddAlwaysAllowRule(toolName);
+                        // Persist for this workspace so repeated tool calls no
+                        // longer prompt on future runs.
+                        if (permissionManager.AddAlwaysAllowRule(toolName))
+                        {
+                            permissionStore.SaveAlwaysAllowRules(permissionManager.GetAlwaysAllowRulesSnapshot());
+                        }
                         return true;
 
                     case PermissionPromptDecision.AllowOnce:

--- a/Desktop/HermesDesktop/App.xaml.cs
+++ b/Desktop/HermesDesktop/App.xaml.cs
@@ -621,6 +621,7 @@ public partial class App : Application
     private static void WirePermissionCallback(IServiceProvider services)
     {
         var agent = services.GetRequiredService<Hermes.Agent.Core.Agent>();
+        var permissionManager = services.GetRequiredService<PermissionManager>();
         // Resolve the dialog service once; it captures the active window's
         // DispatcherQueue and XamlRoot internally and is safe to reuse across
         // many permission prompts. PermissionDialogService is the dedicated
@@ -635,7 +636,21 @@ public partial class App : Application
                 var dialogService = new HermesDesktop.Services.PermissionDialogService(
                     app._window,
                     TryGetAppLogger());
-                return await dialogService.ShowPermissionDialogAsync(message, toolName, toolArguments);
+                var decision = await dialogService.ShowPermissionDecisionAsync(message, toolName, toolArguments);
+                switch (decision)
+                {
+                    case PermissionPromptDecision.AlwaysAllowTool:
+                        // Persist in-memory for the app lifetime so repeated tool calls
+                        // no longer prompt during this run.
+                        permissionManager.AddAlwaysAllowRule(toolName);
+                        return true;
+
+                    case PermissionPromptDecision.AllowOnce:
+                        return true;
+
+                    default:
+                        return false;
+                }
             }
             return false;
         };

--- a/Desktop/HermesDesktop/Services/HermesChatService.cs
+++ b/Desktop/HermesDesktop/Services/HermesChatService.cs
@@ -21,6 +21,7 @@ internal sealed class HermesChatService : IDisposable
     private readonly IChatClient _chatClient;
     private readonly TranscriptStore _transcriptStore;
     private readonly PermissionManager _permissionManager;
+    private readonly WorkspacePermissionRuleStore _permissionRuleStore;
     private readonly ILogger<HermesChatService> _logger;
 
     private Session? _currentSession;
@@ -32,12 +33,14 @@ internal sealed class HermesChatService : IDisposable
         IChatClient chatClient,
         TranscriptStore transcriptStore,
         PermissionManager permissionManager,
+        WorkspacePermissionRuleStore permissionRuleStore,
         ILogger<HermesChatService> logger)
     {
         _agent = agent;
         _chatClient = chatClient;
         _transcriptStore = transcriptStore;
         _permissionManager = permissionManager;
+        _permissionRuleStore = permissionRuleStore;
         _logger = logger;
         CurrentPermissionMode = _permissionManager.Mode;
     }
@@ -221,6 +224,12 @@ internal sealed class HermesChatService : IDisposable
     {
         _permissionManager.Mode = mode;
         CurrentPermissionMode = mode;
+    }
+
+    public void ClearRememberedPermissionsForWorkspace()
+    {
+        _permissionManager.ClearAlwaysAllowRules();
+        _permissionRuleStore.ClearAlwaysAllowRules();
     }
 
     // ── Tool Registration ──

--- a/Desktop/HermesDesktop/Services/PermissionDialogService.cs
+++ b/Desktop/HermesDesktop/Services/PermissionDialogService.cs
@@ -10,6 +10,13 @@ using Microsoft.UI.Xaml.Media;
 
 namespace HermesDesktop.Services;
 
+public enum PermissionPromptDecision
+{
+    Deny = 0,
+    AllowOnce = 1,
+    AlwaysAllowTool = 2,
+}
+
 /// <summary>
 /// Renders the WinUI permission prompt that fires when the agent's
 /// PermissionManager returns <c>PermissionBehavior.Ask</c>. Extracted from
@@ -46,11 +53,21 @@ public sealed class PermissionDialogService
     }
 
     /// <summary>
-    /// Show a modal permission prompt for the given tool and return whether
-    /// the user approved it. Returns <c>false</c> on any failure (window
-    /// gone, dispatcher shutting down, dialog throws) so the agent loop
-    /// always gets a definite answer instead of hanging on an uncompleted
-    /// task.
+    /// Backward-compatible allow/deny API. Prefer <see cref="ShowPermissionDecisionAsync"/>
+    /// for callers that need richer decisions.
+    /// </summary>
+    public async Task<bool> ShowPermissionDialogAsync(string message, string toolName, string? toolArguments)
+    {
+        var decision = await ShowPermissionDecisionAsync(message, toolName, toolArguments);
+        return decision is PermissionPromptDecision.AllowOnce or PermissionPromptDecision.AlwaysAllowTool;
+    }
+
+    /// <summary>
+    /// Show a modal permission prompt for the given tool and return a rich
+    /// decision (deny / allow once / always allow this tool). Returns deny
+    /// on any failure (window gone, dispatcher shutting down, dialog throws)
+    /// so the agent loop always gets a definite answer instead of hanging on
+    /// an uncompleted task.
     /// </summary>
     /// <param name="message">
     /// Human-readable explanation of why permission is being requested.
@@ -68,14 +85,17 @@ public sealed class PermissionDialogService
     /// JSON wrapper. May be null/empty if the host doesn't have it, in
     /// which case the Command section is omitted entirely.
     /// </param>
-    public Task<bool> ShowPermissionDialogAsync(string message, string toolName, string? toolArguments)
+    public Task<PermissionPromptDecision> ShowPermissionDecisionAsync(
+        string message,
+        string toolName,
+        string? toolArguments)
     {
         // RunContinuationsAsynchronously: when the dialog completes on the UI
         // thread, the awaiting agent loop must NOT pick up its continuation
         // synchronously on that same UI thread — otherwise the next iteration
         // of the agent loop would run inside the dispatcher callback and
         // create a re-entrancy hazard for subsequent permission prompts.
-        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tcs = new TaskCompletionSource<PermissionPromptDecision>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         // TryEnqueue can fail (return false) if the dispatcher has already
         // started shutting down — e.g. the user closed the window while the
@@ -89,7 +109,13 @@ public sealed class PermissionDialogService
             {
                 var dialog = BuildDialog(message, toolName, toolArguments);
                 var result = await dialog.ShowAsync();
-                tcs.TrySetResult(result == ContentDialogResult.Primary);
+                var decision = result switch
+                {
+                    ContentDialogResult.Primary => PermissionPromptDecision.AllowOnce,
+                    ContentDialogResult.Secondary => PermissionPromptDecision.AlwaysAllowTool,
+                    _ => PermissionPromptDecision.Deny
+                };
+                tcs.TrySetResult(decision);
             }
             catch (Exception ex)
             {
@@ -99,7 +125,7 @@ public sealed class PermissionDialogService
                         toolName);
                 else
                     Debug.WriteLine($"Permission prompt dialog failed for tool {toolName}: {ex}");
-                tcs.TrySetResult(false);
+                tcs.TrySetResult(PermissionPromptDecision.Deny);
             }
         });
 
@@ -112,7 +138,7 @@ public sealed class PermissionDialogService
             else
                 Debug.WriteLine(
                     $"DispatcherQueue.TryEnqueue refused permission prompt for tool {toolName}; denying by default");
-            tcs.TrySetResult(false);
+            tcs.TrySetResult(PermissionPromptDecision.Deny);
         }
 
         return tcs.Task;
@@ -172,7 +198,8 @@ public sealed class PermissionDialogService
         {
             Title = $"Permission Required: {toolName}",
             Content = body,
-            PrimaryButtonText = "Allow",
+            PrimaryButtonText = "Allow once",
+            SecondaryButtonText = "Always allow tool",
             CloseButtonText = "Deny",
             DefaultButton = ContentDialogButton.Close,
             XamlRoot = _window.Content.XamlRoot

--- a/Desktop/HermesDesktop/Strings/en-us/Resources.resw
+++ b/Desktop/HermesDesktop/Strings/en-us/Resources.resw
@@ -552,6 +552,18 @@
   <data name="ChatPermissionModeNameBypass" xml:space="preserve">
     <value>Bypass</value>
   </data>
+  <data name="ChatPermissionClearRememberedAction" xml:space="preserve">
+    <value>Clear remembered tool permissions (workspace)</value>
+  </data>
+  <data name="ChatPermissionClearRememberedSuccess" xml:space="preserve">
+    <value>Cleared remembered tool permissions for this workspace.</value>
+  </data>
+  <data name="ChatPermissionClearRememberedNoop" xml:space="preserve">
+    <value>No remembered workspace tool permissions to clear.</value>
+  </data>
+  <data name="ChatPermissionClearRememberedErrorFormat" xml:space="preserve">
+    <value>Could not clear remembered workspace tool permissions: {0}</value>
+  </data>
   <data name="DashOverviewKpiSessionsTitle.Text" xml:space="preserve">
     <value>Sessions</value>
   </data>

--- a/Desktop/HermesDesktop/Strings/zh-cn/Resources.resw
+++ b/Desktop/HermesDesktop/Strings/zh-cn/Resources.resw
@@ -495,6 +495,12 @@
   <data name="ChatPermissionModeChange.Content" xml:space="preserve">
     <value>更改</value>
   </data>
+  <data name="ChatPermissionModeClearWorkspacePermissions" xml:space="preserve">
+    <value>清除此工作区的记忆权限</value>
+  </data>
+  <data name="ChatPermissionModeClearWorkspacePermissionsConfirm" xml:space="preserve">
+    <value>已清除此工作区的记忆权限。</value>
+  </data>
   <data name="ChatPageDisclaimer.Text" xml:space="preserve">
     <value>Hermes 可能出错。重要信息请自行核实。</value>
   </data>

--- a/Desktop/HermesDesktop/Views/ChatPage.xaml.cs
+++ b/Desktop/HermesDesktop/Views/ChatPage.xaml.cs
@@ -14,6 +14,7 @@ using Hermes.Agent.Transcript;
 using HermesDesktop.Models;
 using HermesDesktop.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
@@ -33,6 +34,7 @@ public sealed partial class ChatPage : Page
     private readonly SessionRecorder _sessionRecorder = new();
     private readonly SoulService _soulService = App.Services.GetRequiredService<SoulService>();
     private readonly ChatClientFactory _clientFactory = App.Services.GetRequiredService<ChatClientFactory>();
+    private readonly ILogger<ChatPage> _logger = App.Services.GetRequiredService<ILogger<ChatPage>>();
     private bool _suppressModelSwitch;
     private readonly Brush _assistantBackgroundBrush;
     private readonly Brush _assistantBorderBrush;
@@ -561,6 +563,13 @@ public sealed partial class ChatPage : Page
             item.Click += (_, _) => SetPermissionModeUi(captured);
             flyout.Items.Add(item);
         }
+        flyout.Items.Add(new MenuFlyoutSeparator());
+        var clearRememberedItem = new MenuFlyoutItem
+        {
+            Text = ResourceLoader.GetString("ChatPermissionClearRemembered")
+        };
+        clearRememberedItem.Click += async (_, _) => await ClearRememberedPermissionsAsync();
+        flyout.Items.Add(clearRememberedItem);
         flyout.ShowAt((FrameworkElement)sender);
     }
 
@@ -582,6 +591,21 @@ public sealed partial class ChatPage : Page
         PermissionMode.BypassPermissions => ResourceLoader.GetString("ChatPermissionModeNameBypass"),
         _ => ResourceLoader.GetString("ChatPermissionModeNameDefault"),
     };
+
+    private async Task ClearRememberedPermissionsAsync()
+    {
+        try
+        {
+            _chatService.ClearRememberedWorkspacePermissions();
+            AppendSystemMessage(ResourceLoader.GetString("ChatPermissionRememberedCleared"));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed clearing remembered workspace permissions.");
+            AppendSystemMessage(ResourceLoader.GetString("ChatPermissionRememberedClearFailed"));
+            await Task.CompletedTask;
+        }
+    }
 
     private void UpdateSessionFooterLabel()
     {

--- a/src/permissions/permissionmanager.cs
+++ b/src/permissions/permissionmanager.cs
@@ -12,6 +12,7 @@ public sealed class PermissionManager
 {
     private readonly PermissionContext _context;
     private readonly ILogger<PermissionManager> _logger;
+    private readonly object _rulesLock = new();
     
     public PermissionManager(PermissionContext context, ILogger<PermissionManager> logger)
     {
@@ -23,6 +24,54 @@ public sealed class PermissionManager
     {
         get => _context.Mode;
         set => _context.Mode = value;
+    }
+
+    /// <summary>
+    /// Add an always-allow rule for a tool (and optional pattern).
+    /// Returns false when an equivalent rule already exists.
+    /// </summary>
+    public bool AddAlwaysAllowRule(string toolName, string? pattern = null)
+    {
+        if (string.IsNullOrWhiteSpace(toolName))
+            throw new ArgumentException("Tool name is required.", nameof(toolName));
+
+        var normalizedToolName = toolName.Trim();
+        var normalizedPattern = string.IsNullOrWhiteSpace(pattern) ? null : pattern.Trim();
+
+        lock (_rulesLock)
+        {
+            if (RuleExists(_context.AlwaysAllow, normalizedToolName, normalizedPattern))
+                return false;
+
+            _context.AlwaysAllow.Add(new PermissionRule
+            {
+                ToolName = normalizedToolName,
+                Pattern = normalizedPattern
+            });
+        }
+
+        _logger.LogInformation(
+            "Added always-allow rule for tool {ToolName} (pattern: {Pattern})",
+            normalizedToolName,
+            normalizedPattern ?? "<none>");
+        return true;
+    }
+
+    /// <summary>
+    /// Check whether an always-allow rule already exists for the given tool and pattern.
+    /// </summary>
+    public bool HasAlwaysAllowRule(string toolName, string? pattern = null)
+    {
+        if (string.IsNullOrWhiteSpace(toolName))
+            return false;
+
+        var normalizedToolName = toolName.Trim();
+        var normalizedPattern = string.IsNullOrWhiteSpace(pattern) ? null : pattern.Trim();
+
+        lock (_rulesLock)
+        {
+            return RuleExists(_context.AlwaysAllow, normalizedToolName, normalizedPattern);
+        }
     }
     
     /// <summary>
@@ -57,22 +106,34 @@ public sealed class PermissionManager
             }
         }
         
+        // Snapshot rules before evaluation so list mutation from the UI thread
+        // can't invalidate enumeration mid-check.
+        PermissionRule[] alwaysAllowRules;
+        PermissionRule[] alwaysDenyRules;
+        PermissionRule[] alwaysAskRules;
+        lock (_rulesLock)
+        {
+            alwaysAllowRules = _context.AlwaysAllow.ToArray();
+            alwaysDenyRules = _context.AlwaysDeny.ToArray();
+            alwaysAskRules = _context.AlwaysAsk.ToArray();
+        }
+
         // 2. Check always_allow rules
-        if (MatchesRule(toolName, input, _context.AlwaysAllow))
+        if (MatchesRule(toolName, input, alwaysAllowRules))
         {
             _logger.LogDebug("Matched always_allow rule for {ToolName}", toolName);
             return Allow(input);
         }
         
         // 3. Check always_deny rules
-        if (MatchesRule(toolName, input, _context.AlwaysDeny))
+        if (MatchesRule(toolName, input, alwaysDenyRules))
         {
             _logger.LogDebug("Matched always_deny rule for {ToolName}", toolName);
             return Deny($"Blocked by permission rule");
         }
         
         // 4. Check always_ask rules
-        if (MatchesRule(toolName, input, _context.AlwaysAsk))
+        if (MatchesRule(toolName, input, alwaysAskRules))
         {
             _logger.LogDebug("Matched always_ask rule for {ToolName}", toolName);
             return Ask($"Requires permission: {toolName}");
@@ -98,7 +159,7 @@ public sealed class PermissionManager
         return decision;
     }
     
-    private bool MatchesRule<T>(string toolName, T input, List<PermissionRule> rules)
+    private static bool MatchesRule<T>(string toolName, T input, IReadOnlyCollection<PermissionRule> rules)
     {
         foreach (var rule in rules)
         {
@@ -117,8 +178,26 @@ public sealed class PermissionManager
         
         return false;
     }
+
+    private static bool RuleExists(
+        IReadOnlyCollection<PermissionRule> rules,
+        string toolName,
+        string? pattern)
+    {
+        foreach (var rule in rules)
+        {
+            if (!string.Equals(rule.ToolName, toolName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var existingPattern = string.IsNullOrWhiteSpace(rule.Pattern) ? null : rule.Pattern.Trim();
+            if (string.Equals(existingPattern, pattern, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
     
-    private bool MatchesPattern<T>(T input, string pattern)
+    private static bool MatchesPattern<T>(T input, string pattern)
     {
         // Convert input to string for pattern matching
         var inputStr = input?.ToString() ?? "";

--- a/src/permissions/permissionmanager.cs
+++ b/src/permissions/permissionmanager.cs
@@ -73,6 +73,23 @@ public sealed class PermissionManager
             return RuleExists(_context.AlwaysAllow, normalizedToolName, normalizedPattern);
         }
     }
+
+    /// <summary>
+    /// Returns a cloned snapshot of always-allow rules suitable for persistence.
+    /// </summary>
+    public IReadOnlyList<PermissionRule> GetAlwaysAllowRulesSnapshot()
+    {
+        lock (_rulesLock)
+        {
+            return _context.AlwaysAllow
+                .Select(rule => new PermissionRule
+                {
+                    ToolName = rule.ToolName,
+                    Pattern = rule.Pattern
+                })
+                .ToArray();
+        }
+    }
     
     /// <summary>
     /// Check permissions for a tool call.

--- a/src/permissions/permissionmanager.cs
+++ b/src/permissions/permissionmanager.cs
@@ -90,6 +90,27 @@ public sealed class PermissionManager
                 .ToArray();
         }
     }
+
+    /// <summary>
+    /// Clears all always-allow rules currently loaded in memory.
+    /// Returns the number of removed rules.
+    /// </summary>
+    public int ClearAlwaysAllowRules()
+    {
+        int removedCount;
+        lock (_rulesLock)
+        {
+            removedCount = _context.AlwaysAllow.Count;
+            _context.AlwaysAllow.Clear();
+        }
+
+        if (removedCount > 0)
+        {
+            _logger.LogInformation("Cleared {RuleCount} always-allow permission rules.", removedCount);
+        }
+
+        return removedCount;
+    }
     
     /// <summary>
     /// Check permissions for a tool call.

--- a/src/permissions/workspacepermissionrulestore.cs
+++ b/src/permissions/workspacepermissionrulestore.cs
@@ -130,6 +130,22 @@ public sealed class WorkspacePermissionRuleStore
         }
     }
 
+    public void ClearAlwaysAllowRules()
+    {
+        try
+        {
+            if (File.Exists(_workspaceFilePath))
+                File.Delete(_workspaceFilePath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed clearing workspace permission rules at {Path}.",
+                _workspaceFilePath);
+        }
+    }
+
     private static string NormalizeWorkspacePath(string workspacePath)
     {
         return Path.GetFullPath(workspacePath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);

--- a/src/permissions/workspacepermissionrulestore.cs
+++ b/src/permissions/workspacepermissionrulestore.cs
@@ -1,0 +1,156 @@
+namespace Hermes.Agent.Permissions;
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Persists permission rules scoped to a specific workspace.
+/// </summary>
+public sealed class WorkspacePermissionRuleStore
+{
+    private readonly string _workspacePermissionsDir;
+    private readonly string _workspacePath;
+    private readonly string _workspaceKey;
+    private readonly string _workspaceFilePath;
+    private readonly ILogger<WorkspacePermissionRuleStore> _logger;
+
+    public WorkspacePermissionRuleStore(
+        string workspacePermissionsDir,
+        string workspacePath,
+        ILogger<WorkspacePermissionRuleStore> logger)
+    {
+        if (string.IsNullOrWhiteSpace(workspacePermissionsDir))
+            throw new ArgumentException("Permissions directory is required.", nameof(workspacePermissionsDir));
+        if (string.IsNullOrWhiteSpace(workspacePath))
+            throw new ArgumentException("Workspace path is required.", nameof(workspacePath));
+
+        _workspacePermissionsDir = workspacePermissionsDir;
+        _workspacePath = NormalizeWorkspacePath(workspacePath);
+        _workspaceKey = BuildWorkspaceKey(_workspacePath);
+        _workspaceFilePath = Path.Combine(_workspacePermissionsDir, $"{_workspaceKey}.json");
+        _logger = logger;
+    }
+
+    public string WorkspaceFilePath => _workspaceFilePath;
+
+    public IReadOnlyList<PermissionRule> LoadAlwaysAllowRules()
+    {
+        if (!File.Exists(_workspaceFilePath))
+            return Array.Empty<PermissionRule>();
+
+        try
+        {
+            var json = File.ReadAllText(_workspaceFilePath);
+            var payload = JsonSerializer.Deserialize<WorkspacePermissionRulePayload>(json);
+            if (payload?.AlwaysAllow is null || payload.AlwaysAllow.Count == 0)
+                return Array.Empty<PermissionRule>();
+
+            var dedupe = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var output = new List<PermissionRule>();
+            foreach (var item in payload.AlwaysAllow)
+            {
+                if (string.IsNullOrWhiteSpace(item.ToolName))
+                    continue;
+
+                var normalizedTool = item.ToolName.Trim();
+                var normalizedPattern = string.IsNullOrWhiteSpace(item.Pattern) ? null : item.Pattern.Trim();
+                var dedupeKey = $"{normalizedTool}\n{normalizedPattern ?? string.Empty}";
+                if (!dedupe.Add(dedupeKey))
+                    continue;
+
+                output.Add(new PermissionRule
+                {
+                    ToolName = normalizedTool,
+                    Pattern = normalizedPattern
+                });
+            }
+
+            return output;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed loading workspace permission rules from {Path}. Continuing with empty rules.",
+                _workspaceFilePath);
+            return Array.Empty<PermissionRule>();
+        }
+    }
+
+    public void SaveAlwaysAllowRules(IEnumerable<PermissionRule> rules)
+    {
+        ArgumentNullException.ThrowIfNull(rules);
+
+        var dedupe = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var normalized = new List<PermissionRuleItem>();
+        foreach (var rule in rules)
+        {
+            if (string.IsNullOrWhiteSpace(rule.ToolName))
+                continue;
+
+            var toolName = rule.ToolName.Trim();
+            var pattern = string.IsNullOrWhiteSpace(rule.Pattern) ? null : rule.Pattern.Trim();
+            var dedupeKey = $"{toolName}\n{pattern ?? string.Empty}";
+            if (!dedupe.Add(dedupeKey))
+                continue;
+
+            normalized.Add(new PermissionRuleItem
+            {
+                ToolName = toolName,
+                Pattern = pattern
+            });
+        }
+
+        var payload = new WorkspacePermissionRulePayload
+        {
+            WorkspacePath = _workspacePath,
+            AlwaysAllow = normalized
+        };
+
+        try
+        {
+            Directory.CreateDirectory(_workspacePermissionsDir);
+
+            var json = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+            var tempPath = $"{_workspaceFilePath}.{Guid.NewGuid():N}.tmp";
+            File.WriteAllText(tempPath, json);
+            File.Move(tempPath, _workspaceFilePath, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed saving workspace permission rules to {Path}.",
+                _workspaceFilePath);
+        }
+    }
+
+    private static string NormalizeWorkspacePath(string workspacePath)
+    {
+        return Path.GetFullPath(workspacePath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+
+    private static string BuildWorkspaceKey(string normalizedWorkspacePath)
+    {
+        var bytes = Encoding.UTF8.GetBytes(normalizedWorkspacePath);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private sealed class WorkspacePermissionRulePayload
+    {
+        public string WorkspacePath { get; set; } = string.Empty;
+        public List<PermissionRuleItem> AlwaysAllow { get; set; } = new();
+    }
+
+    private sealed class PermissionRuleItem
+    {
+        public string ToolName { get; set; } = string.Empty;
+        public string? Pattern { get; set; }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `PermissionManager.AddAlwaysAllowRule` and `HasAlwaysAllowRule` so permission decisions can be remembered per tool
- make permission rule reads/writes thread-safe by snapshotting rule lists under a lock before evaluation
- extend `PermissionDialogService` to return a richer decision (`Allow once`, `Always allow tool`, `Deny`) and expose an "Always allow tool" button in the dialog
- wire the agent permission callback in `App.xaml.cs` to persist an always-allow rule when the user chooses the new option
- expand `PermissionManagerTests` to cover rule insertion, duplicate prevention, validation, and case-insensitive lookup

## Verification
- `dotnet test ./Desktop/HermesDesktop.Tests/HermesDesktop.Tests.csproj -c Release --logger "trx;LogFileName=local-test-results.trx"` ✅ (498 passed)
- `dotnet build ./Desktop/HermesDesktop/HermesDesktop.csproj -c Release -p:Platform=x64 -p:EnableWindowsTargeting=true` ❌ expected on Linux cloud runner (`XamlCompiler.exe` Windows-only executable)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18f7ed9b-b01d-45a5-a38a-404e4bea7c62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18f7ed9b-b01d-45a5-a38a-404e4bea7c62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

