### PR TITLE
Add CI guardrail to block unresolved test symbol references

### DIFF
--- a/.github/workflows/ci-dotnet-tests.yml
+++ b/.github/workflows/ci-dotnet-tests.yml
@@ -15,15 +15,114 @@ jobs:
   dotnet-tests-and-coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "10.0.x"
+
+      - name: Guardrail - validate new test symbols resolve
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          python - <<'PY'
+          import pathlib
+          import re
+          import subprocess
+          import sys
+
+          base_ref = "${{ github.base_ref }}"
+          diff_cmd = [
+              "git",
+              "diff",
+              "--unified=0",
+              f"origin/{base_ref}...HEAD",
+              "--",
+              ":(glob)Desktop/HermesDesktop.Tests/**/*.cs",
+          ]
+          result = subprocess.run(diff_cmd, capture_output=True, text=True, check=False)
+          if result.returncode != 0:
+              print("Failed to diff changed test files:")
+              print(result.stderr.strip())
+              sys.exit(1)
+
+          added_lines = []
+          for line in result.stdout.splitlines():
+              if line.startswith("+++"):
+                  continue
+              if line.startswith("+"):
+                  added_lines.append(line[1:])
+
+          if not added_lines:
+              print("No added test lines detected; symbol guardrail skipped.")
+              sys.exit(0)
+
+          candidate_patterns = [
+              re.compile(r"\bnew\s+([A-Z][A-Za-z0-9_]*)\s*(?:<|\()"),
+              re.compile(r"\bNullLogger<([A-Z][A-Za-z0-9_]*)>"),
+              re.compile(r"\bMock<([A-Z][A-Za-z0-9_]*)>"),
+              re.compile(r"\bTask<([A-Z][A-Za-z0-9_]*)>"),
+          ]
+          candidates = set()
+          for line in added_lines:
+              for pattern in candidate_patterns:
+                  for match in pattern.findall(line):
+                      candidates.add(match)
+
+          if not candidates:
+              print("No project-type symbol candidates found in added test lines.")
+              sys.exit(0)
+
+          declaration_pattern = re.compile(
+              r"^\s*(?:public|internal|private|protected)?\s*(?:sealed\s+|abstract\s+|static\s+|partial\s+)*"
+              r"(?:class|record|interface|enum|struct)\s+([A-Za-z_][A-Za-z0-9_]*)",
+              re.MULTILINE,
+          )
+          declared_types = set()
+          for root in ("src", "Desktop/HermesDesktop.Tests"):
+              for file_path in pathlib.Path(root).rglob("*.cs"):
+                  text = file_path.read_text(encoding="utf-8")
+                  declared_types.update(declaration_pattern.findall(text))
+
+          allowlist = {
+              "Task",
+              "List",
+              "Dictionary",
+              "HashSet",
+              "Action",
+              "Func",
+              "StringBuilder",
+              "CancellationToken",
+              "DateTime",
+              "TimeSpan",
+              "Guid",
+              "Path",
+              "File",
+              "Directory",
+              "Regex",
+              "Uri",
+          }
+
+          unresolved = sorted(
+              symbol for symbol in candidates
+              if symbol not in declared_types and symbol not in allowlist
+          )
+
+          if unresolved:
+              print("::error::New test code references unresolved symbols: " + ", ".join(unresolved))
+              print("Add matching implementation symbols to src/, or remove/rework tests before merge.")
+              sys.exit(1)
+
+          print("Guardrail passed. Added test symbol references resolve in this PR.")
+          PY
 
       - name: Restore test project dependencies
         run: dotnet restore ./Desktop/HermesDesktop.Tests/HermesDesktop.Tests.csproj

--- a/Desktop/HermesDesktop/Services/HermesChatService.cs
+++ b/Desktop/HermesDesktop/Services/HermesChatService.cs
@@ -232,6 +232,8 @@ internal sealed class HermesChatService : IDisposable
         _permissionRuleStore.ClearAlwaysAllowRules();
     }
 
+    public void ClearRememberedWorkspacePermissions() => ClearRememberedPermissionsForWorkspace();
+
     // ── Tool Registration ──
 
     public void RegisterTool(ITool tool) => _agent.RegisterTool(tool);

--- a/src/dreamer/DreamerService.cs
+++ b/src/dreamer/DreamerService.cs
@@ -144,9 +144,10 @@ public sealed class DreamerService
             () => BuildResearchContextAsync(config, ct),
             "(no research context)");
         var prior = ReadLatestWalkExcerpt();
+        async Task<string?> RunDreamWalkAsync() => await walk.RunAsync(config, research, prior, ct);
         var walkText = await TryGetRecoverableAsync<string?>(
             "running Dreamer walk",
-            () => walk.RunAsync(config, research, prior, ct),
+            RunDreamWalkAsync,
             null);
         if (string.IsNullOrWhiteSpace(walkText))
         {

--- a/src/dreamer/RssFetcher.cs
+++ b/src/dreamer/RssFetcher.cs
@@ -100,8 +100,9 @@ public sealed class RssFetcher
             return false;
 
         var trimmed = rawUrl.Trim();
-        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out feedUri))
+        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var parsedUri))
             return false;
+        feedUri = parsedUri;
 
         if (feedUri.Scheme is not ("http" or "https"))
             return false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a PR-only guardrail step to `.github/workflows/ci-dotnet-tests.yml` that scans newly added test lines and validates referenced symbols resolve in `src/` or existing test declarations
- fail fast with a clear actionable error when tests reference missing implementation symbols (prevents bot-generated test drift from breaking `dotnet test` unexpectedly)
- set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` in the workflow job to proactively align with GitHub Actions Node 24 migration guidance
- update checkout to `fetch-depth: 0` so the guardrail can reliably diff against `origin/${{ github.base_ref }}`
- add a compatibility forwarder on `HermesChatService` (`ClearRememberedWorkspacePermissions`) so `ChatPage` and smoke builds compile against the same API surface
- fix the two Dreamer nullability warnings by aligning async delegate nullability in `DreamerService` and tightening URI parsing flow in `RssFetcher`

## Verification
- local: `dotnet test Desktop/HermesDesktop.Tests/HermesDesktop.Tests.csproj` (Passed: 505)
- CI: `dotnet-tests-and-coverage` passes on PR #40
- CI: `windows-portable-smoke` passes on PR #40
- CodeQL/CodeFactor/Repo Guard checks pass

## Notes
- The original smoke failure was not an external flake; it was a compile-time API mismatch (`ChatPage` called `ClearRememberedWorkspacePermissions` while `HermesChatService` only exposed `ClearRememberedPermissionsForWorkspace`).
- The nullability cleanup removes the two recurring warnings from `src/dreamer/DreamerService.cs` and `src/dreamer/RssFetcher.cs` without behavior changes.
- The guardrail remains scoped to test-file additions on PR events and skips when no new test lines are detected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18f7ed9b-b01d-45a5-a38a-404e4bea7c62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18f7ed9b-b01d-45a5-a38a-404e4bea7c62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new method for clearing remembered workspace permissions, providing an additional interface for permission management.

* **Chores**
  * Enhanced continuous integration pipeline with automated validation guardrails to ensure test code consistency.
  * Internal code optimizations and refactoring improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->