### PR TITLE
Fix #42: add Web Search provider settings (DuckDuckGo / Google / Bing)

### DIFF
--- a/Desktop/HermesDesktop.Tests/Services/WebSearchConfigTests.cs
+++ b/Desktop/HermesDesktop.Tests/Services/WebSearchConfigTests.cs
@@ -1,0 +1,79 @@
+using Hermes.Agent.Tools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HermesDesktop.Tests.Services;
+
+/// <summary>
+/// Regression tests for PR #44 — WebSearchConfig.NormalizeProvider.
+/// Locks in the contract that a typo or manual edit in config.yaml can't
+/// turn every web-search call into NotSupportedException (the Codex review
+/// concern that prompted this helper).
+/// </summary>
+[TestClass]
+public class WebSearchConfigTests
+{
+    [TestMethod]
+    public void NormalizeProvider_Null_ReturnsDuckDuckGo()
+    {
+        Assert.AreEqual("duckduckgo", WebSearchConfig.NormalizeProvider(null));
+    }
+
+    [TestMethod]
+    public void NormalizeProvider_Empty_ReturnsDuckDuckGo()
+    {
+        Assert.AreEqual("duckduckgo", WebSearchConfig.NormalizeProvider(""));
+    }
+
+    [TestMethod]
+    public void NormalizeProvider_Whitespace_ReturnsDuckDuckGo()
+    {
+        Assert.AreEqual("duckduckgo", WebSearchConfig.NormalizeProvider("   "));
+    }
+
+    [TestMethod]
+    public void NormalizeProvider_Unknown_ReturnsDuckDuckGo()
+    {
+        // A typo like "gogle" or "bingg" previously caused WebSearchTool to
+        // throw NotSupportedException on every call.
+        Assert.AreEqual("duckduckgo", WebSearchConfig.NormalizeProvider("gogle"));
+        Assert.AreEqual("duckduckgo", WebSearchConfig.NormalizeProvider("bingg"));
+        Assert.AreEqual("duckduckgo", WebSearchConfig.NormalizeProvider("yahoo"));
+    }
+
+    [TestMethod]
+    public void NormalizeProvider_Google_Lowercased()
+    {
+        Assert.AreEqual("google", WebSearchConfig.NormalizeProvider("Google"));
+        Assert.AreEqual("google", WebSearchConfig.NormalizeProvider("GOOGLE"));
+        Assert.AreEqual("google", WebSearchConfig.NormalizeProvider("  google  "));
+    }
+
+    [TestMethod]
+    public void NormalizeProvider_Bing_Lowercased()
+    {
+        Assert.AreEqual("bing", WebSearchConfig.NormalizeProvider("Bing"));
+    }
+
+    [TestMethod]
+    public void NormalizeProvider_DuckDuckGo_Lowercased()
+    {
+        Assert.AreEqual("duckduckgo", WebSearchConfig.NormalizeProvider("DuckDuckGo"));
+    }
+
+    [TestMethod]
+    public void NormalizeProvider_DdgAlias_MapsToDuckDuckGo()
+    {
+        // WebSearchTool.ExecuteAsync treats "ddg" as an alias for DuckDuckGo;
+        // the normalizer preserves that mapping.
+        Assert.AreEqual("duckduckgo", WebSearchConfig.NormalizeProvider("ddg"));
+        Assert.AreEqual("duckduckgo", WebSearchConfig.NormalizeProvider("DDG"));
+    }
+
+    [TestMethod]
+    public void SupportedProviders_ListedExactly()
+    {
+        CollectionAssert.AreEquivalent(
+            new[] { "duckduckgo", "google", "bing" },
+            WebSearchConfig.SupportedProviders.ToArray());
+    }
+}

--- a/Desktop/HermesDesktop/App.xaml.cs
+++ b/Desktop/HermesDesktop/App.xaml.cs
@@ -701,7 +701,14 @@ public partial class App : Application
         // Web tools
         RegisterAndTrack(agent, toolRegistry, new WebFetchTool(httpClient));
         RegisterAndTrack(agent, toolRegistry, new WebSearchTool(
-            new WebSearchConfig { Provider = "duckduckgo" }, httpClient));
+            new WebSearchConfig
+            {
+                Provider = HermesEnvironment.WebSearchProvider,
+                GoogleApiKey = HermesEnvironment.WebSearchGoogleApiKey,
+                GoogleSearchEngineId = HermesEnvironment.WebSearchGoogleEngineId,
+                BingApiKey = HermesEnvironment.WebSearchBingApiKey,
+            },
+            httpClient));
 
         // Task management
         RegisterAndTrack(agent, toolRegistry, new TodoWriteTool());

--- a/Desktop/HermesDesktop/Services/HermesEnvironment.cs
+++ b/Desktop/HermesDesktop/Services/HermesEnvironment.cs
@@ -737,26 +737,13 @@ internal static class HermesEnvironment
     internal static string? ReadIntegrationSetting(string key) => ReadConfigSetting("integrations", key);
 
     // ── Web search ──
-    private static readonly HashSet<string> SupportedWebSearchProviders = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "duckduckgo", "google", "bing"
-    };
-
     /// <summary>
-    /// Normalizes the persisted provider to one of {duckduckgo, google, bing}.
-    /// Unknown or mis-typed values fall back to DuckDuckGo so WebSearchTool
-    /// doesn't throw NotSupportedException on every call after a bad edit.
+    /// Provider the WebSearchTool should use. Normalization lives next to the
+    /// tool itself (<see cref="Hermes.Agent.Tools.WebSearchConfig.NormalizeProvider"/>)
+    /// so the list of supported providers stays in one place.
     /// </summary>
-    internal static string WebSearchProvider
-    {
-        get
-        {
-            var raw = ReadConfigSetting("search", "provider");
-            if (string.IsNullOrWhiteSpace(raw)) return "duckduckgo";
-            var normalized = raw.Trim().ToLowerInvariant();
-            return SupportedWebSearchProviders.Contains(normalized) ? normalized : "duckduckgo";
-        }
-    }
+    internal static string WebSearchProvider =>
+        Hermes.Agent.Tools.WebSearchConfig.NormalizeProvider(ReadConfigSetting("search", "provider"));
 
     internal static string? WebSearchGoogleApiKey =>
         ReadConfigSetting("search", "google_api_key");

--- a/Desktop/HermesDesktop/Services/HermesEnvironment.cs
+++ b/Desktop/HermesDesktop/Services/HermesEnvironment.cs
@@ -736,6 +736,19 @@ internal static class HermesEnvironment
     /// <summary>Read a value from the integrations section of config.yaml.</summary>
     internal static string? ReadIntegrationSetting(string key) => ReadConfigSetting("integrations", key);
 
+    // ── Web search ──
+    internal static string WebSearchProvider =>
+        ReadConfigSetting("search", "provider") ?? "duckduckgo";
+
+    internal static string? WebSearchGoogleApiKey =>
+        ReadConfigSetting("search", "google_api_key");
+
+    internal static string? WebSearchGoogleEngineId =>
+        ReadConfigSetting("search", "google_engine_id");
+
+    internal static string? WebSearchBingApiKey =>
+        ReadConfigSetting("search", "bing_api_key");
+
     /// <summary>Read a value from any top-level section of config.yaml (section.key).</summary>
     internal static string? ReadConfigSetting(string section, string key)
     {

--- a/Desktop/HermesDesktop/Services/HermesEnvironment.cs
+++ b/Desktop/HermesDesktop/Services/HermesEnvironment.cs
@@ -737,8 +737,26 @@ internal static class HermesEnvironment
     internal static string? ReadIntegrationSetting(string key) => ReadConfigSetting("integrations", key);
 
     // ── Web search ──
-    internal static string WebSearchProvider =>
-        ReadConfigSetting("search", "provider") ?? "duckduckgo";
+    private static readonly HashSet<string> SupportedWebSearchProviders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "duckduckgo", "google", "bing"
+    };
+
+    /// <summary>
+    /// Normalizes the persisted provider to one of {duckduckgo, google, bing}.
+    /// Unknown or mis-typed values fall back to DuckDuckGo so WebSearchTool
+    /// doesn't throw NotSupportedException on every call after a bad edit.
+    /// </summary>
+    internal static string WebSearchProvider
+    {
+        get
+        {
+            var raw = ReadConfigSetting("search", "provider");
+            if (string.IsNullOrWhiteSpace(raw)) return "duckduckgo";
+            var normalized = raw.Trim().ToLowerInvariant();
+            return SupportedWebSearchProviders.Contains(normalized) ? normalized : "duckduckgo";
+        }
+    }
 
     internal static string? WebSearchGoogleApiKey =>
         ReadConfigSetting("search", "google_api_key");

--- a/Desktop/HermesDesktop/Strings/en-us/Resources.resw
+++ b/Desktop/HermesDesktop/Strings/en-us/Resources.resw
@@ -1242,6 +1242,33 @@
   <data name="SettingsSavePluginBtn.Content" xml:space="preserve">
     <value>Save Plugin Config</value>
   </data>
+  <data name="SettingsExpSearchHeader.Text" xml:space="preserve">
+    <value>Web Search</value>
+  </data>
+  <data name="SettingsLblSearchProvider.Text" xml:space="preserve">
+    <value>SEARCH PROVIDER</value>
+  </data>
+  <data name="SettingsLblSearchGoogleApiKey.Text" xml:space="preserve">
+    <value>GOOGLE API KEY</value>
+  </data>
+  <data name="SettingsSearchGoogleApiKeyBox.PlaceholderText" xml:space="preserve">
+    <value>Required for Google Custom Search</value>
+  </data>
+  <data name="SettingsLblSearchGoogleEngineId.Text" xml:space="preserve">
+    <value>GOOGLE ENGINE ID (CX)</value>
+  </data>
+  <data name="SettingsSearchGoogleEngineIdBox.PlaceholderText" xml:space="preserve">
+    <value>Custom Search Engine identifier</value>
+  </data>
+  <data name="SettingsLblSearchBingApiKey.Text" xml:space="preserve">
+    <value>BING API KEY</value>
+  </data>
+  <data name="SettingsSearchBingApiKeyBox.PlaceholderText" xml:space="preserve">
+    <value>Required for Bing Web Search</value>
+  </data>
+  <data name="SettingsSaveSearchBtn.Content" xml:space="preserve">
+    <value>Save Search Config</value>
+  </data>
   <data name="SettingsExpPathsSystemHeader.Text" xml:space="preserve">
     <value>Paths &amp; System</value>
   </data>

--- a/Desktop/HermesDesktop/Strings/en-us/Resources.resw
+++ b/Desktop/HermesDesktop/Strings/en-us/Resources.resw
@@ -1245,6 +1245,21 @@
   <data name="SettingsExpSearchHeader.Text" xml:space="preserve">
     <value>Web Search</value>
   </data>
+  <data name="SearchProviderDuckDuckGoItem.Content" xml:space="preserve">
+    <value>DuckDuckGo (no key required)</value>
+  </data>
+  <data name="SearchProviderGoogleItem.Content" xml:space="preserve">
+    <value>Google Custom Search</value>
+  </data>
+  <data name="SearchProviderBingItem.Content" xml:space="preserve">
+    <value>Bing Web Search</value>
+  </data>
+  <data name="SettingsSearchMissingGoogleKey" xml:space="preserve">
+    <value>Google search requires both API key and Engine ID.</value>
+  </data>
+  <data name="SettingsSearchMissingBingKey" xml:space="preserve">
+    <value>Bing search requires an API key.</value>
+  </data>
   <data name="SettingsLblSearchProvider.Text" xml:space="preserve">
     <value>SEARCH PROVIDER</value>
   </data>

--- a/Desktop/HermesDesktop/Strings/zh-cn/Resources.resw
+++ b/Desktop/HermesDesktop/Strings/zh-cn/Resources.resw
@@ -1239,6 +1239,21 @@
   <data name="SettingsExpSearchHeader.Text" xml:space="preserve">
     <value>网络搜索</value>
   </data>
+  <data name="SearchProviderDuckDuckGoItem.Content" xml:space="preserve">
+    <value>DuckDuckGo（无需密钥）</value>
+  </data>
+  <data name="SearchProviderGoogleItem.Content" xml:space="preserve">
+    <value>Google 自定义搜索</value>
+  </data>
+  <data name="SearchProviderBingItem.Content" xml:space="preserve">
+    <value>Bing 网络搜索</value>
+  </data>
+  <data name="SettingsSearchMissingGoogleKey" xml:space="preserve">
+    <value>Google 搜索需要 API 密钥和引擎 ID。</value>
+  </data>
+  <data name="SettingsSearchMissingBingKey" xml:space="preserve">
+    <value>Bing 搜索需要 API 密钥。</value>
+  </data>
   <data name="SettingsLblSearchProvider.Text" xml:space="preserve">
     <value>搜索提供商</value>
   </data>

--- a/Desktop/HermesDesktop/Strings/zh-cn/Resources.resw
+++ b/Desktop/HermesDesktop/Strings/zh-cn/Resources.resw
@@ -1236,6 +1236,33 @@
   <data name="SettingsSavePluginBtn.Content" xml:space="preserve">
     <value>保存插件配置</value>
   </data>
+  <data name="SettingsExpSearchHeader.Text" xml:space="preserve">
+    <value>网络搜索</value>
+  </data>
+  <data name="SettingsLblSearchProvider.Text" xml:space="preserve">
+    <value>搜索提供商</value>
+  </data>
+  <data name="SettingsLblSearchGoogleApiKey.Text" xml:space="preserve">
+    <value>GOOGLE API 密钥</value>
+  </data>
+  <data name="SettingsSearchGoogleApiKeyBox.PlaceholderText" xml:space="preserve">
+    <value>Google 自定义搜索所需</value>
+  </data>
+  <data name="SettingsLblSearchGoogleEngineId.Text" xml:space="preserve">
+    <value>GOOGLE 引擎 ID (CX)</value>
+  </data>
+  <data name="SettingsSearchGoogleEngineIdBox.PlaceholderText" xml:space="preserve">
+    <value>自定义搜索引擎标识符</value>
+  </data>
+  <data name="SettingsLblSearchBingApiKey.Text" xml:space="preserve">
+    <value>BING API 密钥</value>
+  </data>
+  <data name="SettingsSearchBingApiKeyBox.PlaceholderText" xml:space="preserve">
+    <value>Bing 网络搜索所需</value>
+  </data>
+  <data name="SettingsSaveSearchBtn.Content" xml:space="preserve">
+    <value>保存搜索配置</value>
+  </data>
   <data name="SettingsExpPathsSystemHeader.Text" xml:space="preserve">
     <value>路径与系统</value>
   </data>

--- a/Desktop/HermesDesktop/Views/SettingsPage.xaml
+++ b/Desktop/HermesDesktop/Views/SettingsPage.xaml
@@ -939,7 +939,76 @@
                 </Expander.Content>
             </Expander>
 
-            <!-- ═══ I. Paths & System ═══ -->
+            <!-- ═══ I. Web Search ═══ -->
+            <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
+                <Expander.Header>
+                    <StackPanel Orientation="Horizontal" Spacing="10">
+                        <FontIcon Glyph="&#xE721;" FontFamily="Segoe MDL2 Assets" FontSize="18"/>
+                        <TextBlock x:Uid="SettingsExpSearchHeader" Style="{StaticResource SectionTitleTextStyle}" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Expander.Header>
+                <Expander.Content>
+                    <StackPanel Spacing="12" Padding="4,8,4,4">
+                        <Grid ColumnSpacing="12" RowSpacing="10">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="200"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+
+                            <TextBlock x:Uid="SettingsLblSearchProvider" VerticalAlignment="Center"
+                                       Style="{StaticResource LabelTextStyle}"/>
+                            <ComboBox x:Name="SearchProviderCombo" Grid.Column="1" HorizontalAlignment="Stretch"
+                                      SelectionChanged="SearchProvider_SelectionChanged">
+                                <ComboBoxItem Content="DuckDuckGo (no key required)" Tag="duckduckgo"/>
+                                <ComboBoxItem Content="Google Custom Search" Tag="google"/>
+                                <ComboBoxItem Content="Bing Web Search" Tag="bing"/>
+                            </ComboBox>
+
+                            <TextBlock Grid.Row="1" x:Uid="SettingsLblSearchGoogleApiKey" VerticalAlignment="Center"
+                                       Style="{StaticResource LabelTextStyle}"/>
+                            <PasswordBox x:Name="SearchGoogleApiKeyBox" Grid.Row="1" Grid.Column="1"
+                                         x:Uid="SettingsSearchGoogleApiKeyBox"
+                                         Background="{StaticResource AppInsetBrush}"
+                                         BorderBrush="{StaticResource AppStrokeBrush}"
+                                         Foreground="White"/>
+
+                            <TextBlock Grid.Row="2" x:Uid="SettingsLblSearchGoogleEngineId" VerticalAlignment="Center"
+                                       Style="{StaticResource LabelTextStyle}"/>
+                            <TextBox x:Name="SearchGoogleEngineIdBox" Grid.Row="2" Grid.Column="1"
+                                     x:Uid="SettingsSearchGoogleEngineIdBox"
+                                     Background="{StaticResource AppInsetBrush}"
+                                     BorderBrush="{StaticResource AppStrokeBrush}"
+                                     Foreground="White"/>
+
+                            <TextBlock Grid.Row="3" x:Uid="SettingsLblSearchBingApiKey" VerticalAlignment="Center"
+                                       Style="{StaticResource LabelTextStyle}"/>
+                            <PasswordBox x:Name="SearchBingApiKeyBox" Grid.Row="3" Grid.Column="1"
+                                         x:Uid="SettingsSearchBingApiKeyBox"
+                                         Background="{StaticResource AppInsetBrush}"
+                                         BorderBrush="{StaticResource AppStrokeBrush}"
+                                         Foreground="White"/>
+                        </Grid>
+
+                        <!-- Save -->
+                        <StackPanel Orientation="Horizontal" Spacing="12">
+                            <Button x:Uid="SettingsSaveSearchBtn" Click="SaveSearchConfig_Click"
+                                    Background="{StaticResource AppAccentGradientBrush}"
+                                    BorderBrush="{StaticResource AppAccentDarkBrush}"
+                                    Foreground="#16110D" Padding="20,8"/>
+                            <TextBlock x:Name="SearchSaveStatus" VerticalAlignment="Center"
+                                       Foreground="{StaticResource AppTextSecondaryBrush}" FontSize="13"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Expander.Content>
+            </Expander>
+
+            <!-- ═══ J. Paths & System ═══ -->
             <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
                 <Expander.Header>
                     <StackPanel Orientation="Horizontal" Spacing="10">

--- a/Desktop/HermesDesktop/Views/SettingsPage.xaml
+++ b/Desktop/HermesDesktop/Views/SettingsPage.xaml
@@ -965,9 +965,9 @@
                                        Style="{StaticResource LabelTextStyle}"/>
                             <ComboBox x:Name="SearchProviderCombo" Grid.Column="1" HorizontalAlignment="Stretch"
                                       SelectionChanged="SearchProvider_SelectionChanged">
-                                <ComboBoxItem Content="DuckDuckGo (no key required)" Tag="duckduckgo"/>
-                                <ComboBoxItem Content="Google Custom Search" Tag="google"/>
-                                <ComboBoxItem Content="Bing Web Search" Tag="bing"/>
+                                <ComboBoxItem x:Uid="SearchProviderDuckDuckGoItem" Tag="duckduckgo"/>
+                                <ComboBoxItem x:Uid="SearchProviderGoogleItem" Tag="google"/>
+                                <ComboBoxItem x:Uid="SearchProviderBingItem" Tag="bing"/>
                             </ComboBox>
 
                             <TextBlock Grid.Row="1" x:Uid="SettingsLblSearchGoogleApiKey" VerticalAlignment="Center"

--- a/Desktop/HermesDesktop/Views/SettingsPage.xaml.cs
+++ b/Desktop/HermesDesktop/Views/SettingsPage.xaml.cs
@@ -61,6 +61,7 @@ public sealed partial class SettingsPage : Page
         LoadExecutionSettings();
         LoadPluginSettings();
         LoadDreamerSettings();
+        LoadSearchSettings();
         await RefreshRuntimeStatusAsync();
     }
 
@@ -777,6 +778,54 @@ This file is a living document about the human I work with. It helps me provide 
         {
             PluginSaveStatus.Text = string.Format(CultureInfo.CurrentCulture, ResourceLoader.GetString("SettingsErrorFormat"), ex.Message);
             PluginSaveStatus.Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["ConnectionOfflineBrush"];
+        }
+    }
+
+    // ── Web Search ──
+    private void LoadSearchSettings()
+    {
+        SelectComboByTag(SearchProviderCombo, HermesEnvironment.WebSearchProvider, fallbackIndex: 0);
+        SearchGoogleApiKeyBox.Password = HermesEnvironment.WebSearchGoogleApiKey ?? "";
+        SearchGoogleEngineIdBox.Text = HermesEnvironment.WebSearchGoogleEngineId ?? "";
+        SearchBingApiKeyBox.Password = HermesEnvironment.WebSearchBingApiKey ?? "";
+        UpdateSearchFieldState((SearchProviderCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString());
+    }
+
+    private void SearchProvider_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        UpdateSearchFieldState((SearchProviderCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString());
+    }
+
+    private void UpdateSearchFieldState(string? provider)
+    {
+        var p = (provider ?? "duckduckgo").ToLowerInvariant();
+        SearchGoogleApiKeyBox.IsEnabled = p == "google";
+        SearchGoogleEngineIdBox.IsEnabled = p == "google";
+        SearchBingApiKeyBox.IsEnabled = p == "bing";
+    }
+
+    private async void SaveSearchConfig_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var provider = (SearchProviderCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "duckduckgo";
+            var settings = new Dictionary<string, string>
+            {
+                ["provider"] = provider,
+                ["google_api_key"] = SearchGoogleApiKeyBox.Password.Trim(),
+                ["google_engine_id"] = SearchGoogleEngineIdBox.Text.Trim(),
+                ["bing_api_key"] = SearchBingApiKeyBox.Password.Trim(),
+            };
+
+            await HermesEnvironment.SaveConfigSectionAsync("search", settings);
+
+            SearchSaveStatus.Text = ResourceLoader.GetString("SettingsSaveSuccessRestart");
+            SearchSaveStatus.Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["ConnectionOnlineBrush"];
+        }
+        catch (Exception ex)
+        {
+            SearchSaveStatus.Text = string.Format(CultureInfo.CurrentCulture, ResourceLoader.GetString("SettingsErrorFormat"), ex.Message);
+            SearchSaveStatus.Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["ConnectionOfflineBrush"];
         }
     }
 

--- a/Desktop/HermesDesktop/Views/SettingsPage.xaml.cs
+++ b/Desktop/HermesDesktop/Views/SettingsPage.xaml.cs
@@ -809,12 +809,30 @@ This file is a living document about the human I work with. It helps me provide 
         try
         {
             var provider = (SearchProviderCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "duckduckgo";
+            var googleKey = SearchGoogleApiKeyBox.Password.Trim();
+            var googleEngineId = SearchGoogleEngineIdBox.Text.Trim();
+            var bingKey = SearchBingApiKeyBox.Password.Trim();
+
+            if (provider == "google" && (string.IsNullOrEmpty(googleKey) || string.IsNullOrEmpty(googleEngineId)))
+            {
+                SearchSaveStatus.Text = ResourceLoader.GetString("SettingsSearchMissingGoogleKey");
+                SearchSaveStatus.Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["ConnectionOfflineBrush"];
+                return;
+            }
+
+            if (provider == "bing" && string.IsNullOrEmpty(bingKey))
+            {
+                SearchSaveStatus.Text = ResourceLoader.GetString("SettingsSearchMissingBingKey");
+                SearchSaveStatus.Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["ConnectionOfflineBrush"];
+                return;
+            }
+
             var settings = new Dictionary<string, string>
             {
                 ["provider"] = provider,
-                ["google_api_key"] = SearchGoogleApiKeyBox.Password.Trim(),
-                ["google_engine_id"] = SearchGoogleEngineIdBox.Text.Trim(),
-                ["bing_api_key"] = SearchBingApiKeyBox.Password.Trim(),
+                ["google_api_key"] = googleKey,
+                ["google_engine_id"] = googleEngineId,
+                ["bing_api_key"] = bingKey,
             };
 
             await HermesEnvironment.SaveConfigSectionAsync("search", settings);

--- a/src/Tools/websearchtool.cs
+++ b/src/Tools/websearchtool.cs
@@ -187,6 +187,26 @@ public sealed class WebSearchConfig
     public string? GoogleApiKey { get; init; }
     public string? GoogleSearchEngineId { get; init; }
     public string? BingApiKey { get; init; }
+
+    /// <summary>The providers WebSearchTool actually knows how to call.</summary>
+    public static readonly IReadOnlyCollection<string> SupportedProviders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "duckduckgo", "google", "bing"
+    };
+
+    /// <summary>
+    /// Normalize a persisted provider string to one of <see cref="SupportedProviders"/>.
+    /// Null, whitespace, or unknown values fall back to <c>duckduckgo</c> so a typo
+    /// in config.yaml can't turn every web-search call into NotSupportedException.
+    /// </summary>
+    public static string NormalizeProvider(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return "duckduckgo";
+        var trimmed = raw.Trim().ToLowerInvariant();
+        // "ddg" is the other alias ExecuteAsync accepts.
+        if (trimmed == "ddg") return "duckduckgo";
+        return SupportedProviders.Contains(trimmed) ? trimmed : "duckduckgo";
+    }
 }
 
 public sealed class WebSearchParameters


### PR DESCRIPTION
## Summary
Fixes #42 (sub-bug 3: "Web search skill is not working… no menu to set up the search provider").

`WebSearchTool` was hardcoded to DuckDuckGo with no way to switch. DuckDuckGo's free instant-answer API rarely returns search-style hits, so even when the agent invoked the tool, results were effectively empty.

This PR makes the provider configurable from Settings and persists to `config.yaml`.

## Changes
- `Desktop/HermesDesktop/Services/HermesEnvironment.cs`: new `WebSearchProvider`, `WebSearchGoogleApiKey`, `WebSearchGoogleEngineId`, `WebSearchBingApiKey` properties backed by a `search:` section.
- `Desktop/HermesDesktop/App.xaml.cs`: `WebSearchTool` now constructs its `WebSearchConfig` from those properties instead of a hardcoded literal.
- `Desktop/HermesDesktop/Views/SettingsPage.xaml` + `.xaml.cs`: new "Web Search" expander with provider dropdown (DuckDuckGo / Google / Bing) and conditional API-key fields enabled only for the selected provider.
- `Strings/en-us/Resources.resw` + `Strings/zh-cn/Resources.resw`: localized labels and save button.

## Test plan
- [ ] Open Settings, scroll to **Web Search** expander.
- [ ] Default selection is DuckDuckGo, no key fields enabled.
- [ ] Switch to Google → both Google API key and Engine ID become enabled, Bing key disabled.
- [ ] Switch to Bing → only Bing key enabled.
- [ ] Save Google config with valid key+CX, restart, ask the agent to search the web → results from Google.
- [ ] Save Bing config with valid key, restart, search → results from Bing.
- [ ] `~/.../hermes/config.yaml` contains a `search:` section with `provider`, `google_api_key`, `google_engine_id`, `bing_api_key`.

## Notes
- API keys are stored plaintext in `config.yaml`. A follow-up could move them to Windows Credential Manager.
- `MaxTurnsBox`-style restart-required pattern: changes apply on next launch (matches every other Settings save in this file).

https://claude.ai/code/session_011kdWRbnDzMFLH3jfajLDwY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes how `WebSearchTool` is configured at runtime and introduces persisted API keys in `config.yaml`, which could affect search behavior and has security implications if config files are exposed.
> 
> **Overview**
> Adds configurable web search settings so the desktop app can switch `WebSearchTool` between DuckDuckGo, Google Custom Search, and Bing using values persisted under a new `search:` section in `config.yaml`.
> 
> The Settings UI gains a **Web Search** section with provider selection and provider-specific key fields (enabled/disabled based on the chosen provider), plus localized strings for EN/zh-CN.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a33ae51f1f703c5a10e8ca8202ffd198d7502fc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->