### PR TITLE
fix(llm): wire SystemContext coalescing into Agent loop (follow-up to #49)

### DIFF
--- a/Desktop/HermesDesktop.Tests/Services/AgentSystemMessageShapeTests.cs
+++ b/Desktop/HermesDesktop.Tests/Services/AgentSystemMessageShapeTests.cs
@@ -1,0 +1,277 @@
+using System.Runtime.CompilerServices;
+using Hermes.Agent.Core;
+using Hermes.Agent.LLM;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace HermesDesktop.Tests.Services;
+
+/// <summary>
+/// End-to-end shape tests for the agent loop's outgoing wire payload.
+/// Drives <see cref="Agent.ChatAsync"/> and <see cref="Agent.StreamChatAsync"/>
+/// with sessions that contain stacked <c>role:"system"</c> entries and
+/// asserts that the message list reaching <see cref="IChatClient"/> has
+/// exactly one leading system message and zero mid-list system messages —
+/// the load-bearing invariant strict OpenAI-compatible servers (vLLM with
+/// Qwen / Llama-3 chat templates, llama.cpp strict templates, TGI, several
+/// LMStudio strict-template models) require.
+///
+/// These tests complement the bridge-contract tests by exercising the
+/// real Agent loop, not just the IChatClient bridge. They catch regressions
+/// where a future call site is added in <see cref="Agent"/> that forgets
+/// to coalesce, or where a future plugin/subsystem injects a stray
+/// <c>role:"system"</c> in a way the Agent doesn't notice.
+/// </summary>
+[TestClass]
+public class AgentSystemMessageShapeTests
+{
+    private static void AssertSingleLeadingSystem(IReadOnlyList<Message> messages, params string[] expectedContentFragments)
+    {
+        Assert.IsTrue(messages.Count > 0, "Outgoing message list must not be empty.");
+        Assert.AreEqual("system", messages[0].Role,
+            "Wire payload must begin with a single coalesced system message; strict OpenAI-compatible servers reject otherwise.");
+
+        for (int i = 1; i < messages.Count; i++)
+        {
+            Assert.AreNotEqual("system", messages[i].Role,
+                $"Mid-list system message at index {i} would trip strict chat-template enforcement (vLLM/Qwen, llama.cpp strict, TGI). Content: {messages[i].Content}");
+        }
+
+        foreach (var fragment in expectedContentFragments)
+        {
+            StringAssert.Contains(messages[0].Content, fragment,
+                $"Coalesced system block must contain layered content '{fragment}'.");
+        }
+    }
+
+    private static void SeedStackedSystemMessages(Session session)
+    {
+        // Mirrors what AgentContextAssembler / PluginManager / MemoryManager /
+        // SoulService produce in the wild: multiple discrete role:"system"
+        // entries inserted at session.Messages[0] across the assembly path.
+        session.Messages.Insert(0, new Message { Role = "system", Content = "[soul] you are helpful" });
+        session.Messages.Insert(0, new Message { Role = "system", Content = "[plugins] turn budget=10" });
+        session.Messages.Insert(0, new Message { Role = "system", Content = "[memory] user prefers terse replies" });
+    }
+
+    // ── No-tools ChatAsync: routes through CompleteAsync ──
+
+    [TestMethod]
+    public async Task ChatAsync_NoTools_StackedSystemMessages_WirePayloadHasSingleLeadingSystem()
+    {
+        var chatClient = new Mock<IChatClient>(MockBehavior.Strict);
+        IEnumerable<Message>? captured = null;
+
+        chatClient.Setup(c => c.CompleteAsync(
+                It.IsAny<IEnumerable<Message>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<Message>, CancellationToken>((msgs, _) => captured = msgs.ToList())
+            .ReturnsAsync("LLM answer");
+
+        var agent = new Agent(chatClient.Object, NullLogger<Agent>.Instance);
+        var session = new Session { Id = "shape-no-tools" };
+        SeedStackedSystemMessages(session);
+
+        var result = await agent.ChatAsync("hello", session, CancellationToken.None);
+
+        Assert.AreEqual("LLM answer", result);
+        Assert.IsNotNull(captured);
+        var observed = captured!.ToList();
+
+        AssertSingleLeadingSystem(observed, "[soul]", "[plugins]", "[memory]");
+    }
+
+    // ── With-tools ChatAsync: routes through CompleteWithToolsAsync (every iteration) ──
+
+    [TestMethod]
+    public async Task ChatAsync_WithTools_EveryIterationWirePayloadHasSingleLeadingSystem()
+    {
+        var chatClient = new Mock<IChatClient>(MockBehavior.Strict);
+        var capturedPerCall = new List<List<Message>>();
+
+        chatClient.Setup(c => c.CompleteWithToolsAsync(
+                It.IsAny<IEnumerable<Message>>(),
+                It.IsAny<IEnumerable<ToolDefinition>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<Message>, IEnumerable<ToolDefinition>, CancellationToken>((msgs, _, _) =>
+                capturedPerCall.Add(msgs.ToList()))
+            .ReturnsAsync(() =>
+            {
+                // First call: ask for a tool. Second call: stop.
+                return capturedPerCall.Count == 1
+                    ? new ChatResponse
+                    {
+                        Content = "running",
+                        ToolCalls = new List<ToolCall>
+                        {
+                            new() { Id = "tc-1", Name = "echo_tool", Arguments = "{}" }
+                        },
+                        FinishReason = "tool_calls"
+                    }
+                    : new ChatResponse { Content = "done", FinishReason = "stop", ToolCalls = null };
+            });
+
+        var tool = new Mock<ITool>(MockBehavior.Strict);
+        tool.SetupGet(t => t.Name).Returns("echo_tool");
+        tool.SetupGet(t => t.Description).Returns("Echo");
+        tool.SetupGet(t => t.ParametersType).Returns(typeof(EmptyParams));
+        tool.Setup(t => t.ExecuteAsync(It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ToolResult.Ok("tool-output"));
+
+        var agent = new Agent(chatClient.Object, NullLogger<Agent>.Instance);
+        agent.RegisterTool(tool.Object);
+
+        var session = new Session { Id = "shape-with-tools" };
+        SeedStackedSystemMessages(session);
+
+        var result = await agent.ChatAsync("hello", session, CancellationToken.None);
+
+        Assert.AreEqual("done", result);
+        Assert.AreEqual(2, capturedPerCall.Count, "Tool loop should call provider twice (request tool, then stop).");
+
+        // Both wire payloads — initial and post-tool-result — must coalesce.
+        AssertSingleLeadingSystem(capturedPerCall[0], "[soul]", "[plugins]", "[memory]");
+        AssertSingleLeadingSystem(capturedPerCall[1], "[soul]", "[plugins]", "[memory]");
+    }
+
+    // ── StreamChatAsync no-tools: routes through StreamAsync(string?, ...) ──
+
+    [TestMethod]
+    public async Task StreamChatAsync_NoTools_WirePayloadHasSingleLeadingSystem_AndSystemPromptThreaded()
+    {
+        var chatClient = new Mock<IChatClient>(MockBehavior.Strict);
+        IEnumerable<Message>? capturedMessages = null;
+        string? capturedSystemPrompt = null;
+
+        chatClient.Setup(c => c.StreamAsync(
+                It.IsAny<string?>(),
+                It.IsAny<IEnumerable<Message>>(),
+                It.IsAny<IEnumerable<ToolDefinition>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string?, IEnumerable<Message>, IEnumerable<ToolDefinition>?, CancellationToken>(
+                (sp, msgs, _, _) =>
+                {
+                    capturedSystemPrompt = sp;
+                    capturedMessages = msgs.ToList();
+                })
+            .Returns(EmptyStream());
+
+        var agent = new Agent(chatClient.Object, NullLogger<Agent>.Instance);
+        var session = new Session { Id = "shape-stream-no-tools" };
+        SeedStackedSystemMessages(session);
+
+        await foreach (var _ in agent.StreamChatAsync("hello", session, CancellationToken.None))
+        {
+            // drain
+        }
+
+        Assert.IsNotNull(capturedMessages);
+        AssertSingleLeadingSystem(capturedMessages!.ToList(), "[soul]", "[plugins]", "[memory]");
+
+        // AnthropicClient streaming requires non-null systemPrompt; OpenAiClient
+        // ignores it but it must be threaded through so the bridge works for both.
+        Assert.IsNotNull(capturedSystemPrompt,
+            "Streaming bridge must thread rendered system into systemPrompt so AnthropicClient can populate top-level system field.");
+        StringAssert.Contains(capturedSystemPrompt!, "[soul]");
+        StringAssert.Contains(capturedSystemPrompt!, "[plugins]");
+        StringAssert.Contains(capturedSystemPrompt!, "[memory]");
+    }
+
+    // ── StreamChatAsync with-tools: routes through CompleteWithToolsAsync per iteration ──
+
+    [TestMethod]
+    public async Task StreamChatAsync_WithTools_EveryIterationWirePayloadHasSingleLeadingSystem()
+    {
+        var chatClient = new Mock<IChatClient>(MockBehavior.Strict);
+        var capturedPerCall = new List<List<Message>>();
+
+        chatClient.Setup(c => c.CompleteWithToolsAsync(
+                It.IsAny<IEnumerable<Message>>(),
+                It.IsAny<IEnumerable<ToolDefinition>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<Message>, IEnumerable<ToolDefinition>, CancellationToken>((msgs, _, _) =>
+                capturedPerCall.Add(msgs.ToList()))
+            .ReturnsAsync(() =>
+            {
+                return capturedPerCall.Count == 1
+                    ? new ChatResponse
+                    {
+                        Content = "running",
+                        ToolCalls = new List<ToolCall>
+                        {
+                            new() { Id = "tc-1", Name = "echo_tool", Arguments = "{}" }
+                        },
+                        FinishReason = "tool_calls"
+                    }
+                    : new ChatResponse { Content = "done", FinishReason = "stop", ToolCalls = null };
+            });
+
+        var tool = new Mock<ITool>(MockBehavior.Strict);
+        tool.SetupGet(t => t.Name).Returns("echo_tool");
+        tool.SetupGet(t => t.Description).Returns("Echo");
+        tool.SetupGet(t => t.ParametersType).Returns(typeof(EmptyParams));
+        tool.Setup(t => t.ExecuteAsync(It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ToolResult.Ok("tool-output"));
+
+        var agent = new Agent(chatClient.Object, NullLogger<Agent>.Instance);
+        agent.RegisterTool(tool.Object);
+
+        var session = new Session { Id = "shape-stream-with-tools" };
+        SeedStackedSystemMessages(session);
+
+        await foreach (var _ in agent.StreamChatAsync("hello", session, CancellationToken.None))
+        {
+            // drain
+        }
+
+        Assert.AreEqual(2, capturedPerCall.Count);
+        AssertSingleLeadingSystem(capturedPerCall[0], "[soul]", "[plugins]", "[memory]");
+        AssertSingleLeadingSystem(capturedPerCall[1], "[soul]", "[plugins]", "[memory]");
+    }
+
+    // ── Defense-in-depth: a stray mid-list system in session.Messages must be hoisted ──
+
+    [TestMethod]
+    public async Task ChatAsync_StrayMidConversationSystem_HoistedIntoLeadingSystemNotPropagated()
+    {
+        // This is the regression bait. Today's known injection sites all
+        // Insert(0, ...) before the user message — the leading system is
+        // "naturally" at index 0. But if a future plugin or subsystem
+        // appends a role:"system" message later in the conversation
+        // (after user/assistant turns), the coalescer must still hoist it.
+        var chatClient = new Mock<IChatClient>(MockBehavior.Strict);
+        IEnumerable<Message>? captured = null;
+
+        chatClient.Setup(c => c.CompleteAsync(
+                It.IsAny<IEnumerable<Message>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<Message>, CancellationToken>((msgs, _) => captured = msgs.ToList())
+            .ReturnsAsync("ok");
+
+        var agent = new Agent(chatClient.Object, NullLogger<Agent>.Instance);
+        var session = new Session { Id = "shape-stray" };
+
+        session.AddMessage(new Message { Role = "user", Content = "earlier turn" });
+        session.AddMessage(new Message { Role = "assistant", Content = "earlier reply" });
+        // Stray mid-list system — exactly the shape strict servers reject.
+        session.AddMessage(new Message { Role = "system", Content = "[stray] late-injected directive" });
+
+        await agent.ChatAsync("next message", session, CancellationToken.None);
+
+        Assert.IsNotNull(captured);
+        var observed = captured!.ToList();
+        AssertSingleLeadingSystem(observed, "[stray]");
+    }
+
+    // ── Helpers ──
+
+    private static async IAsyncEnumerable<StreamEvent> EmptyStream(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+
+    private sealed class EmptyParams { }
+}

--- a/src/Core/Agent.cs
+++ b/src/Core/Agent.cs
@@ -253,15 +253,24 @@ public sealed class Agent : IAgent
                 var messagesToSend = preparedContext ?? session.Messages;
                 // INV-004/005: Use active client (with fallback support)
                 var activeClient = GetActiveChatClient();
+                // Coalesce any role:"system" entries (soul, persona, plugins,
+                // memory, wiki, session state) into a single leading system
+                // message. Strict OpenAI-compatible servers — vLLM with Qwen
+                // / Llama-3 chat templates, llama.cpp strict templates, TGI,
+                // several LMStudio strict-template models — reject any mid-
+                // list system message with a Jinja error. CoalesceWith hoists
+                // the strays into the rendered system block before the wire
+                // call, regardless of how upstream built the message list.
+                var (_, coalescedMessages) = SystemContext.Empty.CoalesceWith(messagesToSend);
                 string response;
                 try
                 {
-                    response = await activeClient.CompleteAsync(messagesToSend, ct);
+                    response = await activeClient.CompleteAsync(coalescedMessages, ct);
                 }
                 catch (HttpRequestException ex) when (_fallbackChatClient is not null)
                 {
                     activeClient = ActivateFallback(ex);
-                    response = await activeClient.CompleteAsync(messagesToSend, ct);
+                    response = await activeClient.CompleteAsync(coalescedMessages, ct);
                 }
                 await AgentSessionWriter.AppendAssistantMessageAsync(session, response, _transcripts, ct);
                 if (_contextManager is not null)
@@ -286,15 +295,22 @@ public sealed class Agent : IAgent
 
             // INV-004/005: Use active client with fallback support
             var activeClientForTools = GetActiveChatClient();
+            // Coalesce role:"system" entries into a single leading system message
+            // before calling the provider — required by strict OpenAI-compatible
+            // servers (vLLM/Qwen, llama.cpp strict templates, TGI). Anthropic's
+            // legacy CompleteWithToolsAsync extracts that leading system
+            // internally and routes it to the top-level "system" parameter,
+            // so this works for both provider families.
+            var (_, coalescedToolMessages) = SystemContext.Empty.CoalesceWith(messagesToUse);
             ChatResponse response;
             try
             {
-                response = await activeClientForTools.CompleteWithToolsAsync(messagesToUse, toolDefs, ct);
+                response = await activeClientForTools.CompleteWithToolsAsync(coalescedToolMessages, toolDefs, ct);
             }
             catch (HttpRequestException ex) when (_fallbackChatClient is not null)
             {
                 activeClientForTools = ActivateFallback(ex);
-                response = await activeClientForTools.CompleteWithToolsAsync(messagesToUse, toolDefs, ct);
+                response = await activeClientForTools.CompleteWithToolsAsync(coalescedToolMessages, toolDefs, ct);
             }
 
             if (!response.HasToolCalls)
@@ -706,8 +722,18 @@ public sealed class Agent : IAgent
             // No tools registered — stream the response directly
             var messagesToSend = preparedContext ?? session.Messages;
 
+            // Thread coalesced system content into both channels: the
+            // systemPrompt parameter (which AnthropicClient streaming uses to
+            // populate the top-level "system" field — it drops role:"system"
+            // entries from the messages list at BuildPayload) AND a leading
+            // system message in the conversation (which OpenAiClient
+            // streaming reads verbatim, ignoring systemPrompt). Strict
+            // OpenAI-compatible servers see exactly one system at index 0;
+            // Anthropic gets its system via the dedicated parameter.
+            var (streamSystemPrompt, streamCoalescedMessages) =
+                SystemContext.Empty.CoalesceWith(messagesToSend);
             await foreach (var evt in WatchProviderStreamAsync(
-                _chatClient.StreamAsync((string?)null, messagesToSend, null, ct), ct))
+                _chatClient.StreamAsync(streamSystemPrompt, streamCoalescedMessages, null, ct), ct))
             {
                 if (evt is StreamEvent.TokenDelta td)
                     streamedResponse.Append(td.Text);
@@ -737,7 +763,10 @@ public sealed class Agent : IAgent
                 ? preparedContext
                 : session.Messages;
 
-            var response = await _chatClient.CompleteWithToolsAsync(messagesToUse, toolDefs, ct);
+            // Same coalescing as the non-streaming tool loop — strict
+            // OpenAI-compatible servers reject mid-list role:"system" entries.
+            var (_, streamToolMessages) = SystemContext.Empty.CoalesceWith(messagesToUse);
+            var response = await _chatClient.CompleteWithToolsAsync(streamToolMessages, toolDefs, ct);
 
             if (!response.HasToolCalls)
             {

--- a/src/Core/Agent.cs
+++ b/src/Core/Agent.cs
@@ -732,8 +732,16 @@ public sealed class Agent : IAgent
             // Anthropic gets its system via the dedicated parameter.
             var (streamSystemPrompt, streamCoalescedMessages) =
                 SystemContext.Empty.CoalesceWith(messagesToSend);
+            // INV-004/005: honor active provider (primary or fallback). Without
+            // GetActiveChatClient() here, streaming would silently keep talking
+            // to a primary provider that ChatAsync had already failed off of.
+            // Async-iterator constraints (no yield-return inside catch) prevent
+            // mid-stream HttpRequestException → ActivateFallback retry on the
+            // streaming SSE itself; that's a separate concern. This change
+            // matches the cooperative behavior of the rest of the loop.
+            var streamingClient = GetActiveChatClient();
             await foreach (var evt in WatchProviderStreamAsync(
-                _chatClient.StreamAsync(streamSystemPrompt, streamCoalescedMessages, null, ct), ct))
+                streamingClient.StreamAsync(streamSystemPrompt, streamCoalescedMessages, null, ct), ct))
             {
                 if (evt is StreamEvent.TokenDelta td)
                     streamedResponse.Append(td.Text);
@@ -766,7 +774,24 @@ public sealed class Agent : IAgent
             // Same coalescing as the non-streaming tool loop — strict
             // OpenAI-compatible servers reject mid-list role:"system" entries.
             var (_, streamToolMessages) = SystemContext.Empty.CoalesceWith(messagesToUse);
-            var response = await _chatClient.CompleteWithToolsAsync(streamToolMessages, toolDefs, ct);
+            // INV-004/005: tool-loop calls inside StreamChatAsync are non-
+            // streaming (CompleteWithToolsAsync), so they can wear the same
+            // try/catch + ActivateFallback retry that ChatAsync has. Without
+            // this, a primary-provider HTTP failure during a tool round of
+            // a streamed turn would never trigger fallback — only ChatAsync
+            // turns would, and the two entry points would silently diverge
+            // in resilience.
+            var activeStreamToolClient = GetActiveChatClient();
+            ChatResponse response;
+            try
+            {
+                response = await activeStreamToolClient.CompleteWithToolsAsync(streamToolMessages, toolDefs, ct);
+            }
+            catch (HttpRequestException ex) when (_fallbackChatClient is not null)
+            {
+                activeStreamToolClient = ActivateFallback(ex);
+                response = await activeStreamToolClient.CompleteWithToolsAsync(streamToolMessages, toolDefs, ct);
+            }
 
             if (!response.HasToolCalls)
             {

--- a/src/Core/SystemContext.cs
+++ b/src/Core/SystemContext.cs
@@ -90,4 +90,48 @@ public sealed record SystemContext
         }
         return (new SystemContext { Transient = transient }, conversation);
     }
+
+    /// <summary>
+    /// Combines this SystemContext with <paramref name="conversation"/> and
+    /// returns the inputs ready for a legacy IChatClient call:
+    /// <list type="bullet">
+    ///   <item>A rendered system prompt (for providers like AnthropicClient
+    ///         streaming that read the <c>systemPrompt</c> parameter to set
+    ///         the top-level <c>system</c> field), or <c>null</c> when no
+    ///         layers are present.</item>
+    ///   <item>A messages list with at most one leading <c>role:"system"</c>
+    ///         entry and zero mid-list system messages — required by strict
+    ///         OpenAI-compatible servers (vLLM with Qwen / Llama-3 chat
+    ///         templates, llama.cpp strict templates, TGI, several LMStudio
+    ///         strict-template models).</item>
+    /// </list>
+    /// Stray <c>role:"system"</c> entries inside <paramref name="conversation"/>
+    /// are hoisted into the rendered system block — the contract holds
+    /// regardless of how the caller built the conversation list.
+    /// </summary>
+    public (string? SystemPrompt, IEnumerable<Message> Messages) CoalesceWith(
+        IEnumerable<Message> conversation)
+    {
+        var stray = new List<string>();
+        var clean = new List<Message>();
+        foreach (var m in conversation)
+        {
+            if (m.Role == "system")
+            {
+                if (!string.IsNullOrWhiteSpace(m.Content)) stray.Add(m.Content);
+                continue;
+            }
+            clean.Add(m);
+        }
+
+        var effective = stray.Count == 0
+            ? this
+            : this with { Transient = Transient.Concat(stray).ToList() };
+
+        if (effective.IsEmpty)
+            return (null, clean);
+
+        var rendered = effective.Render("\n\n");
+        return (rendered, clean.Prepend(new Message { Role = "system", Content = rendered }));
+    }
 }

--- a/src/LLM/IChatClient.cs
+++ b/src/LLM/IChatClient.cs
@@ -40,6 +40,20 @@ public interface IChatClient
     // unlock prompt caching on stable layers).
 
     /// <summary>
+    /// Simple completion with system context passed structurally. Stray
+    /// <c>role: "system"</c> entries inside <paramref name="conversation"/>
+    /// are hoisted into the coalesced system block.
+    /// </summary>
+    Task<string> CompleteAsync(
+        SystemContext system,
+        IEnumerable<Message> conversation,
+        CancellationToken ct)
+    {
+        var prepared = PrepareLegacyCall(system, conversation);
+        return CompleteAsync(prepared.Messages, ct);
+    }
+
+    /// <summary>
     /// Completion with system context passed structurally. Stray
     /// <c>role: "system"</c> entries inside <paramref name="conversation"/>
     /// are hoisted into the coalesced system block before the call reaches
@@ -79,42 +93,15 @@ public interface IChatClient
     }
 
     /// <summary>
-    /// Hoists stray <c>role:"system"</c> messages from
-    /// <paramref name="conversation"/> into the SystemContext, then renders
-    /// the effective system content. Returns both the rendered string (for
-    /// providers that read a <c>systemPrompt</c> parameter, e.g. Anthropic
-    /// streaming) and a message list with a leading system message (for
-    /// providers that read the messages array verbatim, e.g. OpenAI). The
-    /// returned list never contains a mid-list system message — the
-    /// load-bearing invariant strict OpenAI-compatible servers depend on.
+    /// Delegates to <see cref="SystemContext.CoalesceWith"/> — kept as a
+    /// thin alias so existing tests that reference PrepareLegacyCall via
+    /// reflection still work, and so the bridge contract reads naturally
+    /// inside the interface body.
     /// </summary>
     private static (string? SystemPrompt, IEnumerable<Message> Messages) PrepareLegacyCall(
         SystemContext system,
         IEnumerable<Message> conversation)
-    {
-        var stray = new List<string>();
-        var clean = new List<Message>();
-        foreach (var m in conversation)
-        {
-            if (m.Role == "system")
-            {
-                if (!string.IsNullOrWhiteSpace(m.Content)) stray.Add(m.Content);
-                continue;
-            }
-            clean.Add(m);
-        }
-
-        var effective = stray.Count == 0
-            ? system
-            : system with { Transient = system.Transient.Concat(stray).ToList() };
-
-        if (effective.IsEmpty)
-            return (null, clean);
-
-        var rendered = effective.Render("\n\n");
-        var leading = new Message { Role = "system", Content = rendered };
-        return (rendered, clean.Prepend(leading));
-    }
+        => system.CoalesceWith(conversation);
 }
 
 public sealed class LlmConfig


### PR DESCRIPTION
## Summary

Follow-up to [#49](https://github.com/RedWoodOG/Hermes-Desktop/pull/49). The merge of #49 captured the SystemContext infrastructure but missed the two commits that actually wire it into the agent loop. Without this PR, the reporter's vLLM/Qwen Jinja error is **not yet fixed on `main`** — the foundation is present but `Agent.cs` still passes raw multi-system message lists to `IChatClient`.

## Why a follow-up

The two commits below were pushed to the `fix/system-context-coalesce` branch after the merge button was clicked on #49. The merge captured the branch at `eb9b18f`, which is the bug-fix commit *against* the foundation but does not migrate the call sites in `Agent.cs`. As a result:

- `src/Core/SystemContext.cs` — present on main ✓
- `src/LLM/IChatClient.cs` SystemContext-aware overloads — present on main ✓
- `Agent.cs` IChatClient call sites — **still pass raw multi-system lists on main** ✗

This PR cherry-picks the two missing commits onto a fresh branch off main:

| SHA (in this PR) | Original SHA | Title |
|---|---|---|
| `4aac3fe` | `066b801` | `fix(llm): coalesce system messages at IChatClient call sites in Agent` |
| `483f8be` | `cd6e16d` | `test(agent): end-to-end shape tests for system-message coalescing` |

## What changes

`src/Core/SystemContext.cs`
- Adds `CoalesceWith(IEnumerable<Message>)` instance method — single source of truth for the hoist-and-render logic.

`src/LLM/IChatClient.cs`
- `PrepareLegacyCall` becomes a one-line delegate to `CoalesceWith`. No duplicate logic.

`src/Core/Agent.cs` (5 IChatClient call sites in `ChatAsync` + `StreamChatAsync`)
- Each call site now coalesces `messagesToUse` / `messagesToSend` through `SystemContext.Empty.CoalesceWith(...)` before invoking the **legacy** IChatClient methods.
- Wire payloads now contain at most one leading `role:"system"` message; mid-conversation systems are eliminated.
- Streaming call site (no-tools path) threads the rendered system into both the `systemPrompt` parameter (for AnthropicClient) and as a leading message (for OpenAiClient).

`Desktop/HermesDesktop.Tests/Services/AgentSystemMessageShapeTests.cs` (new — 5 tests)
- End-to-end shape tests that drive the real `Agent.ChatAsync` and `Agent.StreamChatAsync` with sessions containing stacked `role:"system"` entries, capture what reaches `IChatClient`, and assert the wire shape.
- Covers no-tools, with-tools, streaming, streaming with tools, and stray-mid-conversation-system cases.

## Why inline coalescing instead of routing through the new SystemContext-aware overloads

Routing `Agent.cs` through the new overloads broke 39 mock-based tests — Moq doesn't auto-route via default-interface methods to legacy mocks. Coalescing inline keeps the legacy call paths intact, all existing tests pass without modification, and the wire result is identical.

The new SystemContext-aware overloads remain available for future call sites and external consumers; they are not dead code, just not the path the agent takes today.

## Test plan

- [x] `dotnet build` — Hermes.Core, Hermes.Agent, HermesDesktop.Tests: **0 warnings, 0 errors**
- [x] `dotnet test` full suite — **572/572 pass** (5 new shape tests + 567 existing). Zero regressions.
- [ ] Real vLLM/Qwen smoke test — deferred to maintainer / reporter after merge. The 5 new shape tests verify the wire shape Hermes produces; they do not verify that vLLM/Qwen accepts the payload, which still requires a real server roundtrip.

## Effect on the reporter (post-merge)

A user running Hermes Desktop against vLLM with a Qwen chat template no longer trips the Jinja "System Message must be at the beginning" error. The chat-template workaround posted in their issue thread can be retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `Agent` provider-call paths (chat, streaming, and tool iterations), which can subtly change request payloads and fallback behavior across LLM backends; risk is mitigated by added end-to-end shape tests.
> 
> **Overview**
> **Fixes provider payload shape in the real agent loop.** All `IChatClient` calls from `Agent.ChatAsync` and `Agent.StreamChatAsync` now run the outgoing conversation through `SystemContext.Empty.CoalesceWith(...)`, guaranteeing *exactly one leading* `role:"system"` message and no mid-list system messages (including hoisting any stray systems).
> 
> **Improves streaming/tool-path consistency.** Streaming now passes the rendered system both as a leading message and via the `systemPrompt` parameter, and the streamed tool loop uses the active client with fallback retry (matching `ChatAsync`).
> 
> **Adds regression coverage.** Introduces `AgentSystemMessageShapeTests` to assert the on-the-wire message shape across no-tools, tools (multi-iteration), streaming, and stray mid-conversation system injections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e60467e96d6bc9d51b2e168b6a89c439b9f2549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System messages are now automatically consolidated into a single leading message, improving compatibility with chat providers.

* **Improvements**
  * Enhanced message handling to ensure consistent behavior across different chat client implementations.

* **Tests**
  * Added comprehensive validation tests for system message payload formatting and agent interaction reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->