### PR TITLE
fix(tools): CheckpointTool no longer recurses into its own output (#52)

### DIFF
--- a/Desktop/HermesDesktop.Tests/Tools/CheckpointToolTests.cs
+++ b/Desktop/HermesDesktop.Tests/Tools/CheckpointToolTests.cs
@@ -1,0 +1,256 @@
+using System.Diagnostics;
+using Hermes.Agent.Core;
+using Hermes.Agent.Tools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HermesDesktop.Tests.Tools;
+
+/// <summary>
+/// Regression tests for issue #52 — CheckpointTool infinite recursion when the
+/// checkpoint output directory was inside the source directory. Also covers
+/// reparse-point cycle defense and legacy fallback for restore/list.
+/// </summary>
+[TestClass]
+public class CheckpointToolTests
+{
+    private string _root = null!;
+    private string _workDir = null!;
+    private string _legacyDir = null!;
+
+    [TestInitialize]
+    public void SetUp()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"hermes-ckpt-test-{Guid.NewGuid():N}");
+        _workDir = Path.Combine(_root, "workdir");
+        _legacyDir = Path.Combine(_root, "legacy-checkpoints");
+        Directory.CreateDirectory(_workDir);
+        Directory.CreateDirectory(_legacyDir);
+    }
+
+    [TestCleanup]
+    public void TearDown()
+    {
+        if (!Directory.Exists(_root)) return;
+        try
+        {
+            ClearReparsePoints(_root);
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    [TestMethod]
+    public async Task Create_DoesNotRecurse_WhenLegacyCheckpointDirIsInsideSource()
+    {
+        // Original repro from issue #52: legacy _checkpointDir lives under the source.
+        // With the A+B fix, snapshots go to <parent>/<basename>-checkpoints, not into the
+        // source — so no infinite recursion is possible regardless of where _checkpointDir is.
+        var legacyInsideSource = Path.Combine(_workDir, "data", "checkpoints");
+        Directory.CreateDirectory(legacyInsideSource);
+        File.WriteAllText(Path.Combine(_workDir, "marker.txt"), "x");
+
+        var tool = new CheckpointTool(legacyInsideSource);
+        var result = await tool.ExecuteAsync(
+            new CheckpointParameters { Action = "create", Directory = _workDir, Name = "test" },
+            CancellationToken.None);
+
+        Assert.IsTrue(result.Success, $"create should succeed: {result.Content}");
+
+        var snapshotRoot = Path.Combine(_root, "workdir-checkpoints");
+        Assert.IsTrue(File.Exists(Path.Combine(snapshotRoot, "test", "marker.txt")),
+            "snapshot should contain source files at the new structural location");
+
+        Assert.IsFalse(Directory.Exists(Path.Combine(legacyInsideSource, "test")),
+            "snapshot must not be written inside the source directory anymore");
+
+        Assert.IsFalse(Directory.Exists(Path.Combine(snapshotRoot, "test", "workdir-checkpoints")),
+            "snapshot must not contain a nested copy of itself");
+
+        Assert.IsFalse(
+            Directory.Exists(Path.Combine(snapshotRoot, "test", "data", "checkpoints", "test")),
+            "snapshot must not contain a nested copy of the legacy checkpoint dir");
+    }
+
+    [TestMethod]
+    public async Task Create_PlacesSnapshotAtParentBasenameCheckpoints()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "a.txt"), "a");
+
+        var tool = new CheckpointTool(_legacyDir);
+        var result = await tool.ExecuteAsync(
+            new CheckpointParameters { Action = "create", Directory = _workDir, Name = "snap1" },
+            CancellationToken.None);
+
+        Assert.IsTrue(result.Success, result.Content);
+        var expected = Path.Combine(_root, "workdir-checkpoints", "snap1");
+        Assert.IsTrue(Directory.Exists(expected),
+            $"snapshot should land at {expected}, got result: {result.Content}");
+        Assert.IsTrue(File.Exists(Path.Combine(expected, "a.txt")));
+    }
+
+    [TestMethod]
+    public async Task Create_DoesNotFollowReparsePointInsideSource()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Inconclusive("Reparse-point test only runs on Windows.");
+            return;
+        }
+
+        File.WriteAllText(Path.Combine(_workDir, "real.txt"), "real");
+
+        // Create a junction inside source pointing back at source. With B's reparse-point
+        // skip, this must not be followed; without it, CopyDirectory would loop forever.
+        var junctionPath = Path.Combine(_workDir, "loop");
+        var psi = new ProcessStartInfo("cmd.exe", $"/c mklink /J \"{junctionPath}\" \"{_workDir}\"")
+        {
+            CreateNoWindow = true,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        using (var proc = Process.Start(psi))
+        {
+            Assert.IsNotNull(proc);
+            proc.WaitForExit(5000);
+            if (proc.ExitCode != 0)
+            {
+                Assert.Inconclusive($"mklink failed: {proc.StandardError.ReadToEnd()}");
+                return;
+            }
+        }
+
+        var tool = new CheckpointTool(_legacyDir);
+
+        var task = tool.ExecuteAsync(
+            new CheckpointParameters { Action = "create", Directory = _workDir, Name = "snap" },
+            CancellationToken.None);
+
+        // Hard cap: if the bug regresses, this test would otherwise hang until the disk fills.
+        var completed = await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(15)));
+        Assert.AreSame(task, completed, "checkpoint must terminate quickly even with junction cycle");
+
+        var result = await task;
+        Assert.IsTrue(result.Success, result.Content);
+
+        var snapPath = Path.Combine(_root, "workdir-checkpoints", "snap");
+        Assert.IsTrue(File.Exists(Path.Combine(snapPath, "real.txt")));
+        // Junction is not followed — either absent in the snapshot or present as an empty entry
+        // we created via Directory.CreateDirectory inside CopyDirectory. Either way, no recursion.
+        Assert.IsFalse(Directory.Exists(Path.Combine(snapPath, "loop", "loop")),
+            "junction must not be followed; no nested 'loop' should exist");
+    }
+
+    [TestMethod]
+    public async Task Restore_FallsBackToLegacyCheckpointDir()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "before.txt"), "before");
+
+        // Place a checkpoint manually into the legacy location, simulating a snapshot
+        // taken before this fix.
+        var legacySnap = Path.Combine(_legacyDir, "old-snap");
+        Directory.CreateDirectory(legacySnap);
+        File.WriteAllText(Path.Combine(legacySnap, "restored.txt"), "from-legacy");
+
+        var tool = new CheckpointTool(_legacyDir);
+        var result = await tool.ExecuteAsync(
+            new CheckpointParameters { Action = "restore", Directory = _workDir, Name = "old-snap" },
+            CancellationToken.None);
+
+        Assert.IsTrue(result.Success, result.Content);
+        Assert.IsTrue(File.Exists(Path.Combine(_workDir, "restored.txt")),
+            "legacy checkpoint should restore into the work dir");
+        Assert.AreEqual("from-legacy", File.ReadAllText(Path.Combine(_workDir, "restored.txt")));
+    }
+
+    [TestMethod]
+    public async Task List_MergesPerSourceAndLegacyCheckpoints()
+    {
+        // Per-source snapshot
+        File.WriteAllText(Path.Combine(_workDir, "x.txt"), "x");
+        var tool = new CheckpointTool(_legacyDir);
+        var create = await tool.ExecuteAsync(
+            new CheckpointParameters { Action = "create", Directory = _workDir, Name = "fresh" },
+            CancellationToken.None);
+        Assert.IsTrue(create.Success, create.Content);
+
+        // Legacy snapshot, placed manually
+        Directory.CreateDirectory(Path.Combine(_legacyDir, "ancient"));
+        File.WriteAllText(Path.Combine(_legacyDir, "ancient", "y.txt"), "y");
+
+        var list = await tool.ExecuteAsync(
+            new CheckpointParameters { Action = "list", Directory = _workDir },
+            CancellationToken.None);
+
+        Assert.IsTrue(list.Success, list.Content);
+        StringAssert.Contains(list.Content, "fresh");
+        StringAssert.Contains(list.Content, "(source)");
+        StringAssert.Contains(list.Content, "ancient");
+        StringAssert.Contains(list.Content, "(legacy)");
+    }
+
+    [TestMethod]
+    public async Task Create_RefusesWhenDirectoryEqualsSnapshotRoot()
+    {
+        // A directory whose computed snapshotRoot equals itself is degenerate. The simplest
+        // way to construct one is to pass a path equal to its own ComputeSnapshotRoot output;
+        // we trigger the equivalent guard by passing the snapshotRoot back as the directory.
+        var basenameDir = Path.Combine(_root, "self-checkpoints");
+        Directory.CreateDirectory(basenameDir);
+
+        var tool = new CheckpointTool(_legacyDir);
+
+        // Compute what the tool would produce for basenameDir: parent=_root, basename="self-checkpoints",
+        // snapshotRoot = _root/self-checkpoints-checkpoints. Distinct, so this is fine — the equality
+        // refusal really fires only at filesystem roots. We assert that on non-degenerate input the
+        // tool does NOT refuse, which is the behavior we care about for normal use.
+        var result = await tool.ExecuteAsync(
+            new CheckpointParameters { Action = "create", Directory = basenameDir, Name = "x" },
+            CancellationToken.None);
+        Assert.IsTrue(result.Success, result.Content);
+    }
+
+    [TestMethod]
+    public async Task Create_RejectsMissingDirectory()
+    {
+        var tool = new CheckpointTool(_legacyDir);
+        var result = await tool.ExecuteAsync(
+            new CheckpointParameters { Action = "create", Directory = null, Name = "x" },
+            CancellationToken.None);
+
+        Assert.IsFalse(result.Success);
+        StringAssert.Contains(result.Content, "Directory is required");
+    }
+
+    private static void ClearReparsePoints(string root)
+    {
+        // Junctions inside the test tree must be removed *before* Directory.Delete recursive,
+        // otherwise the recursive delete would traverse them and risk deleting the target.
+        // Walk manually so we never recurse into a reparse point.
+        if (!Directory.Exists(root)) return;
+        var stack = new Stack<string>();
+        stack.Push(root);
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            string[] subDirs;
+            try { subDirs = Directory.GetDirectories(current); }
+            catch (IOException) { continue; }
+            catch (UnauthorizedAccessException) { continue; }
+
+            foreach (var sub in subDirs)
+            {
+                try
+                {
+                    if ((File.GetAttributes(sub) & FileAttributes.ReparsePoint) != 0)
+                        Directory.Delete(sub);  // delete the link, not its target
+                    else
+                        stack.Push(sub);
+                }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+            }
+        }
+    }
+}

--- a/Desktop/HermesDesktop.Tests/Tools/CheckpointToolTests.cs
+++ b/Desktop/HermesDesktop.Tests/Tools/CheckpointToolTests.cs
@@ -103,20 +103,13 @@ public class CheckpointToolTests
         // Create a junction inside source pointing back at source. With B's reparse-point
         // skip, this must not be followed; without it, CopyDirectory would loop forever.
         var junctionPath = Path.Combine(_workDir, "loop");
-        var psi = new ProcessStartInfo("cmd.exe", $"/c mklink /J \"{junctionPath}\" \"{_workDir}\"")
-        {
-            CreateNoWindow = true,
-            UseShellExecute = false,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-        };
-        using (var proc = Process.Start(psi))
+        using (var proc = Process.Start("cmd.exe", $"/c mklink /J \"{junctionPath}\" \"{_workDir}\""))
         {
             Assert.IsNotNull(proc);
             proc.WaitForExit(5000);
             if (proc.ExitCode != 0)
             {
-                Assert.Inconclusive($"mklink failed: {proc.StandardError.ReadToEnd()}");
+                Assert.Inconclusive($"mklink failed with exit code {proc.ExitCode}");
                 return;
             }
         }
@@ -227,13 +220,14 @@ public class CheckpointToolTests
     {
         // Junctions inside the test tree must be removed *before* Directory.Delete recursive,
         // otherwise the recursive delete would traverse them and risk deleting the target.
-        // Walk manually so we never recurse into a reparse point.
+        // Walk manually (List used as a stack) so we never recurse into a reparse point.
         if (!Directory.Exists(root)) return;
-        var stack = new Stack<string>();
-        stack.Push(root);
-        while (stack.Count > 0)
+        var pending = new List<string> { root };
+        while (pending.Count > 0)
         {
-            var current = stack.Pop();
+            var current = pending[pending.Count - 1];
+            pending.RemoveAt(pending.Count - 1);
+
             string[] subDirs;
             try { subDirs = Directory.GetDirectories(current); }
             catch (IOException) { continue; }
@@ -246,7 +240,7 @@ public class CheckpointToolTests
                     if ((File.GetAttributes(sub) & FileAttributes.ReparsePoint) != 0)
                         Directory.Delete(sub);  // delete the link, not its target
                     else
-                        stack.Push(sub);
+                        pending.Add(sub);
                 }
                 catch (IOException) { }
                 catch (UnauthorizedAccessException) { }

--- a/src/Tools/CheckpointTool.cs
+++ b/src/Tools/CheckpointTool.cs
@@ -4,11 +4,21 @@ using Hermes.Agent.Core;
 
 /// <summary>
 /// Create/restore filesystem snapshots for safe rollback.
-/// Copies directory contents to timestamped checkpoints.
+///
+/// New snapshots are written to <c>&lt;parent-of-source&gt;/&lt;basename-of-source&gt;-checkpoints/&lt;name&gt;/</c>
+/// so the snapshot location is structurally outside the source directory and cannot
+/// recurse back into it (issue #52).
+///
+/// The legacy <c>checkpointDir</c> passed to the constructor remains a fallback location
+/// for <c>list</c> and <c>restore</c>, so checkpoints created before this change are still
+/// reachable.
 /// </summary>
 public sealed class CheckpointTool : ITool
 {
     private readonly string _checkpointDir;
+
+    private static readonly StringComparison PathComparison =
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
     public string Name => "checkpoint";
     public string Description => "Create, restore, or list filesystem snapshots for safe rollback.";
@@ -16,7 +26,7 @@ public sealed class CheckpointTool : ITool
 
     public CheckpointTool(string checkpointDir)
     {
-        _checkpointDir = checkpointDir;
+        _checkpointDir = Path.GetFullPath(checkpointDir).TrimEnd(Path.DirectorySeparatorChar);
         Directory.CreateDirectory(_checkpointDir);
     }
 
@@ -28,7 +38,7 @@ public sealed class CheckpointTool : ITool
         {
             "create" => CreateCheckpointAsync(p.Directory, p.Name, ct),
             "restore" => RestoreCheckpointAsync(p.Directory, p.Name, ct),
-            "list" => ListCheckpointsAsync(ct),
+            "list" => ListCheckpointsAsync(p.Directory, ct),
             _ => Task.FromResult(ToolResult.Fail($"Unknown action: {p.Action}. Use create, restore, or list."))
         };
     }
@@ -43,14 +53,23 @@ public sealed class CheckpointTool : ITool
 
         try
         {
+            var dirFull = Path.GetFullPath(directory).TrimEnd(Path.DirectorySeparatorChar);
+            var snapshotRoot = ComputeSnapshotRoot(dirFull);
+
+            if (string.Equals(dirFull, snapshotRoot, PathComparison))
+                return Task.FromResult(ToolResult.Fail(
+                    $"Refusing to checkpoint a directory into itself: {dirFull}"));
+
+            Directory.CreateDirectory(snapshotRoot);
+
             var snapshotName = string.IsNullOrWhiteSpace(name)
                 ? $"checkpoint_{DateTime.UtcNow:yyyyMMdd_HHmmss}"
                 : name;
-            var snapshotPath = Path.Combine(_checkpointDir, snapshotName);
+            var snapshotPath = Path.Combine(snapshotRoot, snapshotName);
 
-            CopyDirectory(directory, snapshotPath);
+            CopyDirectory(dirFull, snapshotPath, excludePrefixes: new[] { snapshotRoot, _checkpointDir });
 
-            return Task.FromResult(ToolResult.Ok($"Checkpoint created: {snapshotName}"));
+            return Task.FromResult(ToolResult.Ok($"Checkpoint created: {snapshotName} -> {snapshotPath}"));
         }
         catch (Exception ex)
         {
@@ -66,15 +85,21 @@ public sealed class CheckpointTool : ITool
         if (string.IsNullOrWhiteSpace(directory))
             return Task.FromResult(ToolResult.Fail("Directory is required for restore."));
 
-        var snapshotPath = Path.Combine(_checkpointDir, name);
+        var dirFull = Path.GetFullPath(directory).TrimEnd(Path.DirectorySeparatorChar);
+        var perSource = Path.Combine(ComputeSnapshotRoot(dirFull), name);
+        var legacy = Path.Combine(_checkpointDir, name);
 
-        if (!System.IO.Directory.Exists(snapshotPath))
+        var snapshotPath = System.IO.Directory.Exists(perSource) ? perSource
+                         : System.IO.Directory.Exists(legacy)    ? legacy
+                         : null;
+
+        if (snapshotPath is null)
             return Task.FromResult(ToolResult.Fail($"Checkpoint not found: {name}"));
 
         try
         {
-            CopyDirectory(snapshotPath, directory);
-            return Task.FromResult(ToolResult.Ok($"Checkpoint restored: {name} -> {directory}"));
+            CopyDirectory(snapshotPath, dirFull);
+            return Task.FromResult(ToolResult.Ok($"Checkpoint restored: {name} -> {dirFull}"));
         }
         catch (Exception ex)
         {
@@ -82,24 +107,44 @@ public sealed class CheckpointTool : ITool
         }
     }
 
-    private Task<ToolResult> ListCheckpointsAsync(CancellationToken ct)
+    private Task<ToolResult> ListCheckpointsAsync(string? directory, CancellationToken ct)
     {
-        if (!System.IO.Directory.Exists(_checkpointDir))
+        var entries = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            var dirFull = Path.GetFullPath(directory).TrimEnd(Path.DirectorySeparatorChar);
+            entries.AddRange(EnumerateCheckpoints(ComputeSnapshotRoot(dirFull), label: "(source)"));
+        }
+
+        entries.AddRange(EnumerateCheckpoints(_checkpointDir, label: "(legacy)"));
+
+        if (entries.Count == 0)
             return Task.FromResult(ToolResult.Ok("No checkpoints found."));
 
-        var dirs = System.IO.Directory.GetDirectories(_checkpointDir)
-            .Select(d => new DirectoryInfo(d))
-            .OrderByDescending(d => d.CreationTimeUtc)
-            .Select(d => $"{d.Name}  (created {d.CreationTimeUtc:yyyy-MM-dd HH:mm:ss} UTC)")
-            .ToArray();
-
-        if (dirs.Length == 0)
-            return Task.FromResult(ToolResult.Ok("No checkpoints found."));
-
-        return Task.FromResult(ToolResult.Ok(string.Join("\n", dirs)));
+        return Task.FromResult(ToolResult.Ok(string.Join("\n", entries)));
     }
 
-    private static void CopyDirectory(string sourceDir, string destDir)
+    private static IEnumerable<string> EnumerateCheckpoints(string root, string label)
+    {
+        if (!System.IO.Directory.Exists(root))
+            return Array.Empty<string>();
+
+        return System.IO.Directory.GetDirectories(root)
+            .Select(d => new DirectoryInfo(d))
+            .OrderByDescending(d => d.CreationTimeUtc)
+            .Select(d => $"{d.Name}  {label}  (created {d.CreationTimeUtc:yyyy-MM-dd HH:mm:ss} UTC)");
+    }
+
+    private static string ComputeSnapshotRoot(string directoryFullPath)
+    {
+        var parent = System.IO.Directory.GetParent(directoryFullPath)?.FullName ?? directoryFullPath;
+        var basename = Path.GetFileName(directoryFullPath);
+        if (string.IsNullOrEmpty(basename)) basename = "root";
+        return Path.Combine(parent, $"{basename}-checkpoints").TrimEnd(Path.DirectorySeparatorChar);
+    }
+
+    private static void CopyDirectory(string sourceDir, string destDir, string[]? excludePrefixes = null)
     {
         Directory.CreateDirectory(destDir);
 
@@ -111,9 +156,33 @@ public sealed class CheckpointTool : ITool
 
         foreach (var subDir in System.IO.Directory.GetDirectories(sourceDir))
         {
-            var destSubDir = Path.Combine(destDir, Path.GetFileName(subDir));
-            CopyDirectory(subDir, destSubDir);
+            try
+            {
+                if ((File.GetAttributes(subDir) & FileAttributes.ReparsePoint) != 0)
+                    continue;
+
+                var subFull = Path.GetFullPath(subDir).TrimEnd(Path.DirectorySeparatorChar);
+                if (excludePrefixes is not null && IsUnderAny(subFull, excludePrefixes))
+                    continue;
+
+                var destSubDir = Path.Combine(destDir, Path.GetFileName(subDir));
+                CopyDirectory(subDir, destSubDir, excludePrefixes);
+            }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
         }
+    }
+
+    private static bool IsUnderAny(string subFull, string[] prefixes)
+    {
+        foreach (var p in prefixes)
+        {
+            if (string.IsNullOrEmpty(p)) continue;
+            var pNorm = p.TrimEnd(Path.DirectorySeparatorChar);
+            if (subFull.Equals(pNorm, PathComparison)) return true;
+            if (subFull.StartsWith(pNorm + Path.DirectorySeparatorChar, PathComparison)) return true;
+        }
+        return false;
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #52.

`CheckpointTool.CopyDirectory` recursed forever when the snapshot path lived inside the source directory, filling a customer's 46 GB USB install before the OS halted it. The bug bit portable installs whose `HERMES_HOME` placed checkpoints under the workdir, and was triggered autonomously under `AlwaysAllow`.

This PR ships an A+B combined fix:

- **Structural (A):** new snapshots write to `<parent-of-source>/<basename-of-source>-checkpoints/<name>/`, which by construction cannot live inside the source.
- **Defensive (B):** `CopyDirectory` skips reparse points (junctions/symlinks) and excluded prefixes, with per-subdir `try/catch` so a single bad path cannot abort a snapshot. Defends against junction cycles inside the source even after the structural fix.
- **Backward compat:** `restore` and `list` fall back to the legacy `_checkpointDir` so snapshots created before this change remain reachable.
- Constructor normalizes `_checkpointDir` via `Path.GetFullPath` once.
- Refuses the degenerate case where `directory == snapshotRoot`.
- `App.xaml.cs` wiring is unchanged — constructor signature preserved.

## Test plan

- [x] Build passes: `dotnet build Desktop/HermesDesktop.Tests/HermesDesktop.Tests.csproj`
- [x] Build passes: `dotnet build Desktop/HermesDesktop/HermesDesktop.csproj`
- [x] New test `Create_DoesNotRecurse_WhenLegacyCheckpointDirIsInsideSource` ports the repro from #52 and passes
- [x] New test `Create_DoesNotFollowReparsePointInsideSource` creates a `mklink /J` cycle inside the source and asserts the snapshot terminates within 15 s (would otherwise fill the disk)
- [x] New tests verify the new structural path, legacy `restore` fallback, and `list` merging per-source + legacy entries
- [x] Full suite: 579/579 passing on `Desktop/HermesDesktop.Tests` (7 new + 572 existing)
- [ ] Manual repro on a portable install with `HERMES_HOME=<workdir>/data`: confirm `checkpoint(action=create, directory=<workdir>)` lands in `<parent>/<basename>-checkpoints/<name>/` and does not nest

## Out of scope

- NTFS hard-link / VSS snapshots (issue suggestion D) — separate feature.
- Permission-layer changes (`AlwaysAllow` is doing what the user asked); a docs note recommending against `AlwaysAllow` for `checkpoint` could be a follow-up.
- Migrating existing legacy checkpoints into the new per-source layout — kept reachable via fallback instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkpoint creation/restore/list behavior and filesystem traversal logic, which could affect where snapshots are stored and what gets copied/restored (especially around symlinks/reparse points and path normalization). Added tests reduce regression risk but path-handling differences across OS/filesystems remain the main concern.
> 
> **Overview**
> Fixes `CheckpointTool` infinite-recursion/disk-fill scenarios by **moving new snapshots to a per-source location** (`<parent>/<basename>-checkpoints/<name>`) and **excluding** both the computed snapshot root and the legacy `_checkpointDir` from copies.
> 
> Hardens `CopyDirectory` to **skip reparse points** (junctions/symlinks), ignore excluded path prefixes, and tolerate per-subdirectory IO/access errors; also adds a guard to refuse checkpointing when the computed snapshot root equals the source directory.
> 
> Updates `restore` and `list` to prefer/merge per-source checkpoints while **falling back to legacy checkpoint directories** for backward compatibility, and adds a comprehensive regression test suite covering the new layout, legacy fallback, and reparse-point cycles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 370940860382d6c5206325a10d574e12de50fe24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-source checkpoint storage (parent/basename-checkpoints), restore fallback to legacy locations, and merged listing across sources.

* **Bug Fixes**
  * Prevents recursive checkpointing and following reparse/junction points; skips excluded locations and tolerates permission/IO errors.
  * Improved input validation with clearer error messages.

* **Tests**
  * Added comprehensive regression tests covering create, restore, list, edge cases, and lifecycle cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->