### PR TITLE
Fix chat permission resource crash

### DIFF
--- a/Desktop/HermesDesktop.Tests/Localization/ChatPermissionResourceTests.cs
+++ b/Desktop/HermesDesktop.Tests/Localization/ChatPermissionResourceTests.cs
@@ -1,0 +1,59 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HermesDesktop.Tests.Localization;
+
+[TestClass]
+public sealed class ChatPermissionResourceTests
+{
+    [TestMethod]
+    public void ChatPagePermissionResources_AllReferencedKeysExist()
+    {
+        var root = FindRepoRoot();
+        var chatPagePath = Path.Combine(root, "Desktop", "HermesDesktop", "Views", "ChatPage.xaml.cs");
+        var referencedKeys = Regex.Matches(
+                File.ReadAllText(chatPagePath),
+                "ResourceLoader\\.GetString\\(\"(ChatPermission[^\"]+)\"\\)")
+            .Select(match => match.Groups[1].Value)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        foreach (var culture in new[] { "en-us", "zh-cn" })
+        {
+            var resourcePath = Path.Combine(root, "Desktop", "HermesDesktop", "Strings", culture, "Resources.resw");
+            var resourceKeys = XDocument.Load(resourcePath)
+                .Descendants("data")
+                .Select(element => element.Attribute("name")?.Value)
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .ToHashSet(StringComparer.Ordinal);
+
+            var missing = referencedKeys
+                .Where(key => !resourceKeys.Contains(key))
+                .ToArray();
+
+            CollectionAssert.AreEqual(
+                Array.Empty<string>(),
+                missing,
+                $"Missing ChatPage permission resource keys in {culture}: {string.Join(", ", missing)}");
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var marker = Path.Combine(directory.FullName, "HermesDesktop.sln");
+            if (File.Exists(marker))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not find HermesDesktop.sln from test output directory.");
+    }
+}

--- a/Desktop/HermesDesktop.Tests/Localization/ChatPermissionResourceTests.cs
+++ b/Desktop/HermesDesktop.Tests/Localization/ChatPermissionResourceTests.cs
@@ -42,18 +42,18 @@ public sealed class ChatPermissionResourceTests
 
     private static string FindRepoRoot()
     {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        while (directory is not null)
+        var directory = AppContext.BaseDirectory;
+        while (!string.IsNullOrWhiteSpace(directory))
         {
-            var marker = Path.Combine(directory.FullName, "HermesDesktop.sln");
+            var marker = Path.Combine(directory, "HermesDesktop.sln");
             if (File.Exists(marker))
             {
-                return directory.FullName;
+                return directory;
             }
 
-            directory = directory.Parent;
+            directory = Directory.GetParent(directory)?.FullName;
         }
 
-        throw new DirectoryNotFoundException("Could not find HermesDesktop.sln from test output directory.");
+        throw new InvalidOperationException("Could not find HermesDesktop.sln from test output directory.");
     }
 }

--- a/Desktop/HermesDesktop.Tests/Localization/ChatPermissionResourceTests.cs
+++ b/Desktop/HermesDesktop.Tests/Localization/ChatPermissionResourceTests.cs
@@ -4,6 +4,14 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace HermesDesktop.Tests.Localization;
 
+internal sealed class SolutionRootNotFoundException : Exception
+{
+    public SolutionRootNotFoundException(string message)
+        : base(message)
+    {
+    }
+}
+
 [TestClass]
 public sealed class ChatPermissionResourceTests
 {
@@ -54,6 +62,6 @@ public sealed class ChatPermissionResourceTests
             directory = Directory.GetParent(directory)?.FullName;
         }
 
-        throw new InvalidOperationException("Could not find HermesDesktop.sln from test output directory.");
+        throw new SolutionRootNotFoundException("Could not find HermesDesktop.sln from test output directory.");
     }
 }

--- a/Desktop/HermesDesktop/Strings/zh-cn/Resources.resw
+++ b/Desktop/HermesDesktop/Strings/zh-cn/Resources.resw
@@ -567,6 +567,18 @@
   <data name="ChatPermissionModeNameBypass" xml:space="preserve">
     <value>绕过</value>
   </data>
+  <data name="ChatPermissionClearRememberedAction" xml:space="preserve">
+    <value>清除此工作区记住的工具权限</value>
+  </data>
+  <data name="ChatPermissionClearRememberedSuccess" xml:space="preserve">
+    <value>已清除此工作区记住的工具权限。</value>
+  </data>
+  <data name="ChatPermissionClearRememberedNoop" xml:space="preserve">
+    <value>没有可清除的工作区工具权限。</value>
+  </data>
+  <data name="ChatPermissionClearRememberedErrorFormat" xml:space="preserve">
+    <value>无法清除记住的工作区工具权限：{0}</value>
+  </data>
   <data name="DashOverviewKpiSessionsTitle.Text" xml:space="preserve">
     <value>会话</value>
   </data>

--- a/Desktop/HermesDesktop/Views/ChatPage.xaml.cs
+++ b/Desktop/HermesDesktop/Views/ChatPage.xaml.cs
@@ -606,7 +606,7 @@ public sealed partial class ChatPage : Page
         flyout.Items.Add(new MenuFlyoutSeparator());
         var clearRememberedItem = new MenuFlyoutItem
         {
-            Text = ResourceLoader.GetString("ChatPermissionClearRemembered")
+            Text = ResourceLoader.GetString("ChatPermissionClearRememberedAction")
         };
         clearRememberedItem.Click += async (_, _) => await ClearRememberedPermissionsAsync();
         flyout.Items.Add(clearRememberedItem);
@@ -637,12 +637,15 @@ public sealed partial class ChatPage : Page
         try
         {
             _chatService.ClearRememberedWorkspacePermissions();
-            AppendSystemMessage(ResourceLoader.GetString("ChatPermissionRememberedCleared"));
+            AppendSystemMessage(ResourceLoader.GetString("ChatPermissionClearRememberedSuccess"));
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed clearing remembered workspace permissions.");
-            AppendSystemMessage(ResourceLoader.GetString("ChatPermissionRememberedClearFailed"));
+            AppendSystemMessage(string.Format(
+                CultureInfo.CurrentCulture,
+                ResourceLoader.GetString("ChatPermissionClearRememberedErrorFormat"),
+                ex.Message));
             await Task.CompletedTask;
         }
     }


### PR DESCRIPTION
## Summary
- Fixes the Chat permission-mode crash by aligning `ChatPage` with the resource keys that are actually shipped.
- Adds localized `zh-cn` entries for the same permission-clear resources.
- Adds a regression test so missing Chat permission resources fail in CI instead of at runtime.

Fixes #55.

## Test plan
- `dotnet test "Desktop\HermesDesktop.Tests\HermesDesktop.Tests.csproj" -c Debug -p:Platform=x64`
- `dotnet build "Desktop\HermesDesktop\HermesDesktop.csproj" -c Debug -p:Platform=x64`
- Startup smoke probe with fatal patterns for `NamedResource Not Found`, `0x80073B17`, and `Unhandled exception`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to localization key renames/added strings in `ChatPage` plus a CI regression test; no business logic or data handling is modified.
> 
> **Overview**
> Fixes a runtime crash in `ChatPage` permission-mode UI by updating `ResourceLoader.GetString(...)` calls to use the shipped `ChatPermissionClearRemembered*` keys, and by improving the failure message to use a formatted error string.
> 
> Adds missing `zh-cn` localized entries for the clear-remembered permission action/status/error strings, and introduces a unit test that scans `ChatPage.xaml.cs` for `ChatPermission*` resource references and asserts those keys exist in both `en-us` and `zh-cn` `Resources.resw` files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b51404392d030ff10f1970ec3aa00ed5f73e432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to clear remembered tool permissions with improved user feedback (action label, success, no-op, and formatted error messages).
  * Added Chinese translations for the new permission-management messages.

* **Tests**
  * Added automated tests that verify all permission-related UI strings referenced by the chat page exist for supported cultures (en-us, zh-cn).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->