### PR TITLE
Fix vLLM system message ordering

### DIFF
--- a/Desktop/HermesDesktop.Tests/LLM/OpenAiClientAuthTests.cs
+++ b/Desktop/HermesDesktop.Tests/LLM/OpenAiClientAuthTests.cs
@@ -245,7 +245,7 @@ public class OpenAiClientAuthTests
                 capturedRequest = request;
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(sse)))
+                    Content = new SseTestContent(sse)
                 };
             }));
 
@@ -304,7 +304,7 @@ public class OpenAiClientAuthTests
                 capturedRequest = request;
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(sse)))
+                    Content = new SseTestContent(sse)
                 };
             }));
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "shared-default-token");
@@ -363,7 +363,7 @@ public class OpenAiClientAuthTests
                 capturedRequest = request;
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(sse)))
+                    Content = new SseTestContent(sse)
                 };
             }));
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "shared-default-token");
@@ -456,6 +456,21 @@ public class OpenAiClientAuthTests
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             return Task.FromResult(responseFactory(request));
+        }
+    }
+
+    private sealed class SseTestContent(string payload) : HttpContent
+    {
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+        {
+            var bytes = Encoding.UTF8.GetBytes(payload);
+            return stream.WriteAsync(bytes, 0, bytes.Length);
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = Encoding.UTF8.GetByteCount(payload);
+            return true;
         }
     }
 }

--- a/Desktop/HermesDesktop.Tests/LLM/OpenAiClientAuthTests.cs
+++ b/Desktop/HermesDesktop.Tests/LLM/OpenAiClientAuthTests.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.Json;
 using Hermes.Agent.Core;
 using Hermes.Agent.LLM;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -12,6 +13,138 @@ namespace HermesDesktop.Tests.LLM;
 [TestClass]
 public class OpenAiClientAuthTests
 {
+    [TestMethod]
+    public async Task CompleteAsync_DirtyLegacySystemMessages_SendsSingleLeadingSystem()
+    {
+        string? capturedJson = null;
+        using var httpClient = new HttpClient(new CaptureHandler(request =>
+        {
+            capturedJson = request.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+            return CreateSuccessResponse();
+        }));
+
+        var client = new OpenAiClient(
+            new LlmConfig
+            {
+                Provider = "openai",
+                Model = "qwen3.5-122b-a10b",
+                BaseUrl = "http://vllm.example/v1",
+                AuthMode = "none"
+            },
+            httpClient);
+
+        await client.CompleteAsync(
+            new[]
+            {
+                new Message { Role = "system", Content = "stable system" },
+                new Message { Role = "user", Content = "first" },
+                new Message { Role = "assistant", Content = "ok" },
+                new Message { Role = "system", Content = "late system" },
+                new Message { Role = "user", Content = "second" }
+            },
+            CancellationToken.None);
+
+        AssertPayloadHasSingleLeadingSystem(
+            capturedJson,
+            new[] { "system", "user", "assistant", "user" },
+            "stable system",
+            "late system");
+    }
+
+    [TestMethod]
+    public async Task CompleteWithToolsAsync_DirtyLegacySystemMessages_SendsSingleLeadingSystem()
+    {
+        string? capturedJson = null;
+        using var httpClient = new HttpClient(new CaptureHandler(request =>
+        {
+            capturedJson = request.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+            return CreateToolCallResponse();
+        }));
+
+        var client = new OpenAiClient(
+            new LlmConfig
+            {
+                Provider = "openai",
+                Model = "qwen3.5-122b-a10b",
+                BaseUrl = "http://vllm.example/v1",
+                AuthMode = "none"
+            },
+            httpClient);
+
+        await client.CompleteWithToolsAsync(
+            new[]
+            {
+                new Message { Role = "system", Content = "tool system" },
+                new Message { Role = "user", Content = "use a tool" },
+                new Message { Role = "system", Content = "late tool system" }
+            },
+            new[]
+            {
+                new ToolDefinition
+                {
+                    Name = "echo_tool",
+                    Description = "Echo input",
+                    Parameters = JsonDocument.Parse("""{"type":"object","properties":{}}""").RootElement.Clone()
+                }
+            },
+            CancellationToken.None);
+
+        AssertPayloadHasSingleLeadingSystem(
+            capturedJson,
+            new[] { "system", "user" },
+            "tool system",
+            "late tool system");
+    }
+
+    [TestMethod]
+    public async Task StreamAsync_DirtyLegacySystemMessages_SendsSingleLeadingSystem()
+    {
+        string? capturedJson = null;
+        var sse =
+            """
+            data: {"choices":[{"delta":{"content":"ok"}}]}
+
+            data: [DONE]
+
+            """;
+        using var httpClient = new HttpClient(new CaptureHandler(request =>
+        {
+            capturedJson = request.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(sse)))
+            };
+        }));
+
+        var client = new OpenAiClient(
+            new LlmConfig
+            {
+                Provider = "openai",
+                Model = "qwen3.5-122b-a10b",
+                BaseUrl = "http://vllm.example/v1",
+                AuthMode = "none"
+            },
+            httpClient);
+
+        await foreach (var _ in client.StreamAsync(
+                           new[]
+                           {
+                               new Message { Role = "system", Content = "stream system" },
+                               new Message { Role = "user", Content = "stream" },
+                               new Message { Role = "system", Content = "late stream system" }
+                           },
+                           CancellationToken.None))
+        {
+            // Drain SSE until completion
+        }
+
+        AssertPayloadHasSingleLeadingSystem(
+            capturedJson,
+            new[] { "system", "user" },
+            "stream system",
+            "late stream system");
+    }
+
     [TestMethod]
     public async Task CompleteAsync_UsesEnvBackedOAuthProxyHeader()
     {
@@ -281,6 +414,41 @@ public class OpenAiClientAuthTests
                 Encoding.UTF8,
                 "application/json")
         };
+    }
+
+    private static HttpResponseMessage CreateToolCallResponse()
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                """
+                {"choices":[{"message":{"content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"echo_tool","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}
+                """,
+                Encoding.UTF8,
+                "application/json")
+        };
+    }
+
+    private static void AssertPayloadHasSingleLeadingSystem(
+        string? capturedJson,
+        string[] expectedRoles,
+        params string[] expectedSystemFragments)
+    {
+        Assert.IsNotNull(capturedJson);
+        using var payload = JsonDocument.Parse(capturedJson!);
+        var messages = payload.RootElement.GetProperty("messages").EnumerateArray().ToArray();
+
+        Assert.AreEqual("system", messages[0].GetProperty("role").GetString());
+        var systemContent = messages[0].GetProperty("content").GetString()!;
+        foreach (var expectedSystemFragment in expectedSystemFragments)
+        {
+            StringAssert.Contains(systemContent, expectedSystemFragment);
+        }
+
+        CollectionAssert.AreEqual(
+            expectedRoles,
+            messages.Select(message => message.GetProperty("role").GetString()).ToArray(),
+            "OpenAI-compatible payloads must have at most one leading system message for strict vLLM/Qwen templates.");
     }
 
     private sealed class CaptureHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler

--- a/Desktop/HermesDesktop.Tests/LLM/OpenAiClientAuthTests.cs
+++ b/Desktop/HermesDesktop.Tests/LLM/OpenAiClientAuthTests.cs
@@ -107,14 +107,14 @@ public class OpenAiClientAuthTests
             data: [DONE]
 
             """;
-        using var httpClient = new HttpClient(new CaptureHandler(request =>
-        {
-            capturedJson = request.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
-            return new HttpResponseMessage(HttpStatusCode.OK)
+            using var httpClient = new HttpClient(new CaptureHandler(request =>
             {
-                Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(sse)))
-            };
-        }));
+                capturedJson = request.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new SseTestContent(sse)
+                };
+            }));
 
         var client = new OpenAiClient(
             new LlmConfig

--- a/src/LLM/OpenAiClient.cs
+++ b/src/LLM/OpenAiClient.cs
@@ -180,7 +180,12 @@ public sealed class OpenAiClient : IChatClient
 
     private object BuildPayload(IEnumerable<Message> messages, object? tools, bool stream)
     {
-        var msgs = messages.Select(m =>
+        // Provider-boundary guardrail for strict OpenAI-compatible servers
+        // (vLLM/Qwen, llama.cpp strict templates, TGI): even legacy/direct
+        // callers must serialize at most one system message, and only at index 0.
+        var (_, normalizedMessages) = SystemContext.Empty.CoalesceWith(messages);
+
+        var msgs = normalizedMessages.Select(m =>
         {
             // Tool result message
             if (m.Role == "tool")


### PR DESCRIPTION
## Summary
- Normalizes OpenAI-compatible payloads inside `OpenAiClient` so even direct/legacy call paths serialize at most one `system` message, located at index 0.
- Keeps agent/bridge-level coalescing intact while adding a final provider-boundary guardrail for strict vLLM/Qwen, llama.cpp, TGI, and LMStudio templates.
- Adds request-body regression coverage for simple completion, tool completion, and streaming payloads with dirty legacy system-message histories.

Fixes #47.

## Test plan
- `dotnet test "Desktop\HermesDesktop.Tests\HermesDesktop.Tests.csproj" -c Debug -p:Platform=x64 --filter "FullyQualifiedName~OpenAiClientAuthTests"`
- `dotnet test "Desktop\HermesDesktop.Tests\HermesDesktop.Tests.csproj" -c Debug -p:Platform=x64`
- `dotnet build "Desktop\HermesDesktop\HermesDesktop.csproj" -c Debug -p:Platform=x64`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request payload construction in `OpenAiClient`, which can affect prompt composition and downstream model behavior across all OpenAI-compatible calls. Added tests reduce regression risk but coverage is limited to system-message coalescing scenarios.
> 
> **Overview**
> Adds a final provider-boundary normalization step in `OpenAiClient.BuildPayload` to coalesce any stray `role:"system"` messages into **one leading system message** (required by strict OpenAI-compatible servers like vLLM/Qwen).
> 
> Expands `OpenAiClientAuthTests` with regression tests that capture outbound JSON for `CompleteAsync`, `CompleteWithToolsAsync`, and `StreamAsync`, asserting the wire payload contains a single index-0 system message (and updates streaming tests to use a shared `SseTestContent` helper).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5de2366bc11b8a8d86a96cd41e3c951974bf963a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->