### PR TITLE
Release v2.5.5: stream fault retry + chat placeholder fix

### DIFF
--- a/Desktop/HermesDesktop/HermesDesktop.csproj
+++ b/Desktop/HermesDesktop/HermesDesktop.csproj
@@ -20,9 +20,9 @@
     <WindowsAppSdkDeploymentManagerInitialize>false</WindowsAppSdkDeploymentManagerInitialize>
     <Nullable>enable</Nullable>
     <!-- Ship version: bump for each user-facing release; tag v{Version} on main to trigger ci-release.yml -->
-    <Version>2.5.4</Version>
-    <AssemblyVersion>2.5.4.0</AssemblyVersion>
-    <FileVersion>2.5.4.0</FileVersion>
+    <Version>2.5.5</Version>
+    <AssemblyVersion>2.5.5.0</AssemblyVersion>
+    <FileVersion>2.5.5.0</FileVersion>
   </PropertyGroup>
 
   <!-- Set -p:HermesMsixPublish=true (see scripts/publish-msix.ps1) to produce a signed .msix under AppPackages\ -->

--- a/Desktop/HermesDesktop/Package.appxmanifest
+++ b/Desktop/HermesDesktop/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:systemai="http://schemas.microsoft.com/appx/manifest/systemai/windows10" IgnorableNamespaces="uap rescap systemai">
-  <Identity Name="EDC29F63-281C-4D34-8723-155C8122DEA2" Publisher="CN=AppPublisher" Version="2.5.4.0" />
+  <Identity Name="EDC29F63-281C-4D34-8723-155C8122DEA2" Publisher="CN=AppPublisher" Version="2.5.5.0" />
   <mp:PhoneIdentity PhoneProductId="EDC29F63-281C-4D34-8723-155C8122DEA2" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>HermesDesktop</DisplayName>

--- a/Desktop/HermesDesktop/packaging/HermesDesktop.appinstaller
+++ b/Desktop/HermesDesktop/packaging/HermesDesktop.appinstaller
@@ -7,7 +7,7 @@
   Docs: https://learn.microsoft.com/windows/msix/app-installer/how-to-create-appinstaller-file
 -->
 <AppInstaller xmlns="http://schemas.microsoft.com/appx/appinstaller/2018" Version="1.0.0.0" Uri="https://YOURCDN.example/hermes/desktop/HermesDesktop.appinstaller">
-  <MainPackage Name="EDC29F63-281C-4D34-8723-155C8122DEA2" Publisher="CN=AppPublisher" Version="2.5.4.0" ProcessorArchitecture="x64" Uri="https://YOURCDN.example/hermes/desktop/HermesDesktop_2.5.4.0_x64.msix" />
+  <MainPackage Name="EDC29F63-281C-4D34-8723-155C8122DEA2" Publisher="CN=AppPublisher" Version="2.5.5.0" ProcessorArchitecture="x64" Uri="https://YOURCDN.example/hermes/desktop/HermesDesktop_2.5.5.0_x64.msix" />
   <UpdateSettings>
     <OnLaunch HoursBetweenUpdateChecks="8" ShowPrompt="true" UpdateBlocksActivation="false" />
     <AutomaticBackgroundTask />

--- a/docs/releases/v2.5.5.md
+++ b/docs/releases/v2.5.5.md
@@ -1,0 +1,47 @@
+# Hermes Desktop v2.5.5
+
+**Release date:** 2026-05-06
+**Portable asset:** `HermesDesktop-portable-x64.zip` (from [GitHub Releases](https://github.com/RedWoodOG/Hermes-Desktop/releases))
+
+## Highlights
+
+### Stream resilience — mid-SSE fault recovery (issue #51)
+
+Streaming chat now retries against the configured fallback provider when the primary throws `HttpRequestException` mid-SSE, matching the resilience the non-streaming and tool-loop paths already had.
+
+The retry is conservative on purpose:
+
+- **Only fires when the turn is on the primary.** If a prior call already activated the fallback during its restoration cooldown, we don't try to "fall back again" (`ActivateFallback` would rethrow because there's no second fallback). The fault surfaces as a `StreamError` instead, exactly as before.
+- **Only fires before any tokens are yielded.** Once the consumer has seen tokens from the primary, restarting against the fallback would replay the same prompt and concatenate two independent completions into the saved assistant message. After the first `TokenDelta`, a fault surfaces as `StreamError` and the consumer can decide what to do.
+- **Single attempt only.** A second fault on the fallback surfaces as a `StreamError` (no infinite retry).
+
+Implementation: `WatchProviderStreamAsync` now takes a `Func<IChatClient, IAsyncEnumerable<StreamEvent>>` factory and wraps its read loop in an outer retry. The `HttpRequestException` catch only flags the retry; outside the catch (where C# async iterators allow it), the failed enumerator is disposed, `ActivateFallback` runs, and a fresh enumerator is built from the fallback client.
+
+### Chat input — placeholder reflects the real binding
+
+The chat input's `KeyDown` handler has always implemented **Enter → send**, **Shift+Enter → newline**. The placeholder text was wrongly telling users to press **Ctrl+Enter**. The active resource key (`ChatPromptTextBox.PlaceholderText`) now states the actual binding in both `en-us` and `zh-cn`.
+
+### Engineering
+
+- **Tests:** new `AgentStreamFallbackTests` class covers four scenarios — pre-token recovery, post-token surface-error-no-retry, no-fallback surface-error, double-fault surface-error, and turn-already-on-fallback surface-error. The streaming stub helper was lifted to namespace scope (`internal sealed StubStreamingChatClient`) so both streaming test classes share it.
+- **CI guardrail:** the test-symbol allowlist in `ci-dotnet-tests.yml` now includes `HttpRequestException`, `NotImplementedException`, `Exception`, `InvalidOperationException`, `ArgumentException`, `ArgumentNullException`, `TimeoutException`, `OperationCanceledException`, and `CancellationTokenSource` — common BCL types future tests need.
+- **Versioning:** `HermesDesktop` assembly and `Package.appxmanifest` identity bumped to **2.5.5.0**.
+
+## Upgrade notes
+
+- **Portable zip:** quit the app, extract the new zip over (or beside) the old folder; `%LOCALAPPDATA%\hermes` (config, memory, transcripts, wiki) is preserved.
+- **Behavioral diff:** if you have a primary provider configured plus a fallback, transient SSE handshake failures (e.g. an upstream 503) now recover automatically instead of surfacing as `StreamError`. Mid-stream failures after tokens have been emitted continue to surface as `StreamError` — that's intentional, see the highlights above.
+
+## Maintainer: publish this release on GitHub
+
+1. Merge the v2.5.5 PR into **`main`**.
+2. On latest `main`, create and push an annotated tag:
+
+   ```bash
+   git checkout main
+   git pull
+   git tag -a v2.5.5 -m "v2.5.5 -- Stream fault retry + chat placeholder fix"
+   git push origin v2.5.5
+   ```
+
+3. The `ci-release.yml` workflow runs on tag push, builds the portable zip, and creates the GitHub Release with the artifact attached.

--- a/docs/releases/v2.5.5.md
+++ b/docs/releases/v2.5.5.md
@@ -23,7 +23,7 @@ The chat input's `KeyDown` handler has always implemented **Enter → send**, **
 
 ### Engineering
 
-- **Tests:** new `AgentStreamFallbackTests` class covers four scenarios — pre-token recovery, post-token surface-error-no-retry, no-fallback surface-error, double-fault surface-error, and turn-already-on-fallback surface-error. The streaming stub helper was lifted to namespace scope (`internal sealed StubStreamingChatClient`) so both streaming test classes share it.
+- **Tests:** new `AgentStreamFallbackTests` class covers five scenarios — pre-token recovery, post-token surface-error-no-retry, no-fallback surface-error, double-fault surface-error, and turn-already-on-fallback surface-error. The streaming stub helper was lifted to namespace scope (`internal sealed StubStreamingChatClient`) so both streaming test classes share it.
 - **CI guardrail:** the test-symbol allowlist in `ci-dotnet-tests.yml` now includes `HttpRequestException`, `NotImplementedException`, `Exception`, `InvalidOperationException`, `ArgumentException`, `ArgumentNullException`, `TimeoutException`, `OperationCanceledException`, and `CancellationTokenSource` — common BCL types future tests need.
 - **Versioning:** `HermesDesktop` assembly and `Package.appxmanifest` identity bumped to **2.5.5.0**.
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 
 A **Windows-native AI agent** that lives on your desktop. Chat with it, give it tools, let it learn who you are. Built with WinUI 3 and .NET 10.
 
-**v2.5.4** &mdash; [Download](https://github.com/RedWoodOG/Hermes-Desktop/releases/latest) | [Changelog](#changelog) | [Discussion](https://github.com/RedWoodOG/Hermes-Desktop/discussions/10)
+**v2.5.5** &mdash; [Download](https://github.com/RedWoodOG/Hermes-Desktop/releases/latest) | [Changelog](#changelog) | [Discussion](https://github.com/RedWoodOG/Hermes-Desktop/discussions/10)
 
 ---
 
@@ -225,6 +225,7 @@ Hermes.CS/
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v2.5.5** | 2026-05-06 | **Stream resilience (issue #51):** mid-SSE `HttpRequestException` now retries against the configured fallback provider, gated to the SSE-handshake case (zero tokens emitted) and to turns currently on the primary client &mdash; avoids prompt-replay duplication and the "already on fallback" rethrow. **Chat input:** placeholder text now states the actual binding (`Enter` to send, `Shift+Enter` for a new line); the wrong-key resource lying about Ctrl+Enter is gone. **CI:** test-symbol guardrail allowlist extended with common BCL exception types so future tests don't trip on `HttpRequestException`/`NotImplementedException`/`Argument*`/`Timeout`. Assembly / MSIX manifest **2.5.5.0**. |
 | **v2.5.4** | 2026-04-28 | **Soul system repair:** runtime soul label now reflects `SOUL.md`, reset uses the shipped `Default` soul, project `AGENTS.md` rules enter prompt context, saved agents retain provider/model, and AutoDream starts soul learning. Assembly / MSIX manifest **2.5.4.0**. |
 | **v2.5.3** | 2026-04-28 | **Brand refresh:** app package icons, splash/tile assets, README logo, and Dashboard version display updated for the new Hermes mark. Assembly / MSIX manifest **2.5.3.0**. |
 | **v2.5.2** | 2026-04-28 | **Windows Sandbox:** native Windows Sandbox backend using generated `.wsb` configs, Desktop execution backend picker option, Bash tool honors configured backend, clear setup message when Windows Sandbox is unavailable. Assembly / MSIX manifest **2.5.2.0**. |


### PR DESCRIPTION
## Summary
Release **v2.5.5** covering the two fixes that landed today:

1. **Stream resilience for issue #51** (PR #60) — `WatchProviderStreamAsync` retries against the configured fallback on mid-SSE `HttpRequestException`. Gated to the pre-token / on-primary case so we don't duplicate-prefix or rethrow when already on fallback.
2. **Chat input placeholder** (PR #61) — placeholder now describes the real binding (Enter to send, Shift+Enter for newline). The active resource key (`ChatPromptTextBox.PlaceholderText`) was the one being read; the prior commit had updated a dead key.
3. **CI guardrail allowlist** — test-symbol guardrail in `ci-dotnet-tests.yml` now allows common BCL exception types so future tests using them don't trip on the false-positive "unresolved symbol" check.

## Files
- `Desktop/HermesDesktop/HermesDesktop.csproj`: `<Version>` 2.5.4 → 2.5.5 (+ AssemblyVersion + FileVersion)
- `Desktop/HermesDesktop/Package.appxmanifest`: identity `Version` 2.5.4.0 → 2.5.5.0
- `docs/releases/v2.5.5.md`: new release notes
- `readme.md`: header badge + new changelog row

## After merge
Tag and push to trigger the release workflow:

```bash
git checkout main
git pull
git tag -a v2.5.5 -m "v2.5.5 -- Stream fault retry + chat placeholder fix"
git push origin v2.5.5
```

`ci-release.yml` builds the portable zip and creates the GitHub Release on tag push.

https://claude.ai/code/session_011kdWRbnDzMFLH3jfajLDwY

---
_Generated by [Claude Code](https://claude.ai/code/session_011kdWRbnDzMFLH3jfajLDwY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only changes: version/packaging metadata bumps plus documentation updates; no functional code changes in this diff.
> 
> **Overview**
> **Prepares the v2.5.5 release** by bumping `HermesDesktop` version numbers (project `Version`/`AssemblyVersion`/`FileVersion`, `Package.appxmanifest` identity, and `HermesDesktop.appinstaller` MSIX URI/version).
> 
> Adds `docs/releases/v2.5.5.md` release notes and updates `readme.md` to reflect **v2.5.5** in the header and changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a49140551211eecc606cf1b55938038c4d72a38b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v2.5.5

* **Bug Fixes**
  * Improved stream resilience with automatic fault recovery for streaming connections.
  * Fixed chat input placeholder text to accurately reflect the keyboard binding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->