### PR TITLE
ci-release: add workflow_dispatch so releases can be cut from the Actions UI

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -36,16 +36,61 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to create (e.g. v2.5.5). Must match HermesDesktop.csproj <Version>.'
+        required: true
+        type: string
 
 permissions:
-  contents: write          # needed to create releases and upload assets
+  contents: write          # needed to create releases, upload assets, and push the tag on workflow_dispatch
 
 jobs:
   build-and-release:
     runs-on: windows-latest
     steps:
-      - name: Checkout tagged commit
+      - name: Resolve release tag
+        id: resolve_tag
+        shell: pwsh
+        run: |
+          if ($env:GITHUB_EVENT_NAME -eq "workflow_dispatch") {
+            $tag = "${{ inputs.tag }}".Trim()
+          } else {
+            $tag = "${{ github.ref_name }}".Trim()
+          }
+          if (-not $tag.StartsWith("v")) {
+            throw "Refusing to release: tag '$tag' must start with 'v' (e.g. v2.5.5)."
+          }
+          "tag=$tag" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          Write-Host "Releasing as tag: $tag"
+
+      - name: Checkout main (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Checkout tagged commit (push)
+        if: github.event_name == 'push'
+        uses: actions/checkout@v4
+
+      - name: Create and push tag (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $tag = "${{ steps.resolve_tag.outputs.tag }}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Fail loudly if the tag already exists — we don't want to retag silently.
+          if (git rev-parse $tag 2>$null) {
+            throw "Tag $tag already exists. Bump the version or delete the existing tag first."
+          }
+          git tag -a $tag -m "$tag — released via workflow_dispatch"
+          git push origin $tag
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -110,7 +155,8 @@ jobs:
       - name: Create GitHub Release with zip attached
         uses: softprops/action-gh-release@v2
         with:
-          name: ${{ github.ref_name }}
+          tag_name: ${{ steps.resolve_tag.outputs.tag }}
+          name: ${{ steps.resolve_tag.outputs.tag }}
           draft: false
           prerelease: false
           generate_release_notes: true


### PR DESCRIPTION
## Why
Need to cut **v2.5.5** but tag pushes are blocked from this environment (HTTP 403 at the git remote). Adding `workflow_dispatch` lets us trigger the same release pipeline from the Actions UI by entering a tag name; the workflow itself creates and pushes the tag using `GITHUB_TOKEN` (which already has `contents: write`).

## What changed
- **`workflow_dispatch:`** trigger added with a single `tag` input (string, required).
- **Resolve release tag** step picks `inputs.tag` on dispatch or `github.ref_name` on push, validates the `v*` prefix, and exposes the result as a step output.
- **Checkout** is split: dispatch checks out `main` with full history (needed for `git tag -a`); push uses the default checkout of the tagged commit. Mutually exclusive via `if:` guards.
- **Create and push tag** runs only on dispatch — fails loudly if the tag already exists, then creates an annotated tag and pushes it. Dispatch then naturally cascades into the same build/smoke/release path the tag-triggered run takes.
- **Release name + tag_name** in `softprops/action-gh-release@v2` now read from the resolved-tag step output instead of `github.ref_name`. On tag push this is unchanged; on dispatch it fixes the previously-broken case where the release would have been named after the branch.

## How to release after merge
1. **Actions** → **"Release — Portable Zip"** → **Run workflow**
2. Enter the tag name (e.g. `v2.5.5`)
3. Hit Run

## Test plan
- [ ] After merge, run via Actions UI with `tag: v2.5.5`. Expect: workflow creates `v2.5.5` tag on main, builds the portable zip, runs the smoke probe, and creates the GitHub Release `v2.5.5` with the zip attached.
- [ ] Sanity: a future tag push (e.g. `git tag v2.5.6 && git push origin v2.5.6`) still works the old way — `github.event_name == 'push'` skips the dispatch-only steps.

https://claude.ai/code/session_011kdWRbnDzMFLH3jfajLDwY

---
_Generated by [Claude Code](https://claude.ai/code/session_011kdWRbnDzMFLH3jfajLDwY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release workflow to create and push git tags from CI; mistakes in input/permissions could publish an unintended version or fail releases. The change is isolated to GitHub Actions config and doesn’t affect runtime application code.
> 
> **Overview**
> Adds a `workflow_dispatch` path to the portable-zip release workflow so releases can be initiated from the Actions UI by providing a tag.
> 
> The job now resolves/validates the release tag, conditionally checks out `main` for manual runs, creates and pushes an annotated tag when dispatched, and uses the resolved tag for the GitHub Release `tag_name`/`name` so manual runs don’t accidentally release under a branch name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eb4f32e4415cda552315f1445a286cba29517d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the release workflow with manual triggering capabilities and improved tag validation and resolution processes to streamline the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->