### PR TITLE
Fix MCP config loading: accept camelCase mcp.json keys (case-insensitive deserialization)

### DIFF
--- a/Desktop/HermesDesktop.Tests/Services/McpConfigCasingTests.cs
+++ b/Desktop/HermesDesktop.Tests/Services/McpConfigCasingTests.cs
@@ -1,0 +1,45 @@
+using Hermes.Agent.Mcp;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HermesDesktop.Tests.Services;
+
+[TestClass]
+public sealed class McpConfigCasingTests
+{
+    [TestMethod]
+    public async Task LoadFromConfigAsync_CamelCaseMcpServers_LoadsConfigs()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "hermes-mcp-config-" + Guid.NewGuid().ToString("n"));
+        var path = Path.Combine(dir, "mcp.json");
+        Directory.CreateDirectory(dir);
+
+        try
+        {
+            await File.WriteAllTextAsync(
+                path,
+                """
+                {
+                  "mcpServers": {
+                    "example": {
+                      "command": "node",
+                      "args": ["server.js"],
+                      "env": { "FOO": "bar" }
+                    }
+                  }
+                }
+                """);
+
+            var manager = new McpManager(NullLogger<McpManager>.Instance);
+
+            await manager.LoadFromConfigAsync(path);
+
+            Assert.AreEqual(1, manager.ConfiguredServerCount);
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/src/mcp/McpManager.cs
+++ b/src/mcp/McpManager.cs
@@ -12,6 +12,10 @@ public sealed class McpManager : IAsyncDisposable
     private readonly Dictionary<string, McpServerConnection> _connections = new();
     private readonly Dictionary<string, McpToolWrapper> _tools = new();
     private readonly List<McpServerConfig> _configs = new();
+    private static readonly JsonSerializerOptions McpConfigJsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
     
     public IReadOnlyDictionary<string, McpServerConnection> Connections => _connections;
     public IReadOnlyDictionary<string, McpToolWrapper> Tools => _tools;
@@ -35,7 +39,7 @@ public sealed class McpManager : IAsyncDisposable
         }
         
         var json = await File.ReadAllTextAsync(configPath, ct);
-        var config = JsonSerializer.Deserialize<McpConfigFile>(json);
+        var config = JsonSerializer.Deserialize<McpConfigFile>(json, McpConfigJsonOptions);
         
         if (config?.McpServers is null) return;
         


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes issue #64.

Hermes failed to load MCP servers when `mcp.json` used standard MCP-style camelCase keys like `mcpServers`, `command`, `args`, and `env`. `System.Text.Json` is case-sensitive by default, so `mcpServers` did not bind to `McpServers`.

## Changes
- `src/mcp/McpManager.cs`: deserialize MCP config with `PropertyNameCaseInsensitive = true`.
- `Desktop/HermesDesktop.Tests/Services/McpConfigCasingTests.cs`: regression test covering camelCase `mcpServers`.

## Note
PR #65 appears to have a base-branch conflict due to branch divergence. This PR is a clean, conflict-free replacement for merging to `main`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddcc0416-0c79-495a-a54d-eaa32071f7e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddcc0416-0c79-495a-a54d-eaa32071f7e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

