### PR TITLE
Add reference-inspired runtime improvements

### DIFF
--- a/Desktop/HermesDesktop.Tests/Services/AgentInvariantTests.cs
+++ b/Desktop/HermesDesktop.Tests/Services/AgentInvariantTests.cs
@@ -312,8 +312,9 @@ public class AgentInvariantTests
             tool.SetupGet(t => t.Name).Returns("secret_tool");
             tool.SetupGet(t => t.Description).Returns("Secret");
             tool.SetupGet(t => t.ParametersType).Returns(typeof(EmptyParams));
+            var fakeSecret = string.Concat("sk", "-", "abcdefghijklmnopqrstuvwxyz");
             tool.Setup(t => t.ExecuteAsync(It.IsAny<object>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ToolResult.Fail("failed with token sk-abcdefghijklmnopqrstuvwxyz"));
+                .ReturnsAsync(ToolResult.Fail($"failed with token {fakeSecret}"));
             agent.RegisterTool(tool.Object);
 
             chatClient
@@ -342,7 +343,7 @@ public class AgentInvariantTests
             Assert.AreEqual("False", resultItem.Metadata["success"]);
             Assert.IsTrue(resultItem.Metadata.ContainsKey("durationMs"));
             StringAssert.Contains(resultItem.ContentSummary, "[REDACTED]");
-            Assert.IsFalse(resultItem.ContentSummary.Contains("sk-abcdefghijklmnopqrstuvwxyz", StringComparison.Ordinal));
+            Assert.IsFalse(resultItem.ContentSummary.Contains(fakeSecret, StringComparison.Ordinal));
         }
         finally
         {

--- a/Desktop/HermesDesktop.Tests/Services/AgentInvariantTests.cs
+++ b/Desktop/HermesDesktop.Tests/Services/AgentInvariantTests.cs
@@ -1,5 +1,7 @@
 using Hermes.Agent.Core;
 using Hermes.Agent.LLM;
+using Hermes.Agent.Permissions;
+using Hermes.Agent.Transcript;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -166,6 +168,187 @@ public class AgentInvariantTests
             It.IsAny<IEnumerable<Message>>(),
             It.IsAny<IEnumerable<ToolDefinition>>(),
             It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task ChatAsync_ToolLoop_RecordsToolLifecycleInTimeline()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "hermes-agent-timeline-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var timeline = new TimelineStore(tempDir);
+            var chatClient = new Mock<IChatClient>(MockBehavior.Strict);
+            var agent = new Agent(chatClient.Object, NullLogger<Agent>.Instance, timeline: timeline);
+            var session = new Session { Id = "timeline-tool-1", Platform = "desktop" };
+            var turn = await timeline.StartTurnAsync(session.Id, "desktop", "hello", null, null, null, CancellationToken.None);
+
+            var tool = new Mock<ITool>(MockBehavior.Strict);
+            tool.SetupGet(t => t.Name).Returns("echo_tool");
+            tool.SetupGet(t => t.Description).Returns("Echo");
+            tool.SetupGet(t => t.ParametersType).Returns(typeof(EmptyParams));
+            tool.Setup(t => t.ExecuteAsync(It.IsAny<object>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ToolResult.Ok("tool-output"));
+            agent.RegisterTool(tool.Object);
+
+            chatClient
+                .SetupSequence(c => c.CompleteWithToolsAsync(
+                    It.IsAny<IEnumerable<Message>>(),
+                    It.IsAny<IEnumerable<ToolDefinition>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ChatResponse
+                {
+                    Content = "running tool",
+                    ToolCalls = new List<ToolCall>
+                    {
+                        new()
+                        {
+                            Id = "tc-1",
+                            Name = "echo_tool",
+                            Arguments = "{}"
+                        }
+                    },
+                    FinishReason = "tool_calls"
+                })
+                .ReturnsAsync(new ChatResponse
+                {
+                    Content = "done",
+                    FinishReason = "stop",
+                    ToolCalls = null
+                });
+
+            await agent.ChatAsync("hello", session, CancellationToken.None);
+
+            var items = await timeline.LoadTurnItemsAsync(turn.TurnId, CancellationToken.None);
+            var toolItems = items.Where(item => item.ToolCallId == "tc-1").ToList();
+
+            Assert.AreEqual(3, toolItems.Count);
+            Assert.AreEqual(TurnItemKind.ToolCall, toolItems[0].Kind);
+            Assert.AreEqual(TurnItemStatus.Pending, toolItems[0].Status);
+            Assert.AreEqual(TurnItemKind.ToolCall, toolItems[1].Kind);
+            Assert.AreEqual(TurnItemStatus.Running, toolItems[1].Status);
+            Assert.AreEqual(TurnItemKind.ToolResult, toolItems[2].Kind);
+            Assert.AreEqual(TurnItemStatus.Completed, toolItems[2].Status);
+            Assert.AreEqual("echo_tool", toolItems[2].ToolName);
+            Assert.AreEqual("True", toolItems[2].Metadata["success"]);
+            Assert.IsTrue(toolItems[2].Metadata.ContainsKey("durationMs"));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ChatAsync_UserDeniedTool_RecordsDeniedTimelineResultWithoutRunningTool()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "hermes-agent-timeline-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var timeline = new TimelineStore(tempDir);
+            var permissions = new PermissionManager(
+                new PermissionContext { Mode = PermissionMode.Default },
+                NullLogger<PermissionManager>.Instance);
+            var chatClient = new Mock<IChatClient>(MockBehavior.Strict);
+            var agent = new Agent(chatClient.Object, NullLogger<Agent>.Instance, permissions: permissions, timeline: timeline);
+            var session = new Session { Id = "timeline-denied-1", Platform = "desktop" };
+            var turn = await timeline.StartTurnAsync(session.Id, "desktop", "deny it", null, null, null, CancellationToken.None);
+
+            var tool = new Mock<ITool>(MockBehavior.Strict);
+            tool.SetupGet(t => t.Name).Returns("denied_tool");
+            tool.SetupGet(t => t.Description).Returns("Denied");
+            tool.SetupGet(t => t.ParametersType).Returns(typeof(EmptyParams));
+            agent.RegisterTool(tool.Object);
+            agent.PermissionPromptCallback = (_, _, _) => Task.FromResult(false);
+
+            chatClient
+                .SetupSequence(c => c.CompleteWithToolsAsync(
+                    It.IsAny<IEnumerable<Message>>(),
+                    It.IsAny<IEnumerable<ToolDefinition>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ChatResponse
+                {
+                    ToolCalls = new List<ToolCall>
+                    {
+                        new() { Id = "deny-1", Name = "denied_tool", Arguments = "{}" }
+                    },
+                    FinishReason = "tool_calls"
+                })
+                .ReturnsAsync(new ChatResponse { Content = "stopped", FinishReason = "stop" });
+
+            await agent.ChatAsync("deny it", session, CancellationToken.None);
+
+            var toolItems = (await timeline.LoadTurnItemsAsync(turn.TurnId, CancellationToken.None))
+                .Where(item => item.ToolCallId == "deny-1")
+                .ToList();
+
+            Assert.AreEqual(2, toolItems.Count);
+            Assert.AreEqual(TurnItemStatus.Pending, toolItems[0].Status);
+            Assert.AreEqual(TurnItemKind.ToolResult, toolItems[1].Kind);
+            Assert.AreEqual(TurnItemStatus.Failed, toolItems[1].Status);
+            Assert.AreEqual("denied", toolItems[1].Metadata["phase"]);
+            tool.Verify(t => t.ExecuteAsync(It.IsAny<object>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ChatAsync_FailedTool_RecordsFailedTimelineResultWithRedactedContent()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "hermes-agent-timeline-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var timeline = new TimelineStore(tempDir);
+            var chatClient = new Mock<IChatClient>(MockBehavior.Strict);
+            var agent = new Agent(chatClient.Object, NullLogger<Agent>.Instance, timeline: timeline);
+            var session = new Session { Id = "timeline-failed-1", Platform = "desktop" };
+            var turn = await timeline.StartTurnAsync(session.Id, "desktop", "run secret tool", null, null, null, CancellationToken.None);
+
+            var tool = new Mock<ITool>(MockBehavior.Strict);
+            tool.SetupGet(t => t.Name).Returns("secret_tool");
+            tool.SetupGet(t => t.Description).Returns("Secret");
+            tool.SetupGet(t => t.ParametersType).Returns(typeof(EmptyParams));
+            tool.Setup(t => t.ExecuteAsync(It.IsAny<object>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ToolResult.Fail("failed with token sk-abcdefghijklmnopqrstuvwxyz"));
+            agent.RegisterTool(tool.Object);
+
+            chatClient
+                .SetupSequence(c => c.CompleteWithToolsAsync(
+                    It.IsAny<IEnumerable<Message>>(),
+                    It.IsAny<IEnumerable<ToolDefinition>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ChatResponse
+                {
+                    ToolCalls = new List<ToolCall>
+                    {
+                        new() { Id = "fail-1", Name = "secret_tool", Arguments = "{}" }
+                    },
+                    FinishReason = "tool_calls"
+                })
+                .ReturnsAsync(new ChatResponse { Content = "handled", FinishReason = "stop" });
+
+            await agent.ChatAsync("run secret tool", session, CancellationToken.None);
+
+            var toolItems = (await timeline.LoadTurnItemsAsync(turn.TurnId, CancellationToken.None))
+                .Where(item => item.ToolCallId == "fail-1")
+                .ToList();
+            var resultItem = toolItems.Single(item => item.Kind == TurnItemKind.ToolResult);
+
+            Assert.AreEqual(TurnItemStatus.Failed, resultItem.Status);
+            Assert.AreEqual("False", resultItem.Metadata["success"]);
+            Assert.IsTrue(resultItem.Metadata.ContainsKey("durationMs"));
+            StringAssert.Contains(resultItem.ContentSummary, "[REDACTED]");
+            Assert.IsFalse(resultItem.ContentSummary.Contains("sk-abcdefghijklmnopqrstuvwxyz", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     private sealed class EmptyParams { }

--- a/Desktop/HermesDesktop.Tests/Services/CommandRegistryTests.cs
+++ b/Desktop/HermesDesktop.Tests/Services/CommandRegistryTests.cs
@@ -1,0 +1,64 @@
+using Hermes.Agent.Commands;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HermesDesktop.Tests.Services;
+
+[TestClass]
+public sealed class CommandRegistryTests
+{
+    [TestMethod]
+    public void Parse_SplitsSlashCommandAndArguments()
+    {
+        var parsed = CommandRegistry<object>.Parse("/model gpt-5.4 high");
+
+        Assert.AreEqual("model", parsed.Name);
+        Assert.AreEqual("gpt-5.4 high", parsed.Arguments);
+    }
+
+    [TestMethod]
+    public async Task TryExecuteAsync_RoutesAliases()
+    {
+        var called = "";
+        var registry = new CommandRegistry<object>()
+            .Register(new RegisteredCommand<object>(
+                "help",
+                "Show help",
+                (_, args, _) =>
+                {
+                    called = args;
+                    return Task.CompletedTask;
+                },
+                aliases: ["skills"]));
+
+        var executed = await registry.TryExecuteAsync("/skills now", new object(), CancellationToken.None);
+
+        Assert.IsTrue(executed);
+        Assert.AreEqual("now", called);
+    }
+
+    [TestMethod]
+    public async Task TryExecuteAsync_ReturnsFalseForUnknownCommand()
+    {
+        var registry = new CommandRegistry<object>();
+
+        var executed = await registry.TryExecuteAsync("/missing", new object(), CancellationToken.None);
+
+        Assert.IsFalse(executed);
+    }
+
+    [TestMethod]
+    public void FormatHelp_UsesRegisteredMetadata()
+    {
+        var registry = new CommandRegistry<object>()
+            .Register(new RegisteredCommand<object>(
+                "new",
+                "Start a new chat",
+                (_, _, _) => Task.CompletedTask,
+                usage: "/new"));
+
+        var help = registry.FormatHelp();
+
+        StringAssert.Contains(help, "Available slash commands:");
+        StringAssert.Contains(help, "/new - Start a new chat");
+    }
+}

--- a/Desktop/HermesDesktop.Tests/Services/StreamingTextAccumulatorTests.cs
+++ b/Desktop/HermesDesktop.Tests/Services/StreamingTextAccumulatorTests.cs
@@ -1,0 +1,75 @@
+using Hermes.Agent.UI;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HermesDesktop.Tests.Services;
+
+[TestClass]
+public sealed class StreamingTextAccumulatorTests
+{
+    [TestMethod]
+    public void FlushIfDue_HoldsSmallDeltaUntilInterval()
+    {
+        var clock = new ManualTimeProvider();
+        var accumulator = new StreamingTextAccumulator(clock, TimeSpan.FromMilliseconds(50), maxBufferedChars: 100);
+
+        accumulator.Append("hello");
+
+        Assert.AreEqual("", accumulator.FlushIfDue());
+
+        clock.Advance(TimeSpan.FromMilliseconds(50));
+
+        Assert.AreEqual("hello", accumulator.FlushIfDue());
+    }
+
+    [TestMethod]
+    public void FlushIfDue_FlushesImmediatelyWhenBufferIsLarge()
+    {
+        var accumulator = new StreamingTextAccumulator(
+            new ManualTimeProvider(),
+            TimeSpan.FromMinutes(1),
+            maxBufferedChars: 4);
+
+        accumulator.Append("hello");
+
+        Assert.AreEqual("hello", accumulator.FlushIfDue());
+    }
+
+    [TestMethod]
+    public void FlushIfDue_DoesNotSplitSurrogatePairDuringTimedFlush()
+    {
+        var clock = new ManualTimeProvider();
+        var accumulator = new StreamingTextAccumulator(clock, TimeSpan.Zero, maxBufferedChars: 100);
+
+        var emoji = char.ConvertFromUtf32(0x1F680);
+        accumulator.Append(emoji[0].ToString());
+
+        Assert.AreEqual("", accumulator.FlushIfDue());
+
+        accumulator.Append(emoji[1].ToString());
+
+        Assert.AreEqual(emoji, accumulator.FlushIfDue());
+    }
+
+    [TestMethod]
+    public void Flush_ReleasesPendingTextRegardlessOfInterval()
+    {
+        var accumulator = new StreamingTextAccumulator(
+            new ManualTimeProvider(),
+            TimeSpan.FromMinutes(1),
+            maxBufferedChars: 100);
+
+        accumulator.Append("final");
+
+        Assert.AreEqual("final", accumulator.Flush());
+        Assert.IsFalse(accumulator.HasPending);
+    }
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now = DateTimeOffset.UnixEpoch;
+
+        public override DateTimeOffset GetUtcNow() => _now;
+
+        public void Advance(TimeSpan delta) => _now += delta;
+    }
+}

--- a/Desktop/HermesDesktop.Tests/Services/TimelineStoreTests.cs
+++ b/Desktop/HermesDesktop.Tests/Services/TimelineStoreTests.cs
@@ -1,0 +1,135 @@
+using Hermes.Agent.Transcript;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HermesDesktop.Tests.Services;
+
+[TestClass]
+public sealed class TimelineStoreTests
+{
+    private string _tempDir = "";
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "hermes-timeline-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [TestMethod]
+    public async Task StartTurnAsync_CreatesDurableThreadAndTurn()
+    {
+        var store = new TimelineStore(_tempDir);
+
+        var turn = await store.StartTurnAsync(
+            "session-a",
+            "desktop",
+            "Build the thing",
+            workspaceRoot: "C:\\workspace",
+            provider: "openai",
+            model: "gpt-test",
+            CancellationToken.None);
+
+        var thread = await store.LoadThreadAsync("session-a", CancellationToken.None);
+        var loadedTurn = await store.LoadTurnAsync(turn.TurnId, CancellationToken.None);
+
+        Assert.IsNotNull(thread);
+        Assert.IsNotNull(loadedTurn);
+        Assert.AreEqual("session-a", thread.ThreadId);
+        Assert.AreEqual(turn.TurnId, thread.LatestTurnId);
+        Assert.AreEqual("C:\\workspace", thread.WorkspaceRoot);
+        Assert.AreEqual(TurnStatus.InProgress, loadedTurn.Status);
+        Assert.AreEqual(1, loadedTurn.Sequence);
+        Assert.AreEqual("Build the thing", loadedTurn.InputSummary);
+    }
+
+    [TestMethod]
+    public async Task AppendItemAsync_PersistsOrderedTurnItems()
+    {
+        var store = new TimelineStore(_tempDir);
+        var turn = await store.StartTurnAsync("session-a", "desktop", "Question", null, null, null, CancellationToken.None);
+
+        var userItem = await store.AppendItemAsync(
+            turn.ThreadId,
+            turn.TurnId,
+            TurnItemKind.UserMessage,
+            TurnItemStatus.Completed,
+            "Question",
+            role: "user",
+            metadata: new Dictionary<string, string> { ["source"] = "test" },
+            ct: CancellationToken.None);
+        var assistantItem = await store.AppendItemAsync(
+            turn.ThreadId,
+            turn.TurnId,
+            TurnItemKind.AssistantMessage,
+            TurnItemStatus.Completed,
+            "Answer",
+            role: "assistant",
+            ct: CancellationToken.None);
+
+        var items = await store.LoadTurnItemsAsync(turn.TurnId, CancellationToken.None);
+
+        Assert.AreEqual(2, items.Count);
+        Assert.AreEqual(userItem.ItemId, items[0].ItemId);
+        Assert.AreEqual(assistantItem.ItemId, items[1].ItemId);
+        Assert.AreEqual(1, items[0].Sequence);
+        Assert.AreEqual(2, items[1].Sequence);
+        Assert.AreEqual("test", items[0].Metadata["source"]);
+    }
+
+    [TestMethod]
+    public async Task CompleteTurnAsync_MarksTurnCompleteAndSurvivesReopen()
+    {
+        var store = new TimelineStore(_tempDir);
+        var turn = await store.StartTurnAsync("session-a", "desktop", "Question", null, null, null, CancellationToken.None);
+
+        await store.CompleteTurnAsync(turn.ThreadId, turn.TurnId, TurnStatus.Completed, null, CancellationToken.None);
+
+        var reopened = new TimelineStore(_tempDir);
+        var loaded = await reopened.LoadTurnAsync(turn.TurnId, CancellationToken.None);
+        var threads = await reopened.ListThreadsAsync(CancellationToken.None);
+
+        Assert.IsNotNull(loaded);
+        Assert.AreEqual(TurnStatus.Completed, loaded.Status);
+        Assert.IsNotNull(loaded.CompletedAt);
+        Assert.IsTrue(loaded.DurationMs >= 0);
+        Assert.AreEqual(1, threads.Count);
+        Assert.AreEqual("session-a", threads[0].ThreadId);
+    }
+
+    [TestMethod]
+    public async Task LoadEventsAsync_PreservesSequenceAndSkipsCorruptLines()
+    {
+        var store = new TimelineStore(_tempDir);
+        var turn = await store.StartTurnAsync("session-a", "desktop", "Question", null, null, null, CancellationToken.None);
+        await store.AppendItemAsync(turn.ThreadId, turn.TurnId, TurnItemKind.UserMessage, TurnItemStatus.Completed, "Question", ct: CancellationToken.None);
+        await store.CompleteTurnAsync(turn.ThreadId, turn.TurnId, TurnStatus.Completed, null, CancellationToken.None);
+
+        var eventPath = Path.Combine(_tempDir, "events", "session-a.jsonl");
+        await File.AppendAllTextAsync(eventPath, "{bad json\n", CancellationToken.None);
+
+        var events = await store.LoadEventsAsync("session-a", CancellationToken.None);
+
+        Assert.AreEqual(4, events.Count);
+        CollectionAssert.AreEqual(new long[] { 1, 2, 3, 4 }, events.Select(evt => evt.EventSequence).ToArray());
+    }
+
+    [TestMethod]
+    public async Task Summaries_AreNormalizedForUiLists()
+    {
+        var store = new TimelineStore(_tempDir);
+        var longMessage = "hello\r\n" + new string('x', 400);
+
+        var turn = await store.StartTurnAsync("session-a", "desktop", longMessage, null, null, null, CancellationToken.None);
+
+        Assert.IsFalse(turn.InputSummary.Contains('\n'));
+        Assert.IsTrue(turn.InputSummary.Length <= 240);
+        StringAssert.EndsWith(turn.InputSummary, "...");
+    }
+}

--- a/Desktop/HermesDesktop.Tests/Tools/BrowserToolStateFormatterTests.cs
+++ b/Desktop/HermesDesktop.Tests/Tools/BrowserToolStateFormatterTests.cs
@@ -1,0 +1,68 @@
+using Hermes.Agent.Tools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HermesDesktop.Tests.Tools;
+
+[TestClass]
+public sealed class BrowserToolStateFormatterTests
+{
+    [TestMethod]
+    public void FormatBrowserState_RendersCompactPageAndRefs()
+    {
+        var state = new BrowserStateSnapshot(
+            Url: "https://example.com/search",
+            Title: "Search",
+            Viewport: new BrowserViewport(1280, 720),
+            Scroll: new BrowserScrollPosition(0, 240, 0, 1800),
+            ClickableRefs:
+            [
+                new BrowserElementRef(
+                    Ref: "#submit",
+                    Role: "button",
+                    Tag: "button",
+                    Text: "Search now")
+            ],
+            InputRefs:
+            [
+                new BrowserElementRef(
+                    Ref: "input[name=\"q\"]",
+                    Tag: "input",
+                    Type: "search",
+                    Name: "q",
+                    Placeholder: "Search terms",
+                    Value: "hermes")
+            ]);
+
+        var output = BrowserTool.FormatBrowserState(state);
+
+        StringAssert.Contains(output, "url: \"https://example.com/search\"");
+        StringAssert.Contains(output, "title: \"Search\"");
+        StringAssert.Contains(output, "viewport: { width: 1280, height: 720 }");
+        StringAssert.Contains(output, "scroll: { x: 0, y: 240, maxX: 0, maxY: 1800 }");
+        StringAssert.Contains(output, "clickable_refs");
+        StringAssert.Contains(output, "ref: \"#submit\"");
+        StringAssert.Contains(output, "text: \"Search now\"");
+        StringAssert.Contains(output, "input_refs");
+        StringAssert.Contains(output, "ref: \"input[name=\\\"q\\\"]\"");
+        StringAssert.Contains(output, "placeholder: \"Search terms\"");
+        StringAssert.Contains(output, "value: \"hermes\"");
+    }
+
+    [TestMethod]
+    public void FormatBrowserState_WithNoRefs_UsesCompactEmptyMarkers()
+    {
+        var state = new BrowserStateSnapshot(
+            Url: "about:blank",
+            Title: "",
+            Viewport: new BrowserViewport(0, 0),
+            Scroll: new BrowserScrollPosition(0, 0, 0, 0),
+            ClickableRefs: [],
+            InputRefs: []);
+
+        var output = BrowserTool.FormatBrowserState(state);
+
+        StringAssert.Contains(output, "clickable_refs: [");
+        StringAssert.Contains(output, "input_refs: [");
+        StringAssert.Contains(output, "// none");
+    }
+}

--- a/Desktop/HermesDesktop.Tests/Tools/LargeToolOutputRouterTests.cs
+++ b/Desktop/HermesDesktop.Tests/Tools/LargeToolOutputRouterTests.cs
@@ -1,0 +1,99 @@
+using Hermes.Agent.Core;
+using Hermes.Agent.Tools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HermesDesktop.Tests.Tools;
+
+[TestClass]
+public sealed class LargeToolOutputRouterTests
+{
+    [TestMethod]
+    public void Route_PassesSmallSuccessfulOutputThrough()
+    {
+        using var temp = new TempDir();
+        var router = new LargeToolOutputRouter(temp.Path, thresholdTokens: 100);
+        var result = ToolResult.Ok("small output");
+
+        var routed = router.Route("read_file", result);
+
+        Assert.AreSame(result, routed);
+    }
+
+    [TestMethod]
+    public void Route_DoesNotRouteFailures()
+    {
+        using var temp = new TempDir();
+        var router = new LargeToolOutputRouter(temp.Path, thresholdTokens: 1);
+        var result = ToolResult.Fail(new string('x', 100));
+
+        var routed = router.Route("bash", result);
+
+        Assert.AreSame(result, routed);
+        Assert.AreEqual(0, Directory.GetFiles(temp.Path).Length);
+    }
+
+    [TestMethod]
+    public void Route_StoresLargeOutputAndReturnsHeadTailSummary()
+    {
+        using var temp = new TempDir();
+        var router = new LargeToolOutputRouter(temp.Path, thresholdTokens: 10);
+        var content = "HEAD-" + new string('m', 6000) + "-TAIL";
+
+        var routed = router.Route("grep", ToolResult.Ok(content));
+
+        Assert.IsTrue(routed.Success);
+        StringAssert.Contains(routed.Content, "[large-tool-output: tool=grep");
+        StringAssert.Contains(routed.Content, "Raw output saved to:");
+        StringAssert.Contains(routed.Content, "HEAD-");
+        StringAssert.Contains(routed.Content, "-TAIL");
+
+        var files = Directory.GetFiles(temp.Path, "*.txt");
+        Assert.AreEqual(1, files.Length);
+        Assert.AreEqual(content, File.ReadAllText(files[0]));
+    }
+
+    [TestMethod]
+    public void Route_RedactsSecretsBeforeWritingArtifact()
+    {
+        using var temp = new TempDir();
+        var router = new LargeToolOutputRouter(temp.Path, thresholdTokens: 10);
+        var secret = "sk-" + new string('a', 48);
+        var content = "HEAD " + secret + " " + new string('m', 6000) + " TAIL";
+
+        var routed = router.Route("bash", ToolResult.Ok(content));
+
+        Assert.IsTrue(routed.Success);
+        Assert.IsFalse(routed.Content.Contains(secret, StringComparison.Ordinal));
+
+        var files = Directory.GetFiles(temp.Path, "*.txt");
+        Assert.AreEqual(1, files.Length);
+        var artifact = File.ReadAllText(files[0]);
+        Assert.IsFalse(artifact.Contains(secret, StringComparison.Ordinal));
+        StringAssert.Contains(artifact, "[REDACTED");
+    }
+
+    [TestMethod]
+    public void EstimateTokens_RoundsUp()
+    {
+        Assert.AreEqual(0, LargeToolOutputRouter.EstimateTokens(""));
+        Assert.AreEqual(1, LargeToolOutputRouter.EstimateTokens("abc"));
+        Assert.AreEqual(2, LargeToolOutputRouter.EstimateTokens("abcd"));
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public TempDir()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "hermes-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/Desktop/HermesDesktop.Tests/Tools/PlanningToolTests.cs
+++ b/Desktop/HermesDesktop.Tests/Tools/PlanningToolTests.cs
@@ -1,0 +1,199 @@
+using Hermes.Agent.Tools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HermesDesktop.Tests.Tools;
+
+[TestClass]
+public sealed class PlanningToolTests
+{
+    [TestMethod]
+    public void Metadata_ExposesPlanningTool()
+    {
+        var tool = new PlanningTool();
+
+        Assert.AreEqual("planning", tool.Name);
+        Assert.AreEqual(typeof(PlanningParameters), tool.ParametersType);
+        StringAssert.Contains(tool.Description, "plans");
+    }
+
+    [TestMethod]
+    public async Task CreateThenGet_ReturnsPlanWithNotStartedSteps()
+    {
+        var tool = new PlanningTool();
+
+        var create = await tool.ExecuteAsync(new PlanningParameters
+        {
+            Command = "create",
+            PlanId = "ship-feature",
+            Title = "Ship feature",
+            Steps = new[] { "Inspect contracts", "Implement tool", "Add tests" }
+        }, CancellationToken.None);
+
+        Assert.IsTrue(create.Success, create.Content);
+        StringAssert.Contains(create.Content, "Plan created: ship-feature");
+        StringAssert.Contains(create.Content, "0. [ ] Inspect contracts");
+
+        var get = await tool.ExecuteAsync(new PlanningParameters
+        {
+            Command = "get",
+            PlanId = "ship-feature"
+        }, CancellationToken.None);
+
+        Assert.IsTrue(get.Success, get.Content);
+        StringAssert.Contains(get.Content, "Plan: Ship feature (ID: ship-feature)");
+        StringAssert.Contains(get.Content, "Progress: 0/3 completed");
+    }
+
+    [TestMethod]
+    public async Task MarkStep_UpdatesStatusAndNotes()
+    {
+        var tool = new PlanningTool();
+        await CreateSamplePlan(tool);
+
+        var result = await tool.ExecuteAsync(new PlanningParameters
+        {
+            Command = "mark_step",
+            PlanId = "sample",
+            StepIndex = 1,
+            StepStatus = "blocked",
+            StepNotes = "Waiting on an API decision."
+        }, CancellationToken.None);
+
+        Assert.IsTrue(result.Success, result.Content);
+        StringAssert.Contains(result.Content, "1. [!] Second");
+        StringAssert.Contains(result.Content, "Notes: Waiting on an API decision.");
+        StringAssert.Contains(result.Content, "1 blocked");
+    }
+
+    [TestMethod]
+    public async Task MarkStep_UsesActivePlan_WhenPlanIdIsOmitted()
+    {
+        var tool = new PlanningTool();
+        await CreateSamplePlan(tool);
+
+        var result = await tool.ExecuteAsync(new PlanningParameters
+        {
+            Command = "mark_step",
+            StepIndex = 0,
+            StepStatus = "in_progress"
+        }, CancellationToken.None);
+
+        Assert.IsTrue(result.Success, result.Content);
+        StringAssert.Contains(result.Content, "0. [~] First");
+    }
+
+    [TestMethod]
+    public async Task List_ShowsAllPlansWithProgress()
+    {
+        var tool = new PlanningTool();
+        await CreateSamplePlan(tool);
+        await tool.ExecuteAsync(new PlanningParameters
+        {
+            Command = "create",
+            PlanId = "second",
+            Title = "Second plan",
+            Steps = new[] { "Only step" }
+        }, CancellationToken.None);
+
+        await tool.ExecuteAsync(new PlanningParameters
+        {
+            Command = "mark_step",
+            PlanId = "sample",
+            StepIndex = 0,
+            StepStatus = "completed"
+        }, CancellationToken.None);
+
+        var list = await tool.ExecuteAsync(new PlanningParameters { Command = "list" }, CancellationToken.None);
+
+        Assert.IsTrue(list.Success, list.Content);
+        StringAssert.Contains(list.Content, "- sample (active): Sample plan - 1/2 completed");
+        StringAssert.Contains(list.Content, "- second: Second plan - 0/1 completed");
+    }
+
+    [TestMethod]
+    public async Task Delete_RemovesPlan()
+    {
+        var tool = new PlanningTool();
+        await CreateSamplePlan(tool);
+
+        var delete = await tool.ExecuteAsync(new PlanningParameters
+        {
+            Command = "delete",
+            PlanId = "sample"
+        }, CancellationToken.None);
+
+        Assert.IsTrue(delete.Success, delete.Content);
+
+        var get = await tool.ExecuteAsync(new PlanningParameters
+        {
+            Command = "get",
+            PlanId = "sample"
+        }, CancellationToken.None);
+
+        Assert.IsFalse(get.Success);
+        StringAssert.Contains(get.Content, "No plan found");
+    }
+
+    [TestMethod]
+    public async Task InvalidStatus_Fails()
+    {
+        var tool = new PlanningTool();
+        await CreateSamplePlan(tool);
+
+        var result = await tool.ExecuteAsync(new PlanningParameters
+        {
+            Command = "mark_step",
+            PlanId = "sample",
+            StepIndex = 0,
+            StepStatus = "waiting"
+        }, CancellationToken.None);
+
+        Assert.IsFalse(result.Success);
+        StringAssert.Contains(result.Content, "Invalid step_status");
+    }
+
+    [TestMethod]
+    public async Task State_IsPerToolInstance()
+    {
+        var first = new PlanningTool();
+        var second = new PlanningTool();
+
+        await CreateSamplePlan(first);
+
+        var firstList = await first.ExecuteAsync(new PlanningParameters { Command = "list" }, CancellationToken.None);
+        var secondList = await second.ExecuteAsync(new PlanningParameters { Command = "list" }, CancellationToken.None);
+
+        StringAssert.Contains(firstList.Content, "sample");
+        Assert.AreEqual("No plans available.", secondList.Content);
+    }
+
+    [TestMethod]
+    public async Task ActionAlias_IsAccepted()
+    {
+        var tool = new PlanningTool();
+
+        var result = await tool.ExecuteAsync(new PlanningParameters
+        {
+            Action = "create",
+            PlanId = "alias",
+            Title = "Alias plan",
+            Steps = new[] { "Use action alias" }
+        }, CancellationToken.None);
+
+        Assert.IsTrue(result.Success, result.Content);
+        StringAssert.Contains(result.Content, "Plan created: alias");
+    }
+
+    private static async Task CreateSamplePlan(PlanningTool tool)
+    {
+        var result = await tool.ExecuteAsync(new PlanningParameters
+        {
+            Command = "create",
+            PlanId = "sample",
+            Title = "Sample plan",
+            Steps = new[] { "First", "Second" }
+        }, CancellationToken.None);
+
+        Assert.IsTrue(result.Success, result.Content);
+    }
+}

--- a/Desktop/HermesDesktop.Tests/Tools/PostEditDiagnosticsHookTests.cs
+++ b/Desktop/HermesDesktop.Tests/Tools/PostEditDiagnosticsHookTests.cs
@@ -1,0 +1,125 @@
+using Hermes.Agent.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HermesDesktop.Tests.Tools;
+
+[TestClass]
+public sealed class PostEditDiagnosticsHookTests
+{
+    [TestMethod]
+    public void DetectChangedFilePaths_ReadsCamelCaseFilePathForMutatingTools()
+    {
+        var paths = PostEditDiagnosticsHook.DetectChangedFilePaths(
+            "edit_file",
+            """{"filePath":"src/Core/Agent.cs","oldString":"a","newString":"b"}""");
+
+        CollectionAssert.AreEqual(new[] { "src/Core/Agent.cs" }, paths.ToArray());
+    }
+
+    [TestMethod]
+    public void DetectChangedFilePaths_ReadsSnakeCaseFilePath()
+    {
+        var paths = PostEditDiagnosticsHook.DetectChangedFilePaths(
+            "patch",
+            """{"file_path":"src/Tools/PatchTool.cs","patch":"@@ -1 +1 @@"}""");
+
+        CollectionAssert.AreEqual(new[] { "src/Tools/PatchTool.cs" }, paths.ToArray());
+    }
+
+    [TestMethod]
+    public void DetectChangedFilePaths_IgnoresNonMutatingTools()
+    {
+        var paths = PostEditDiagnosticsHook.DetectChangedFilePaths(
+            "read_file",
+            """{"filePath":"src/Core/Agent.cs"}""");
+
+        Assert.AreEqual(0, paths.Count);
+    }
+
+    [TestMethod]
+    public void DetectChangedFilePaths_InvalidJsonReturnsEmptyList()
+    {
+        var paths = PostEditDiagnosticsHook.DetectChangedFilePaths("write_file", "{not-json");
+
+        Assert.AreEqual(0, paths.Count);
+    }
+
+    [TestMethod]
+    public void FormatDiagnostics_IncludesSeverityLocationAndMessage()
+    {
+        var formatted = PostEditDiagnosticsHook.FormatDiagnostics(new[]
+        {
+            new PostEditDiagnostic(
+                "src/Core/Agent.cs",
+                12,
+                8,
+                "Example diagnostic",
+                PostEditDiagnosticSeverity.Warning)
+        });
+
+        StringAssert.StartsWith(formatted, "Post-edit diagnostics:");
+        StringAssert.Contains(formatted, "[WARN] src/Core/Agent.cs:12:8: Example diagnostic");
+    }
+
+    [TestMethod]
+    public async Task BuildReportAsync_DefaultOptionsStaySilent()
+    {
+        var hook = new PostEditDiagnosticsHook();
+        var toolCall = new ToolCall
+        {
+            Id = "call-1",
+            Name = "write_file",
+            Arguments = """{"filePath":"src/NewFile.cs","content":"text"}"""
+        };
+
+        var report = await hook.BuildReportAsync(toolCall, ToolResult.Ok("wrote file"), CancellationToken.None);
+
+        Assert.IsNull(report);
+    }
+
+    [TestMethod]
+    public async Task BuildReportAsync_CanEmitOptInNoDiagnosticsMessage()
+    {
+        var hook = new PostEditDiagnosticsHook(
+            new NoOpPostEditDiagnosticsProvider(),
+            new PostEditDiagnosticsOptions
+            {
+                Enabled = true,
+                IncludeNoDiagnosticsMessage = true
+            });
+        var toolCall = new ToolCall
+        {
+            Id = "call-1",
+            Name = "write_file",
+            Arguments = """{"filePath":"src/NewFile.cs","content":"text"}"""
+        };
+
+        var report = await hook.BuildReportAsync(toolCall, ToolResult.Ok("wrote file"), CancellationToken.None);
+
+        Assert.IsNotNull(report);
+        StringAssert.Contains(report, "Post-edit diagnostics: no diagnostics for changed file(s):");
+        StringAssert.Contains(report, "- src/NewFile.cs");
+    }
+
+    [TestMethod]
+    public async Task BuildReportAsync_CanEmitOptInDisabledMessage()
+    {
+        var hook = new PostEditDiagnosticsHook(
+            options: new PostEditDiagnosticsOptions
+            {
+                IncludeDisabledMessage = true
+            });
+        var toolCall = new ToolCall
+        {
+            Id = "call-1",
+            Name = "patch",
+            Arguments = """{"filePath":"src/Core/Agent.cs","patch":"@@ -1 +1 @@"}"""
+        };
+
+        var report = await hook.BuildReportAsync(toolCall, ToolResult.Ok("patched"), CancellationToken.None);
+
+        Assert.IsNotNull(report);
+        StringAssert.Contains(report, "Post-edit diagnostics disabled for changed file(s):");
+        StringAssert.Contains(report, "- src/Core/Agent.cs");
+    }
+}

--- a/Desktop/HermesDesktop/App.xaml.cs
+++ b/Desktop/HermesDesktop/App.xaml.cs
@@ -376,6 +376,7 @@ public partial class App : Application
         // Transcript store
         var transcriptsDir = Path.Combine(projectDir, "transcripts");
         services.AddSingleton(sp => new TranscriptStore(transcriptsDir, eagerFlush: true));
+        services.AddSingleton(sp => new TimelineStore(Path.Combine(projectDir, "timeline")));
 
         // Memory manager
         var memoryDir = Path.Combine(projectDir, "memory");
@@ -537,6 +538,7 @@ public partial class App : Application
                 sp.GetRequiredService<ILogger<Agent>>(),
                 permissions: sp.GetRequiredService<PermissionManager>(),
                 transcripts: sp.GetRequiredService<TranscriptStore>(),
+                timeline: sp.GetRequiredService<TimelineStore>(),
                 memories: sp.GetRequiredService<MemoryManager>(),
                 contextManager: sp.GetRequiredService<ContextManager>(),
                 soulService: sp.GetRequiredService<SoulService>(),
@@ -812,6 +814,7 @@ public partial class App : Application
 
         // Task management
         RegisterAndTrack(agent, toolRegistry, new TodoWriteTool());
+        RegisterAndTrack(agent, toolRegistry, new PlanningTool());
         RegisterAndTrack(agent, toolRegistry, new ScheduleCronTool());
 
         // LSP tool (optional config)

--- a/Desktop/HermesDesktop/Models/ChatMessageItem.cs
+++ b/Desktop/HermesDesktop/Models/ChatMessageItem.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using Hermes.Agent.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 
@@ -51,6 +52,8 @@ public sealed class ToolCallInfo : INotifyPropertyChanged
 public sealed class ChatMessageItem : INotifyPropertyChanged
 {
     private string _content;
+    private readonly StreamingTextAccumulator _contentAccumulator = new();
+    private readonly StreamingTextAccumulator _thinkingAccumulator = new();
     private readonly System.Text.StringBuilder _thinkingBuilder = new();
     private string _thinkingContent = "";
     private bool _isStreaming;
@@ -85,7 +88,12 @@ public sealed class ChatMessageItem : INotifyPropertyChanged
     public string Content
     {
         get => _content;
-        set { _content = value; OnPropertyChanged(); }
+        set
+        {
+            _contentAccumulator.Clear();
+            _content = value;
+            OnPropertyChanged();
+        }
     }
 
     /// <summary>Reasoning/thinking content from reasoning models (collapsible in UI).</summary>
@@ -101,7 +109,13 @@ public sealed class ChatMessageItem : INotifyPropertyChanged
     public bool IsStreaming
     {
         get => _isStreaming;
-        set { _isStreaming = value; OnPropertyChanged(); }
+        set
+        {
+            if (_isStreaming == value) return;
+            if (!value) FlushStreaming();
+            _isStreaming = value;
+            OnPropertyChanged();
+        }
     }
 
     public ChatMessageType MessageType
@@ -116,16 +130,43 @@ public sealed class ChatMessageItem : INotifyPropertyChanged
 
     public void AppendToken(string token)
     {
-        _content += token;
+        _contentAccumulator.Append(token);
+        var flushed = _contentAccumulator.FlushIfDue();
+        if (flushed.Length == 0) return;
+
+        _content += flushed;
         OnPropertyChanged(nameof(Content));
     }
 
     public void AppendThinking(string token)
     {
-        _thinkingBuilder.Append(token);
+        _thinkingAccumulator.Append(token);
+        var flushed = _thinkingAccumulator.FlushIfDue();
+        if (flushed.Length == 0) return;
+
+        _thinkingBuilder.Append(flushed);
         _thinkingContent = _thinkingBuilder.ToString();
         OnPropertyChanged(nameof(ThinkingContent));
         OnPropertyChanged(nameof(HasThinking));
+    }
+
+    public void FlushStreaming()
+    {
+        var content = _contentAccumulator.Flush();
+        if (content.Length > 0)
+        {
+            _content += content;
+            OnPropertyChanged(nameof(Content));
+        }
+
+        var thinking = _thinkingAccumulator.Flush();
+        if (thinking.Length > 0)
+        {
+            _thinkingBuilder.Append(thinking);
+            _thinkingContent = _thinkingBuilder.ToString();
+            OnPropertyChanged(nameof(ThinkingContent));
+            OnPropertyChanged(nameof(HasThinking));
+        }
     }
 
     // ── INotifyPropertyChanged ──

--- a/Desktop/HermesDesktop/Services/HermesChatService.cs
+++ b/Desktop/HermesDesktop/Services/HermesChatService.cs
@@ -20,6 +20,7 @@ internal sealed class HermesChatService : IDisposable
     private readonly Agent _agent;
     private readonly IChatClient _chatClient;
     private readonly TranscriptStore _transcriptStore;
+    private readonly TimelineStore? _timelineStore;
     private readonly PermissionManager _permissionManager;
     private readonly WorkspacePermissionRuleStore _permissionRuleStore;
     private readonly ILogger<HermesChatService> _logger;
@@ -34,11 +35,13 @@ internal sealed class HermesChatService : IDisposable
         TranscriptStore transcriptStore,
         PermissionManager permissionManager,
         WorkspacePermissionRuleStore permissionRuleStore,
-        ILogger<HermesChatService> logger)
+        ILogger<HermesChatService> logger,
+        TimelineStore? timelineStore = null)
     {
         _agent = agent;
         _chatClient = chatClient;
         _transcriptStore = transcriptStore;
+        _timelineStore = timelineStore;
         _permissionManager = permissionManager;
         _permissionRuleStore = permissionRuleStore;
         _logger = logger;
@@ -73,6 +76,7 @@ internal sealed class HermesChatService : IDisposable
     {
         EnsureSession();
         var messageCountBefore = _currentSession!.Messages.Count;
+        var turn = await StartTimelineTurnAsync(message, ct);
 
         try
         {
@@ -80,6 +84,7 @@ internal sealed class HermesChatService : IDisposable
 
             // Persist all new messages (user + tool calls + assistant)
             await PersistNewMessagesAsync(messageCountBefore);
+            await CompleteTimelineTurnAsync(turn, response, TurnStatus.Completed, null);
 
             _logger.LogInformation("Chat reply for session {SessionId}: {Length} chars", _currentSession.Id, response.Length);
             return new HermesChatReply(response, _currentSession.Id);
@@ -87,12 +92,14 @@ internal sealed class HermesChatService : IDisposable
         catch (OperationCanceledException)
         {
             await PersistNewMessagesAsync(messageCountBefore);
+            await CompleteTimelineTurnAsync(turn, null, TurnStatus.Canceled, null);
             throw;
         }
         catch (Exception ex)
         {
             // Persist whatever was added before the failure (at minimum the user message)
             await PersistNewMessagesAsync(messageCountBefore);
+            await CompleteTimelineTurnAsync(turn, null, TurnStatus.Failed, ex.Message);
             _logger.LogWarning(ex, "Chat send failed for session {SessionId}", _currentSession.Id);
             throw;
         }
@@ -108,7 +115,7 @@ internal sealed class HermesChatService : IDisposable
 
     // ── Stream (structured events: tokens + thinking) ──
 
-    public async IAsyncEnumerable<ChatStreamEvent> StreamStructuredAsync(
+    public async IAsyncEnumerable<ChatRuntimeEvent> StreamRuntimeAsync(
         string message,
         [EnumeratorCancellation] CancellationToken ct)
     {
@@ -117,10 +124,35 @@ internal sealed class HermesChatService : IDisposable
         _streamCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
 
         var fullResponse = new System.Text.StringBuilder();
+        var turn = await StartTimelineTurnAsync(message, ct);
+        var turnStatus = TurnStatus.Completed;
+        string? turnError = null;
+        await using var stream = _agent.StreamChatAsync(message, _currentSession!, _streamCts.Token)
+            .GetAsyncEnumerator(_streamCts.Token);
         try
         {
-            await foreach (var evt in _agent.StreamChatAsync(message, _currentSession!, _streamCts.Token))
+            while (true)
             {
+                Hermes.Agent.LLM.StreamEvent evt;
+                try
+                {
+                    if (!await stream.MoveNextAsync())
+                        break;
+
+                    evt = stream.Current;
+                }
+                catch (OperationCanceledException)
+                {
+                    turnStatus = TurnStatus.Canceled;
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    turnStatus = TurnStatus.Failed;
+                    turnError = ex.Message;
+                    throw;
+                }
+
                 switch (evt)
                 {
                     case Hermes.Agent.LLM.StreamEvent.TokenDelta td:
@@ -128,21 +160,40 @@ internal sealed class HermesChatService : IDisposable
                         // informational — show in UI but don't accumulate into the saved response
                         if (td.Text.StartsWith("\n[Calling tool:") && td.Text.TrimEnd().EndsWith("]"))
                         {
-                            yield return new ChatStreamEvent(ChatStreamEventType.Thinking, td.Text.Trim());
+                            yield return new ChatRuntimeEvent.ToolStatus(td.Text.Trim());
                         }
                         else
                         {
                             fullResponse.Append(td.Text);
-                            yield return new ChatStreamEvent(ChatStreamEventType.Token, td.Text);
+                            yield return new ChatRuntimeEvent.TokenDelta(td.Text);
                         }
                         break;
 
                     case Hermes.Agent.LLM.StreamEvent.ThinkingDelta tk:
-                        yield return new ChatStreamEvent(ChatStreamEventType.Thinking, tk.Text);
+                        yield return new ChatRuntimeEvent.ThinkingDelta(tk.Text);
                         break;
 
                     case Hermes.Agent.LLM.StreamEvent.StreamError err:
-                        yield return new ChatStreamEvent(ChatStreamEventType.Error, err.Error.Message);
+                        turnStatus = TurnStatus.Failed;
+                        turnError = err.Error.Message;
+                        await AppendTimelineItemAsync(
+                            turn,
+                            TurnItemKind.Error,
+                            TurnItemStatus.Failed,
+                            err.Error.Message,
+                            role: null,
+                            metadata: new Dictionary<string, string> { ["code"] = err.Code.ToString() });
+                        yield return new ChatRuntimeEvent.Error(new ChatRuntimeError(
+                            err.Error.Message,
+                            Code: err.Code.ToString(),
+                            Retryable: err.Code is not ProviderErrorCode.ProviderAuth,
+                            SuggestedAction: err.Code switch
+                            {
+                                ProviderErrorCode.ProviderAuth => "Open Settings and check the provider API key.",
+                                ProviderErrorCode.RateLimit => "Retry later or switch models.",
+                                ProviderErrorCode.ProviderTimeout => "Retry or switch providers.",
+                                _ => "Retry the request."
+                            }));
                         break;
                 }
             }
@@ -158,6 +209,35 @@ internal sealed class HermesChatService : IDisposable
                 var assistantMsg = new Message { Role = "assistant", Content = fullResponse.ToString() };
                 _currentSession.AddMessage(assistantMsg);
                 await _transcriptStore.SaveMessageAsync(_currentSession.Id, assistantMsg, CancellationToken.None);
+            }
+
+            await CompleteTimelineTurnAsync(turn, fullResponse.ToString(), turnStatus, turnError);
+        }
+
+        if (_currentSession is not null)
+            yield return new ChatRuntimeEvent.Completed(_currentSession.Id);
+    }
+
+    public async IAsyncEnumerable<ChatStreamEvent> StreamStructuredAsync(
+        string message,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        await foreach (var evt in StreamRuntimeAsync(message, ct))
+        {
+            switch (evt)
+            {
+                case ChatRuntimeEvent.TokenDelta token:
+                    yield return new ChatStreamEvent(ChatStreamEventType.Token, token.Text);
+                    break;
+                case ChatRuntimeEvent.ThinkingDelta thinking:
+                    yield return new ChatStreamEvent(ChatStreamEventType.Thinking, thinking.Text);
+                    break;
+                case ChatRuntimeEvent.ToolStatus toolStatus:
+                    yield return new ChatStreamEvent(ChatStreamEventType.Thinking, toolStatus.Text);
+                    break;
+                case ChatRuntimeEvent.Error error:
+                    yield return new ChatStreamEvent(ChatStreamEventType.Error, error.Detail.Message);
+                    break;
             }
         }
     }
@@ -207,6 +287,7 @@ internal sealed class HermesChatService : IDisposable
         foreach (var msg in messages)
             _currentSession.AddMessage(msg);
 
+        await UpsertTimelineThreadAsync(ct);
         _logger.LogInformation("Loaded session {SessionId} with {Count} messages", sessionId, messages.Count);
     }
 
@@ -237,6 +318,131 @@ internal sealed class HermesChatService : IDisposable
     // ── Tool Registration ──
 
     public void RegisterTool(ITool tool) => _agent.RegisterTool(tool);
+
+    private async Task UpsertTimelineThreadAsync(CancellationToken ct)
+    {
+        if (_timelineStore is null || _currentSession is null)
+            return;
+
+        try
+        {
+            var firstUserMessage = _currentSession.Messages.FirstOrDefault(message => message.Role == "user")?.Content;
+            await _timelineStore.GetOrCreateThreadAsync(
+                _currentSession.Id,
+                _currentSession.Platform ?? "desktop",
+                workspaceRoot: null,
+                provider: null,
+                model: null,
+                title: firstUserMessage,
+                ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to upsert timeline thread for session {SessionId}", _currentSession?.Id);
+        }
+    }
+
+    private async Task<TurnRecord?> StartTimelineTurnAsync(string message, CancellationToken ct)
+    {
+        if (_timelineStore is null || _currentSession is null)
+            return null;
+
+        try
+        {
+            var turn = await _timelineStore.StartTurnAsync(
+                _currentSession.Id,
+                _currentSession.Platform ?? "desktop",
+                message,
+                workspaceRoot: null,
+                provider: null,
+                model: null,
+                ct);
+
+            await _timelineStore.AppendItemAsync(
+                turn.ThreadId,
+                turn.TurnId,
+                TurnItemKind.UserMessage,
+                TurnItemStatus.Completed,
+                message,
+                role: "user",
+                messageIndex: _currentSession.Messages.Count,
+                ct: ct);
+
+            return turn;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to start timeline turn for session {SessionId}", _currentSession?.Id);
+            return null;
+        }
+    }
+
+    private async Task AppendTimelineItemAsync(
+        TurnRecord? turn,
+        TurnItemKind kind,
+        TurnItemStatus status,
+        string contentSummary,
+        string? role,
+        IReadOnlyDictionary<string, string>? metadata = null)
+    {
+        if (_timelineStore is null || turn is null)
+            return;
+
+        try
+        {
+            await _timelineStore.AppendItemAsync(
+                turn.ThreadId,
+                turn.TurnId,
+                kind,
+                status,
+                contentSummary,
+                role: role,
+                metadata: metadata,
+                ct: CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to append timeline item for turn {TurnId}", turn.TurnId);
+        }
+    }
+
+    private async Task CompleteTimelineTurnAsync(
+        TurnRecord? turn,
+        string? assistantResponse,
+        TurnStatus status,
+        string? error)
+    {
+        if (_timelineStore is null || turn is null)
+            return;
+
+        try
+        {
+            if (!string.IsNullOrEmpty(assistantResponse))
+            {
+                var itemStatus = status switch
+                {
+                    TurnStatus.Completed => TurnItemStatus.Completed,
+                    TurnStatus.Canceled => TurnItemStatus.Canceled,
+                    _ => TurnItemStatus.Failed
+                };
+
+                await _timelineStore.AppendItemAsync(
+                    turn.ThreadId,
+                    turn.TurnId,
+                    TurnItemKind.AssistantMessage,
+                    itemStatus,
+                    assistantResponse,
+                    role: "assistant",
+                    ct: CancellationToken.None);
+            }
+
+            await _timelineStore.CompleteTurnAsync(turn.ThreadId, turn.TurnId, status, error, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to complete timeline turn {TurnId}", turn.TurnId);
+        }
+    }
 
     // ── Dispose ──
 

--- a/Desktop/HermesDesktop/Views/ChatPage.xaml.cs
+++ b/Desktop/HermesDesktop/Views/ChatPage.xaml.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Hermes.Agent.Commands;
 using Hermes.Agent.Core;
 using Hermes.Agent.LLM;
 using Hermes.Agent.Permissions;
@@ -348,6 +349,7 @@ public sealed partial class ChatPage : Page
         dotTimer.Tick += (_, _) =>
         {
             dotCount = (dotCount + 1) % 4;
+            assistantItem?.FlushStreaming();
             var line = assistantItem is null
                 ? ResourceLoader.GetString("ChatThinkingLineThinking")
                 : ResourceLoader.GetString("ChatThinkingLineReasoning");
@@ -363,18 +365,24 @@ public sealed partial class ChatPage : Page
             var hasContent = false;
             var streamFailed = false;
 
-            // Stream structured events (tokens + thinking)
-            await foreach (var evt in _chatService.StreamStructuredAsync(prompt, CancellationToken.None))
+            // Stream typed runtime events (tokens + thinking + tool status + errors)
+            await foreach (var evt in _chatService.StreamRuntimeAsync(prompt, CancellationToken.None))
             {
-                switch (evt.Type)
+                switch (evt)
                 {
-                    case ChatStreamEventType.Thinking:
+                    case ChatRuntimeEvent.ThinkingDelta thinking:
                         if (assistantItem is not null)
-                            assistantItem.AppendThinking(evt.Text);
-                        thinkingBuffer.Append(evt.Text);
+                            assistantItem.AppendThinking(thinking.Text);
+                        thinkingBuffer.Append(thinking.Text);
                         break;
 
-                    case ChatStreamEventType.Token:
+                    case ChatRuntimeEvent.ToolStatus toolStatus:
+                        if (assistantItem is not null)
+                            assistantItem.AppendThinking(toolStatus.Text);
+                        thinkingBuffer.Append(toolStatus.Text);
+                        break;
+
+                    case ChatRuntimeEvent.TokenDelta token:
                         if (!hasContent)
                         {
                             hasContent = true;
@@ -392,14 +400,14 @@ public sealed partial class ChatPage : Page
 
                             ShowThinking(false);
                         }
-                        assistantItem!.AppendToken(evt.Text);
+                        assistantItem!.AppendToken(token.Text);
                         break;
 
-                    case ChatStreamEventType.Error:
+                    case ChatRuntimeEvent.Error error:
                         streamFailed = true;
                         ShowThinking(false);
                         ApplyConnectionState(RuntimeConnectionState.Error);
-                        ShowChatError(evt.Text);
+                        ShowChatError(error.Detail.Message);
                         break;
                 }
             }
@@ -456,47 +464,19 @@ public sealed partial class ChatPage : Page
 
     private async Task HandleSlashCommandAsync(string input)
     {
-        var parts = input.TrimStart('/').Split(' ', 2);
-        var command = parts[0].ToLowerInvariant();
-        var args = parts.Length > 1 ? parts[1] : "";
-
-        if (command is "help" or "skills")
-        {
-            var skillManager = App.Services.GetRequiredService<SkillManager>();
-            var skills = skillManager.ListSkills();
-            var lines = new System.Text.StringBuilder();
-            lines.AppendLine("Available slash commands:");
-            lines.AppendLine("  /help, /skills  - Show this help");
-            lines.AppendLine("  /new            - Start a new chat");
-            lines.AppendLine();
-            if (skills.Count > 0)
-            {
-                lines.AppendLine("Installed skills:");
-                foreach (var s in skills)
-                    lines.AppendLine($"  /{s.Name}  - {s.Description}");
-            }
-            else
-            {
-                lines.AppendLine("No custom skills installed. Add .md files to your skills directory.");
-            }
-            AppendSystemMessage(lines.ToString());
+        var registry = BuildSlashCommandRegistry();
+        if (await registry.TryExecuteAsync(input, this, CancellationToken.None))
             return;
-        }
-
-        if (command == "new")
-        {
-            NewChat_Click(this, new RoutedEventArgs());
-            return;
-        }
 
         // Try to invoke as a skill
+        var parsed = CommandRegistry<ChatPage>.Parse(input);
         try
         {
             var invoker = App.Services.GetRequiredService<SkillInvoker>();
             SetBusy(true);
             ShowThinking(true, ResourceLoader.GetString("ChatThinkingRunningSkill"));
 
-            var response = await invoker.InvokeAsync(command, args, CancellationToken.None);
+            var response = await invoker.InvokeAsync(parsed.Name, parsed.Arguments, CancellationToken.None);
             ShowThinking(false);
 
             if (!string.IsNullOrWhiteSpace(response))
@@ -506,7 +486,7 @@ public sealed partial class ChatPage : Page
         }
         catch (SkillNotFoundException)
         {
-            AppendSystemMessage($"Unknown command: /{command}. Type /help for available commands.");
+            AppendSystemMessage($"Unknown command: /{parsed.Name}. Type /help for available commands.");
         }
         catch (Exception ex)
         {
@@ -518,6 +498,49 @@ public sealed partial class ChatPage : Page
             SetBusy(false);
             PromptTextBox.Focus(FocusState.Programmatic);
         }
+    }
+
+    private CommandRegistry<ChatPage> BuildSlashCommandRegistry()
+    {
+        return new CommandRegistry<ChatPage>()
+            .Register(new RegisteredCommand<ChatPage>(
+                "help",
+                "Show commands and installed skills",
+                static async (page, _, _) => await page.ShowSlashHelpAsync(),
+                usage: "/help",
+                aliases: ["skills"]))
+            .Register(new RegisteredCommand<ChatPage>(
+                "new",
+                "Start a new chat",
+                static (page, _, _) =>
+                {
+                    page.NewChat_Click(page, new RoutedEventArgs());
+                    return Task.CompletedTask;
+                },
+                usage: "/new"));
+    }
+
+    private Task ShowSlashHelpAsync()
+    {
+        var registry = BuildSlashCommandRegistry();
+        var skillManager = App.Services.GetRequiredService<SkillManager>();
+        var skills = skillManager.ListSkills();
+        var lines = new System.Text.StringBuilder();
+        lines.AppendLine(registry.FormatHelp());
+        lines.AppendLine();
+        if (skills.Count > 0)
+        {
+            lines.AppendLine("Installed skills:");
+            foreach (var s in skills)
+                lines.AppendLine($"  /{s.Name}  - {s.Description}");
+        }
+        else
+        {
+            lines.AppendLine("No custom skills installed. Add .md files to your skills directory.");
+        }
+
+        AppendSystemMessage(lines.ToString());
+        return Task.CompletedTask;
     }
 
     // ── Stop Generation ──

--- a/docs/reference-repo-lessons-openmanus-deepseek-tui.md
+++ b/docs/reference-repo-lessons-openmanus-deepseek-tui.md
@@ -1,0 +1,440 @@
+# Reference Repo Lessons: OpenManus and DeepSeek-TUI
+
+This note captures the useful patterns from two local reference repositories:
+
+- `artifacts/reference-repos/OpenManus-main`
+- `artifacts/reference-repos/DeepSeek-TUI-main`
+
+The goal is not to clone either project. Hermes Desktop already has stronger Windows-native safety, provider fallback, memory/wiki, credential rotation, MCP wrapping, and transcript persistence than OpenManus, and it should stay a native desktop app rather than become a terminal interface. The useful path is selective adaptation: keep Hermes' safety and identity stack, then borrow the sharper runtime, planning, browser, streaming, and UX structures where they improve the desktop.
+
+Both reference projects are MIT licensed. Hermes can use their patterns and port code directly when it maps cleanly, with attribution preserved for substantially derived pieces. The default approach should be "port, adapt, and test" rather than re-inventing equivalent machinery.
+
+## Current Hermes Baseline
+
+Hermes is already a serious in-process agent runtime:
+
+- `src/Core/Agent.cs` owns tool loops, provider fallback, permission gating, activity logging, parallel safe-tool execution, transient system message cleanup, and streaming watchdogs.
+- `src/LLM/*` covers provider abstraction, model routing, OpenAI-compatible clients, Anthropic, credential pool rotation, and structured provider errors.
+- `src/Tools/*` already includes shell, browser, file, patch, grep/glob, LSP, session search, MCP wrappers, memory, image, vision, web, and automation tools.
+- `src/transcript/TranscriptStore.cs` uses crash-aware JSONL persistence with write-through appends.
+- `src/tasks/TaskManager.cs` has durable task objects, but today they are closer to project/task metadata than executable background work records.
+- `Desktop/HermesDesktop/Views/ChatPage.xaml.cs` and `Desktop/HermesDesktop/Services/HermesChatService.cs` carry too much UI/runtime orchestration compared with the cleaner event boundary in DeepSeek-TUI.
+
+## OpenManus: Useful Ideas
+
+OpenManus is less hardened than Hermes, but it has a clean conceptual separation that is worth borrowing.
+
+### 1. Smaller Agent Loop Phases
+
+OpenManus splits the loop into `BaseAgent.run()`, `ReActAgent.step()`, `ToolCallAgent.think()`, and `ToolCallAgent.act()`:
+
+- `app/agent/base.py`
+- `app/agent/react.py`
+- `app/agent/toolcall.py`
+
+Hermes' `Agent` is more capable, but it remains monolithic. Future work should keep extracting these phases into C# services:
+
+- context preparation
+- model/provider call
+- stream accumulation
+- tool-call normalization
+- tool dispatch and permission gating
+- result persistence
+- lifecycle cleanup
+
+This would make the agent easier to test and reduce the chance that fixes in provider behavior, context injection, and tool execution collide.
+
+### 2. First-Class Planning Tool
+
+OpenManus' `PlanningFlow` plus `PlanningTool` provide a concrete status model:
+
+- `not_started`
+- `in_progress`
+- `completed`
+- `blocked`
+
+Relevant files:
+
+- `app/flow/planning.py`
+- `app/tool/planning.py`
+
+Hermes has `TodoWriteTool` and `TaskManager`, but not an agent-visible plan object with step statuses and notes. Add a `planning` or `plan_update` tool backed by session state or `TaskManager`, then teach the loop to execute the current step only and mark progress. This should become the default visible structure for complex turns and sub-agent work.
+
+### 3. Richer Tool Result Shape
+
+OpenManus' `ToolResult` carries:
+
+- `output`
+- `error`
+- `base64_image`
+- `system`
+
+Relevant file:
+
+- `app/tool/base.py`
+
+Hermes `ToolResult` mostly exposes success/content/error. Extend it with optional metadata rather than breaking existing tools:
+
+- `MimeType`
+- `MediaBase64` or artifact reference
+- `SystemNote`
+- `IsTruncated`
+- `RawArtifactPath`
+- `Summary`
+- `Diagnostics`
+
+This helps browser screenshots, chart outputs, long command logs, and hidden tool-system guidance without dumping everything into the user-visible transcript.
+
+### 4. Browser State Feedback
+
+OpenManus' browser agent gives the model explicit browser state: current URL, tabs, scroll position, interactive elements, and screenshot/context.
+
+Relevant files:
+
+- `app/agent/browser.py`
+- `app/tool/browser_use_tool.py`
+
+Hermes' `BrowserTool` is safer and uses Playwright, but its snapshot path is mostly text extraction. Add a `browser_state` action that returns:
+
+- title and URL
+- tab list
+- scroll position
+- viewport dimensions
+- clickable/input element refs
+- optional screenshot artifact
+- last navigation and network failure summary
+
+Then feed that state into the next tool observation or multimodal message for models with vision support.
+
+### 5. Duplicate/Stuck Loop Guard
+
+OpenManus detects repeated assistant messages and injects a strategy-change prompt. Hermes has max iteration limits and a compression cooldown, but it would benefit from finer-grained loop signatures:
+
+- repeated assistant content
+- repeated identical tool name + arguments
+- repeated tool failure class
+- no progress after N steps
+
+Add this to `Agent` as a guardrail before the max tool-iteration fallback.
+
+### 6. Undoable File Edits
+
+OpenManus' string-replace editor has edit history and undo. Hermes' edit/patch tools are safer and more C#-appropriate, but a per-session edit history plus `undo_edit` would be a meaningful safety feature for desktop users.
+
+## DeepSeek-TUI: Useful Ideas
+
+DeepSeek-TUI's best contribution is not the terminal UI. It is the durable, evented runtime model under the UI.
+
+### 1. UI/Engine Event Boundary
+
+DeepSeek separates user intent from engine events:
+
+- `crates/tui/src/core/ops.rs`
+- `crates/tui/src/core/events.rs`
+- `crates/tui/src/tui/ui.rs`
+
+Hermes should introduce a desktop runtime event layer between `HermesChatService` and `ChatPage.xaml.cs`.
+
+Target shape:
+
+- `ChatRuntimeCommand`: user sent message, cancel, retry, switch model, approve tool, deny tool, steer, resume.
+- `ChatRuntimeEvent`: token delta, reasoning delta, tool started, tool updated, tool completed, approval requested, provider switched, error, turn completed.
+- `ChatPage` renders events and dispatches commands; it should not know the details of tool loop sequencing.
+
+This also makes tests easier because the desktop shell can be tested as an event reducer instead of UI callback soup.
+
+### 2. Streaming Accumulator
+
+DeepSeek has explicit streaming chunking, commit ticks, line buffering, and low-motion behavior:
+
+- `crates/tui/src/tui/streaming/chunking.rs`
+- `crates/tui/src/tui/streaming/commit_tick.rs`
+- `crates/tui/src/tui/streaming/line_buffer.rs`
+- `crates/tui/src/core/engine/streaming.rs`
+
+Hermes currently mutates chat message content on each token. Add a `StreamingTextAccumulator` for WinUI that:
+
+- batches token updates on a timer
+- preserves grapheme boundaries
+- flushes immediately on tool boundary/error/turn completion
+- tracks revision numbers
+- supports reduced-motion or low-frequency updates
+
+This should reduce binding churn and make long responses feel steadier.
+
+### 3. Active Turn Model
+
+DeepSeek keeps in-flight work in an active cell, then finalizes it. Hermes logs activities, but chat bubbles and tool cards are not yet one coherent live turn model.
+
+Add `ActiveTurnViewModel` with:
+
+- assistant text
+- reasoning text
+- grouped tool cards
+- permission prompts
+- provider status
+- retry/switch actions
+- finalization into transcript records
+
+This is especially important for parallel tools and sub-agents, where interleaved events can otherwise feel jumpy.
+
+### 4. Command Registry and Palette
+
+DeepSeek treats commands and keybindings as a discoverable contract:
+
+- `docs/KEYBINDINGS.md`
+- `crates/tui/src/commands/mod.rs`
+- `crates/tui/src/tui/slash_menu.rs`
+- `crates/tui/src/tui/command_palette.rs`
+
+Hermes has ad hoc slash command handling. Add a `CommandRegistry` service with:
+
+- name
+- aliases
+- description
+- usage
+- argument parser
+- handler
+- command category
+- keybinding, when applicable
+
+Use it for slash commands, command palette search, help display, diagnostics commands, session actions, settings actions, and future tool invocations.
+
+Good first commands:
+
+- `/help`
+- `/new`
+- `/resume`
+- `/model`
+- `/provider`
+- `/mcp`
+- `/memory`
+- `/sessions`
+- `/tasks`
+- `/diagnostics`
+- `/config`
+
+Good first desktop keybindings:
+
+- `Ctrl+K` or `Ctrl+Shift+P`: command palette
+- `Esc`: close modal/cancel pending UI state
+- `Ctrl+R`: resume session picker
+- `Ctrl+L`: clear/refresh transcript view
+- `Ctrl+S`: stash current draft
+
+### 5. Durable Thread/Turn/Item Timeline
+
+DeepSeek's runtime model persists:
+
+- thread records
+- turn records
+- turn item records
+- event streams
+- schema versions
+- replayable SSE events
+
+Relevant file:
+
+- `crates/tui/src/runtime_threads.rs`
+
+Hermes transcripts are crash-safe but message-centric. Add a runtime timeline layer on top:
+
+- `ThreadRecord`: session metadata, model, workspace, mode, title, archived flag.
+- `TurnRecord`: status, input summary, timestamps, duration, usage, error.
+- `TurnItemRecord`: user message, assistant message, reasoning, tool call, file change, command execution, context compaction, status, error.
+- `RuntimeEventRecord`: monotonic sequence for replay, diagnostics, and UI recovery.
+
+This would make session resume, UI restoration, background tasks, and debugging much cleaner.
+
+### 6. Background Tasks With Evidence
+
+DeepSeek's `TaskManager` is executable and evidence-oriented:
+
+- bounded workers
+- queued/running/completed/failed/canceled states
+- runtime thread/turn linkage
+- timeline entries
+- tool call summaries
+- artifacts
+- verification gates
+- PR attempts
+
+Relevant file:
+
+- `crates/tui/src/task_manager.rs`
+
+Hermes `TaskManager` tracks tasks and dependencies, but not execution evidence. Evolve it toward:
+
+- task queue and worker pool
+- linked session/turn IDs
+- artifact records for large logs
+- verification gates with command, cwd, exit code, duration, summary, and log path
+- checklist progress
+- cancellation
+
+This can power long-running desktop work without freezing the chat.
+
+### 7. Structured Recoverable Errors
+
+DeepSeek sends typed errors to the UI via an error taxonomy:
+
+- category
+- severity
+- recoverability
+- code
+- message
+
+Relevant file:
+
+- `crates/tui/src/error_taxonomy.rs`
+
+Hermes already has provider errors, but `HermesChatService` should surface structured stream errors to the desktop UI:
+
+- `Code`
+- `Provider`
+- `Retryable`
+- `SuggestedAction`
+- `Severity`
+- `RawDetail`
+
+Map these to banner actions:
+
+- Retry
+- Switch model
+- Open settings
+- Check provider
+- Resume queued draft
+
+### 8. Large Output Routing
+
+DeepSeek avoids polluting the parent context with huge tool output:
+
+- estimates output tokens
+- routes large output through synthesis
+- stores raw output out-of-band
+- returns compact provenance plus summary
+
+Relevant file:
+
+- `crates/tui/src/tools/large_output_router.rs`
+
+Hermes should add a `LargeToolOutputRouter` before tool results are appended to session messages:
+
+- default threshold around 4K estimated tokens
+- per-tool thresholds
+- raw artifact path
+- optional summarization
+- `retrieve_tool_result` or `promote_to_context` follow-up tool
+
+This is a high-value context hygiene feature.
+
+### 9. Post-Edit Diagnostics
+
+DeepSeek runs LSP diagnostics after edit/write/patch tools and injects pending diagnostics before the next model call:
+
+- `crates/tui/src/core/engine/lsp_hooks.rs`
+- `crates/tui/src/lsp/*`
+
+Hermes has `LspTool`, but diagnostics are agent-pull rather than loop-pushed. Add a post-edit hook:
+
+- after successful `edit_file`, `write_file`, or `patch`
+- collect diagnostics for changed files
+- attach diagnostics to the active turn
+- inject a synthetic user/tool message before the next model request
+
+This makes the model repair compile/type errors immediately.
+
+### 10. Config Layering and Effective Config
+
+DeepSeek has richer config layering: global config, profiles, env overrides, project overlays, provider sub-tables, custom headers, and managed requirements.
+
+Hermes should keep `%LOCALAPPDATA%\hermes\config.yaml` but move toward:
+
+- typed config loading
+- validation with actionable errors
+- environment override reporting
+- workspace-level overlays
+- visible effective-config diagnostics view
+- provider capability metadata in `ModelCatalog`
+
+## Do Not Copy Blindly
+
+Avoid these direct imports:
+
+- OpenManus' permissive Python execution model.
+- OpenManus' shared in-memory `PlanningTool.plans` state as-is.
+- OpenManus browser defaults where security is weaker than Hermes' current SSRF checks.
+- DeepSeek-specific terminal UI details that do not map to WinUI.
+- DeepSeek's Rust storage shape verbatim; port the concepts, not the file layout.
+
+## Recommended Hermes Roadmap
+
+### Phase 1: Desktop Runtime Boundary
+
+1. Add `ChatRuntimeCommand` and `ChatRuntimeEvent`.
+2. Move stream/tool/session event shaping out of `ChatPage.xaml.cs`.
+3. Add tests for event ordering, cancellation, retry, and error banners.
+
+### Phase 2: Streaming and Active Turn UX
+
+1. Add `StreamingTextAccumulator`.
+2. Add `ActiveTurnViewModel`.
+3. Group tool calls, reasoning, assistant text, and errors under one active turn.
+4. Batch WinUI updates.
+
+### Phase 3: Command Registry
+
+1. Add `CommandRegistry`.
+2. Port current slash commands into registry handlers.
+3. Add command palette UI and centralized keybindings.
+4. Generate help from command metadata.
+
+### Phase 4: Durable Timeline
+
+1. Add thread/turn/item records alongside existing JSONL transcripts.
+2. Add schema versioning and metadata-only session list.
+3. Add in-flight checkpoint records and draft queue persistence.
+
+### Phase 5: Agent Intelligence Guardrails
+
+1. Add stuck-loop signature detection.
+2. Add planning tool with statuses and notes.
+3. Add large-output router with artifact storage.
+4. Add post-edit LSP diagnostic injection.
+
+### Phase 6: Browser and Tool Results
+
+1. Extend `ToolResult` metadata.
+2. Add browser state snapshots with refs and optional screenshots.
+3. Add undoable edit history.
+4. Add runtime MCP connect/disconnect UI and activity events.
+
+## Highest-Value First Patch
+
+The best first implementation target is the command/runtime boundary, not a new agent feature. It unlocks cleaner streaming, testable UI behavior, command palette work, structured errors, active turns, and durable timelines without destabilizing the existing provider/tool system.
+
+Small first slice:
+
+1. Create `ChatRuntimeEvent` and `ChatRuntimeCommand` models.
+2. Add a `StreamingTextAccumulator`.
+3. Adapt `HermesChatService.StreamStructuredAsync` to emit richer events internally.
+4. Keep `ChatPage.xaml.cs` behavior visually the same, but make it consume the new event stream.
+5. Add unit tests for token batching and error event mapping.
+
+## Port Progress
+
+Implemented in the first pass:
+
+- `StreamingTextAccumulator` for batched WinUI streaming updates, adapted from DeepSeek-TUI's chunk/commit-tick pattern.
+- `planning` tool with create/get/list/mark_step/delete and step statuses, adapted from OpenManus' planning tool shape.
+- `browser_state`/`state` action on `BrowserTool`, adapted from OpenManus browser-state feedback.
+- `LargeToolOutputRouter` at the Hermes agent boundary, adapted from DeepSeek-TUI's large-output routing concept.
+- `ChatRuntimeEvent` / `ChatRuntimeCommand` typed runtime seam, adapted from DeepSeek-TUI's engine-event boundary.
+- `CommandRegistry<TContext>` for metadata-driven slash commands and future command palette use, adapted from DeepSeek-TUI's command catalog.
+- Conservative post-edit diagnostics hook extension point, adapted from DeepSeek-TUI's post-edit diagnostics flow. It is quiet by default until a real diagnostics provider is configured.
+
+Still valuable next ports:
+
+- Durable thread/turn/item timeline and executable background task records.
+- Real LSP-backed diagnostics provider wired into the post-edit diagnostics hook.
+- Command palette UI over the new command registry.

--- a/src/Commands/CommandRegistry.cs
+++ b/src/Commands/CommandRegistry.cs
@@ -1,0 +1,105 @@
+namespace Hermes.Agent.Commands;
+
+using System.Text;
+
+/// <summary>
+/// Metadata-driven command registry for slash commands and future command palettes.
+/// Inspired by DeepSeek-TUI's shared slash-command / command-palette catalog.
+/// </summary>
+public sealed class CommandRegistry<TContext>
+{
+    private readonly Dictionary<string, RegisteredCommand<TContext>> _commands = new(StringComparer.OrdinalIgnoreCase);
+
+    public IReadOnlyCollection<RegisteredCommand<TContext>> Commands =>
+        _commands.Values.DistinctBy(c => c.Name).OrderBy(c => c.Name).ToList();
+
+    public CommandRegistry<TContext> Register(RegisteredCommand<TContext> command)
+    {
+        if (string.IsNullOrWhiteSpace(command.Name))
+            throw new ArgumentException("Command name is required.", nameof(command));
+
+        AddAlias(command.Name, command);
+        foreach (var alias in command.Aliases)
+            AddAlias(alias, command);
+        return this;
+    }
+
+    public bool TryGet(string name, out RegisteredCommand<TContext> command) =>
+        _commands.TryGetValue(Normalize(name), out command!);
+
+    public static ParsedCommand Parse(string input)
+    {
+        var trimmed = input.Trim();
+        if (trimmed.StartsWith("/", StringComparison.Ordinal))
+            trimmed = trimmed[1..];
+
+        var parts = trimmed.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length == 0
+            ? new ParsedCommand("", "")
+            : new ParsedCommand(parts[0], parts.Length > 1 ? parts[1] : "");
+    }
+
+    public async Task<bool> TryExecuteAsync(string input, TContext context, CancellationToken ct)
+    {
+        var parsed = Parse(input);
+        if (!TryGet(parsed.Name, out var command))
+            return false;
+
+        await command.ExecuteAsync(context, parsed.Arguments, ct);
+        return true;
+    }
+
+    public string FormatHelp(string header = "Available slash commands:")
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(header);
+        foreach (var command in Commands)
+        {
+            var aliases = command.Aliases.Count == 0
+                ? ""
+                : $" ({string.Join(", ", command.Aliases.Select(a => "/" + a))})";
+            var usage = string.IsNullOrWhiteSpace(command.Usage) ? "/" + command.Name : command.Usage;
+            sb.AppendLine($"  {usage}{aliases} - {command.Description}");
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    private void AddAlias(string alias, RegisteredCommand<TContext> command)
+    {
+        var normalized = Normalize(alias);
+        if (string.IsNullOrWhiteSpace(normalized))
+            throw new ArgumentException("Command alias cannot be empty.", nameof(command));
+        _commands[normalized] = command;
+    }
+
+    private static string Normalize(string value) =>
+        value.Trim().TrimStart('/').ToLowerInvariant();
+}
+
+public sealed class RegisteredCommand<TContext>
+{
+    public RegisteredCommand(
+        string name,
+        string description,
+        Func<TContext, string, CancellationToken, Task> executeAsync,
+        string? usage = null,
+        IReadOnlyList<string>? aliases = null,
+        string category = "general")
+    {
+        Name = name;
+        Description = description;
+        ExecuteAsync = executeAsync;
+        Usage = usage;
+        Aliases = aliases ?? [];
+        Category = category;
+    }
+
+    public string Name { get; }
+    public string Description { get; }
+    public Func<TContext, string, CancellationToken, Task> ExecuteAsync { get; }
+    public string? Usage { get; }
+    public IReadOnlyList<string> Aliases { get; }
+    public string Category { get; }
+}
+
+public sealed record ParsedCommand(string Name, string Arguments);

--- a/src/Core/Agent.cs
+++ b/src/Core/Agent.cs
@@ -8,6 +8,7 @@ using Hermes.Agent.Soul;
 using Hermes.Agent.Transcript;
 using Hermes.Agent.Memory;
 using Hermes.Agent.Context;
+using Hermes.Agent.Tools;
 using Microsoft.Extensions.Logging;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
@@ -18,10 +19,13 @@ public sealed class Agent : IAgent
     private readonly IChatClient _chatClient;
     private readonly ILogger<Agent> _logger;
     private readonly Dictionary<string, ITool> _tools = new();
+    private readonly LargeToolOutputRouter _largeOutputRouter = new();
+    private readonly PostEditDiagnosticsHook _postEditDiagnosticsHook;
 
     // Optional subsystem dependencies — Agent works without any of these
     private readonly PermissionManager? _permissions;
     private readonly TranscriptStore? _transcripts;
+    private readonly TimelineStore? _timeline;
     private readonly MemoryManager? _memories;
     private readonly ContextManager? _contextManager;
     private readonly SoulService? _soulService;
@@ -93,23 +97,30 @@ public sealed class Agent : IAgent
         ILogger<Agent> logger,
         PermissionManager? permissions = null,
         TranscriptStore? transcripts = null,
+        TimelineStore? timeline = null,
         MemoryManager? memories = null,
         ContextManager? contextManager = null,
         SoulService? soulService = null,
         PluginManager? pluginManager = null,
         IChatClient? fallbackChatClient = null,
-        CredentialPool? credentialPool = null)
+        CredentialPool? credentialPool = null,
+        IPostEditDiagnosticsProvider? postEditDiagnosticsProvider = null,
+        PostEditDiagnosticsOptions? postEditDiagnosticsOptions = null)
     {
         _chatClient = chatClient;
         _logger = logger;
         _permissions = permissions;
         _transcripts = transcripts;
+        _timeline = timeline;
         _memories = memories;
         _contextManager = contextManager;
         _soulService = soulService;
         _pluginManager = pluginManager;
         _fallbackChatClient = fallbackChatClient;
         _credentialPool = credentialPool;
+        _postEditDiagnosticsHook = new PostEditDiagnosticsHook(
+            postEditDiagnosticsProvider,
+            postEditDiagnosticsOptions);
     }
 
     /// <summary>
@@ -330,6 +341,8 @@ public sealed class Agent : IAgent
             // Record the assistant message with its tool call requests
             await AgentSessionWriter.AppendAssistantToolRequestMessageAsync(
                 session, response.Content ?? "", normalizedToolCalls, _transcripts, ct);
+            foreach (var toolCall in normalizedToolCalls)
+                await AppendTimelineToolRequestAsync(session, toolCall, ct);
 
             // Execute tool calls — parallel when safe, sequential otherwise
             var toolCallsList = normalizedToolCalls;
@@ -359,6 +372,7 @@ public sealed class Agent : IAgent
                     var resultContent = result.Content;
                     if (SecretScanner.ContainsSecrets(resultContent))
                         resultContent = SecretScanner.RedactSecrets(resultContent);
+                    await AppendTimelineToolResultAsync(session, toolCall, result, resultContent, durationMs, ct);
 
                     var toolResultMsg = new Message
                     {
@@ -411,6 +425,7 @@ public sealed class Agent : IAgent
                             session.AddMessage(denialMsg);
                             if (_transcripts is not null)
                                 await _transcripts.SaveMessageAsync(session.Id, denialMsg, ct);
+                            await AppendTimelineToolDeniedAsync(session, toolCall, denialMsg.Content, ct);
                             continue;
                         }
 
@@ -461,6 +476,7 @@ public sealed class Agent : IAgent
                                 session.AddMessage(askMsg);
                                 if (_transcripts is not null)
                                     await _transcripts.SaveMessageAsync(session.Id, askMsg, ct);
+                                await AppendTimelineToolDeniedAsync(session, toolCall, askMsg.Content, ct);
                                 continue;
                             }
                             // User approved — fall through to execute the tool
@@ -482,11 +498,13 @@ public sealed class Agent : IAgent
                 };
                 ActivityLog.Add(activityEntry);
                 ActivityEntryAdded?.Invoke(activityEntry);
+                await AppendTimelineToolRunningAsync(session, toolCall, ct);
 
                 _logger.LogInformation("Executing tool {ToolName} (call {CallId})", toolCall.Name, toolCall.Id);
                 var sw = System.Diagnostics.Stopwatch.StartNew();
                 var result = await ExecuteToolCallAsync(toolCall, ct);
                 sw.Stop();
+                result = await AppendPostEditDiagnosticsAsync(toolCall, result, ct);
 
                 // ── Activity tracking: AFTER execution ──
                 activityEntry.DurationMs = sw.ElapsedMilliseconds;
@@ -532,6 +550,7 @@ public sealed class Agent : IAgent
                     _logger.LogWarning("Secrets detected in tool result from {ToolName}, redacting", toolCall.Name);
                     resultContent = SecretScanner.RedactSecrets(resultContent);
                 }
+                await AppendTimelineToolResultAsync(session, toolCall, result, resultContent, sw.ElapsedMilliseconds, ct);
 
                 var toolResultMsg = new Message
                 {
@@ -828,6 +847,8 @@ public sealed class Agent : IAgent
             session.AddMessage(assistantToolMsg);
             if (_transcripts is not null)
                 await _transcripts.SaveMessageAsync(session.Id, assistantToolMsg, ct);
+            foreach (var toolCall in normalizedStreamToolCalls)
+                await AppendTimelineToolRequestAsync(session, toolCall, ct);
 
             // Execute each tool call
             foreach (var toolCall in normalizedStreamToolCalls)
@@ -865,6 +886,7 @@ public sealed class Agent : IAgent
                             session.AddMessage(denialMsg);
                             if (_transcripts is not null)
                                 await _transcripts.SaveMessageAsync(session.Id, denialMsg, ct);
+                            await AppendTimelineToolDeniedAsync(session, toolCall, denialMsg.Content, ct);
                             continue;
                         }
 
@@ -910,6 +932,7 @@ public sealed class Agent : IAgent
                                 session.AddMessage(askMsg);
                                 if (_transcripts is not null)
                                     await _transcripts.SaveMessageAsync(session.Id, askMsg, ct);
+                                await AppendTimelineToolDeniedAsync(session, toolCall, askMsg.Content, ct);
                                 continue;
                             }
                         }
@@ -933,11 +956,13 @@ public sealed class Agent : IAgent
                 };
                 ActivityLog.Add(activityEntry);
                 ActivityEntryAdded?.Invoke(activityEntry);
+                await AppendTimelineToolRunningAsync(session, toolCall, ct);
 
                 _logger.LogInformation("Executing tool {ToolName} (call {CallId})", toolCall.Name, toolCall.Id);
                 var sw = System.Diagnostics.Stopwatch.StartNew();
                 var result = await ExecuteToolCallAsync(toolCall, ct);
                 sw.Stop();
+                result = await AppendPostEditDiagnosticsAsync(toolCall, result, ct);
 
                 // ── Activity tracking: AFTER execution ──
                 activityEntry.DurationMs = sw.ElapsedMilliseconds;
@@ -982,6 +1007,7 @@ public sealed class Agent : IAgent
                     _logger.LogWarning("Secrets detected in tool result from {ToolName}, redacting", toolCall.Name);
                     resultContent = SecretScanner.RedactSecrets(resultContent);
                 }
+                await AppendTimelineToolResultAsync(session, toolCall, result, resultContent, sw.ElapsedMilliseconds, ct);
 
                 var toolResultMsg = new Message
                 {
@@ -1251,6 +1277,108 @@ public sealed class Agent : IAgent
         return results.ToList();
     }
 
+    private async Task AppendTimelineToolRequestAsync(Session session, ToolCall toolCall, CancellationToken ct)
+    {
+        await AppendTimelineToolItemAsync(
+            session,
+            toolCall,
+            TurnItemKind.ToolCall,
+            TurnItemStatus.Pending,
+            toolCall.Arguments,
+            durationMs: null,
+            metadata: new Dictionary<string, string> { ["phase"] = "requested" },
+            ct);
+    }
+
+    private async Task AppendTimelineToolRunningAsync(Session session, ToolCall toolCall, CancellationToken ct)
+    {
+        await AppendTimelineToolItemAsync(
+            session,
+            toolCall,
+            TurnItemKind.ToolCall,
+            TurnItemStatus.Running,
+            toolCall.Arguments,
+            durationMs: null,
+            metadata: new Dictionary<string, string> { ["phase"] = "running" },
+            ct);
+    }
+
+    private async Task AppendTimelineToolDeniedAsync(Session session, ToolCall toolCall, string reason, CancellationToken ct)
+    {
+        await AppendTimelineToolItemAsync(
+            session,
+            toolCall,
+            TurnItemKind.ToolResult,
+            TurnItemStatus.Failed,
+            reason,
+            durationMs: null,
+            metadata: new Dictionary<string, string> { ["phase"] = "denied" },
+            ct);
+    }
+
+    private async Task AppendTimelineToolResultAsync(
+        Session session,
+        ToolCall toolCall,
+        ToolResult result,
+        string redactedContent,
+        long durationMs,
+        CancellationToken ct)
+    {
+        await AppendTimelineToolItemAsync(
+            session,
+            toolCall,
+            TurnItemKind.ToolResult,
+            result.Success ? TurnItemStatus.Completed : TurnItemStatus.Failed,
+            redactedContent,
+            durationMs,
+            new Dictionary<string, string>
+            {
+                ["phase"] = "completed",
+                ["success"] = result.Success.ToString()
+            },
+            ct);
+    }
+
+    private async Task AppendTimelineToolItemAsync(
+        Session session,
+        ToolCall toolCall,
+        TurnItemKind kind,
+        TurnItemStatus status,
+        string contentSummary,
+        long? durationMs,
+        IReadOnlyDictionary<string, string> metadata,
+        CancellationToken ct)
+    {
+        if (_timeline is null)
+            return;
+
+        try
+        {
+            var turn = await _timeline.LoadLatestTurnForThreadAsync(session.Id, ct);
+            if (turn is null || turn.Status != TurnStatus.InProgress)
+                return;
+
+            var itemMetadata = new Dictionary<string, string>(metadata);
+            if (durationMs.HasValue)
+                itemMetadata["durationMs"] = durationMs.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+            await _timeline.AppendItemAsync(
+                turn.ThreadId,
+                turn.TurnId,
+                kind,
+                status,
+                contentSummary,
+                toolCallId: toolCall.Id,
+                toolName: toolCall.Name,
+                metadata: itemMetadata,
+                ct: ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to append timeline item for tool {ToolName} ({ToolCallId})", toolCall.Name, toolCall.Id);
+        }
+    }
+
     private async Task<ToolResult> ExecuteToolCallAsync(ToolCall toolCall, CancellationToken ct)
     {
         if (!_tools.TryGetValue(toolCall.Name, out var tool))
@@ -1263,13 +1391,31 @@ public sealed class Agent : IAgent
         {
             var parameters = JsonSerializer.Deserialize(toolCall.Arguments, tool.ParametersType, ToolArgJsonOptions)
                 ?? throw new JsonException($"Failed to deserialize arguments for {toolCall.Name}");
-            return await tool.ExecuteAsync(parameters, ct);
+            var result = await tool.ExecuteAsync(parameters, ct);
+            return _largeOutputRouter.Route(toolCall.Name, result);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Tool {ToolName} failed", toolCall.Name);
             return ToolResult.Fail($"Tool execution failed: {ex.Message}", ex);
         }
+    }
+
+    private async Task<ToolResult> AppendPostEditDiagnosticsAsync(
+        ToolCall toolCall,
+        ToolResult result,
+        CancellationToken ct)
+    {
+        var diagnosticsReport = await _postEditDiagnosticsHook.BuildReportAsync(toolCall, result, ct);
+        if (string.IsNullOrWhiteSpace(diagnosticsReport))
+            return result;
+
+        return new ToolResult
+        {
+            Success = result.Success,
+            Content = $"{result.Content}\n\n{diagnosticsReport}",
+            Error = result.Error
+        };
     }
 
     private static JsonElement BuildParameterSchema(ITool tool)

--- a/src/Core/ChatRuntimeEvent.cs
+++ b/src/Core/ChatRuntimeEvent.cs
@@ -1,0 +1,34 @@
+namespace Hermes.Agent.Core;
+
+/// <summary>
+/// Typed chat runtime events that separate agent execution from UI rendering.
+/// Adapted from DeepSeek-TUI's engine-event boundary for Hermes desktop.
+/// </summary>
+public abstract record ChatRuntimeEvent
+{
+    public sealed record TokenDelta(string Text) : ChatRuntimeEvent;
+    public sealed record ThinkingDelta(string Text) : ChatRuntimeEvent;
+    public sealed record ToolStatus(string Text) : ChatRuntimeEvent;
+    public sealed record Error(ChatRuntimeError Detail) : ChatRuntimeEvent;
+    public sealed record Completed(string SessionId) : ChatRuntimeEvent;
+}
+
+public sealed record ChatRuntimeError(
+    string Message,
+    string Code = "stream_error",
+    bool Retryable = true,
+    string? SuggestedAction = null,
+    string Severity = "error");
+
+/// <summary>
+/// Typed commands the UI can send to the chat runtime.
+/// This is intentionally small today; it gives the desktop app a stable seam
+/// for cancel/retry/steer work without screen or control coupling.
+/// </summary>
+public abstract record ChatRuntimeCommand
+{
+    public sealed record SendMessage(string Text) : ChatRuntimeCommand;
+    public sealed record CancelTurn : ChatRuntimeCommand;
+    public sealed record RetryLast : ChatRuntimeCommand;
+    public sealed record SwitchModel(string Provider, string Model) : ChatRuntimeCommand;
+}

--- a/src/Core/PostEditDiagnosticsHook.cs
+++ b/src/Core/PostEditDiagnosticsHook.cs
@@ -1,0 +1,169 @@
+namespace Hermes.Agent.Core;
+
+using System.Text;
+using System.Text.Json;
+
+public sealed record PostEditDiagnostic(
+    string FilePath,
+    int Line,
+    int Column,
+    string Message,
+    PostEditDiagnosticSeverity Severity);
+
+public enum PostEditDiagnosticSeverity
+{
+    Error,
+    Warning,
+    Information,
+    Hint
+}
+
+public interface IPostEditDiagnosticsProvider
+{
+    Task<IReadOnlyList<PostEditDiagnostic>> GetDiagnosticsAsync(
+        IReadOnlyList<string> changedFilePaths,
+        CancellationToken ct);
+}
+
+public sealed class NoOpPostEditDiagnosticsProvider : IPostEditDiagnosticsProvider
+{
+    public Task<IReadOnlyList<PostEditDiagnostic>> GetDiagnosticsAsync(
+        IReadOnlyList<string> changedFilePaths,
+        CancellationToken ct) =>
+        Task.FromResult<IReadOnlyList<PostEditDiagnostic>>(Array.Empty<PostEditDiagnostic>());
+}
+
+public sealed class PostEditDiagnosticsOptions
+{
+    public bool Enabled { get; init; }
+    public bool IncludeNoDiagnosticsMessage { get; init; }
+    public bool IncludeDisabledMessage { get; init; }
+}
+
+public sealed class PostEditDiagnosticsHook
+{
+    private static readonly HashSet<string> FileMutatingToolNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "edit_file",
+        "write_file",
+        "patch"
+    };
+
+    private readonly IPostEditDiagnosticsProvider _provider;
+    private readonly PostEditDiagnosticsOptions _options;
+
+    public PostEditDiagnosticsHook(
+        IPostEditDiagnosticsProvider? provider = null,
+        PostEditDiagnosticsOptions? options = null)
+    {
+        _provider = provider ?? new NoOpPostEditDiagnosticsProvider();
+        _options = options ?? new PostEditDiagnosticsOptions();
+    }
+
+    public async Task<string?> BuildReportAsync(ToolCall toolCall, ToolResult result, CancellationToken ct)
+    {
+        if (!result.Success)
+            return null;
+
+        var changedFilePaths = DetectChangedFilePaths(toolCall.Name, toolCall.Arguments);
+        if (changedFilePaths.Count == 0)
+            return null;
+
+        if (!_options.Enabled)
+        {
+            return _options.IncludeDisabledMessage
+                ? FormatDisabled(changedFilePaths)
+                : null;
+        }
+
+        var diagnostics = await _provider.GetDiagnosticsAsync(changedFilePaths, ct);
+        if (diagnostics.Count == 0)
+        {
+            return _options.IncludeNoDiagnosticsMessage
+                ? FormatNoDiagnostics(changedFilePaths)
+                : null;
+        }
+
+        return FormatDiagnostics(diagnostics);
+    }
+
+    public static IReadOnlyList<string> DetectChangedFilePaths(string toolName, string arguments)
+    {
+        if (!FileMutatingToolNames.Contains(toolName))
+            return Array.Empty<string>();
+
+        try
+        {
+            using var doc = JsonDocument.Parse(arguments);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+                return Array.Empty<string>();
+
+            var paths = new List<string>();
+            AddPathIfPresent(doc.RootElement, "filePath", paths);
+            AddPathIfPresent(doc.RootElement, "file_path", paths);
+
+            return paths
+                .Where(path => !string.IsNullOrWhiteSpace(path))
+                .Select(path => path.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+        catch (JsonException)
+        {
+            return Array.Empty<string>();
+        }
+    }
+
+    public static string FormatDiagnostics(IReadOnlyList<PostEditDiagnostic> diagnostics)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Post-edit diagnostics:");
+        foreach (var diagnostic in diagnostics)
+        {
+            sb.AppendLine(
+                $"[{FormatSeverity(diagnostic.Severity)}] {diagnostic.FilePath}:{diagnostic.Line}:{diagnostic.Column}: {diagnostic.Message}");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    public static string FormatNoDiagnostics(IReadOnlyList<string> changedFilePaths) =>
+        FormatPathList("Post-edit diagnostics: no diagnostics for changed file(s):", changedFilePaths);
+
+    public static string FormatDisabled(IReadOnlyList<string> changedFilePaths) =>
+        FormatPathList("Post-edit diagnostics disabled for changed file(s):", changedFilePaths);
+
+    private static void AddPathIfPresent(JsonElement root, string propertyName, List<string> paths)
+    {
+        foreach (var property in root.EnumerateObject())
+        {
+            if (!string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (property.Value.ValueKind == JsonValueKind.String)
+            {
+                var path = property.Value.GetString();
+                if (!string.IsNullOrWhiteSpace(path))
+                    paths.Add(path);
+            }
+        }
+    }
+
+    private static string FormatPathList(string header, IReadOnlyList<string> changedFilePaths)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(header);
+        foreach (var path in changedFilePaths)
+            sb.AppendLine($"- {path}");
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string FormatSeverity(PostEditDiagnosticSeverity severity) =>
+        severity switch
+        {
+            PostEditDiagnosticSeverity.Error => "ERROR",
+            PostEditDiagnosticSeverity.Warning => "WARN",
+            PostEditDiagnosticSeverity.Information => "INFO",
+            _ => "HINT"
+        };
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -94,6 +94,7 @@ static async Task<int> InvokeChatAsync(
     services.AddSingleton<IChatClient>(new OpenAiClient(config, new HttpClient()));
     services.AddSingleton<IAgent, Agent>();
     services.AddSingleton<ITool, TerminalTool>();
+    services.AddSingleton<ITool, PlanningTool>();
 
     using var serviceProvider = services.BuildServiceProvider();
     var agent = serviceProvider.GetRequiredService<IAgent>();

--- a/src/Tools/BrowserTool.cs
+++ b/src/Tools/BrowserTool.cs
@@ -3,6 +3,9 @@ namespace Hermes.Agent.Tools;
 using Hermes.Agent.Core;
 using Microsoft.Playwright;
 using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 
 // ══════════════════════════════════════════════
@@ -16,7 +19,7 @@ using System.Text.RegularExpressions;
 
 /// <summary>
 /// Browser automation via Playwright accessibility tree.
-/// Actions: navigate, click, type, scroll, press, js, snapshot, close.
+/// Actions: navigate, click, type, scroll, press, js, snapshot, browser_state, close.
 /// Returns page content as structured text, not screenshots.
 /// </summary>
 public sealed class BrowserTool : ITool, IAsyncDisposable
@@ -27,7 +30,7 @@ public sealed class BrowserTool : ITool, IAsyncDisposable
     private readonly SemaphoreSlim _lock = new(1, 1);
 
     public string Name => "browser";
-    public string Description => "Browse the web. Actions: navigate(url), click(selector), type(selector,text), scroll(direction), press(key), js(expression), snapshot, close.";
+    public string Description => "Browse the web. Actions: navigate(url), click(selector), type(selector,text), scroll(direction), press(key), js(expression), snapshot, browser_state/state, close.";
     public Type ParametersType => typeof(BrowserParameters);
 
     // SSRF protection
@@ -56,8 +59,9 @@ public sealed class BrowserTool : ITool, IAsyncDisposable
                 "press" => await PressAsync(p),
                 "js" or "evaluate" => await EvaluateAsync(p),
                 "snapshot" => await SnapshotAsync(),
+                "browser_state" or "state" => await BrowserStateAsync(),
                 "close" => await CloseAsync(),
-                _ => ToolResult.Fail("Unknown action. Use: navigate, click, type, scroll, press, js, snapshot, close")
+                _ => ToolResult.Fail("Unknown action. Use: navigate, click, type, scroll, press, js, snapshot, browser_state/state, close")
             };
         }
         catch (PlaywrightException ex)
@@ -210,6 +214,219 @@ public sealed class BrowserTool : ITool, IAsyncDisposable
         return ToolResult.Ok(output);
     }
 
+    private async Task<ToolResult> BrowserStateAsync()
+    {
+        if (_page is null) return ToolResult.Fail("No page open. Use navigate first.");
+
+        var title = await _page.TitleAsync();
+        var url = _page.Url;
+        var json = await _page.EvaluateAsync<string>(BrowserStateScript);
+        var domState = JsonSerializer.Deserialize<BrowserStateDomSnapshot>(json, JsonOptions)
+            ?? new BrowserStateDomSnapshot();
+
+        var viewport = domState.Viewport ?? new BrowserViewport(0, 0);
+        var scroll = domState.Scroll ?? new BrowserScrollPosition(0, 0, 0, 0);
+        var state = new BrowserStateSnapshot(
+            Url: url,
+            Title: title,
+            Viewport: viewport,
+            Scroll: scroll,
+            ClickableRefs: domState.ClickableRefs ?? [],
+            InputRefs: domState.InputRefs ?? []);
+
+        return ToolResult.Ok(FormatBrowserState(state));
+    }
+
+    public static string FormatBrowserState(BrowserStateSnapshot state)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("{");
+        AppendProperty(sb, "url", state.Url, trailingComma: true, indent: 2);
+        AppendProperty(sb, "title", state.Title, trailingComma: true, indent: 2);
+        sb.AppendLine($"  viewport: {{ width: {state.Viewport.Width}, height: {state.Viewport.Height} }},");
+        sb.AppendLine($"  scroll: {{ x: {state.Scroll.X}, y: {state.Scroll.Y}, maxX: {state.Scroll.MaxX}, maxY: {state.Scroll.MaxY} }},");
+
+        sb.AppendLine("  clickable_refs: [");
+        AppendRefs(sb, state.ClickableRefs);
+        sb.AppendLine("  ],");
+
+        sb.AppendLine("  input_refs: [");
+        AppendRefs(sb, state.InputRefs);
+        sb.AppendLine("  ]");
+        sb.AppendLine("}");
+
+        return sb.ToString();
+    }
+
+    private static void AppendRefs(StringBuilder sb, IReadOnlyList<BrowserElementRef> refs)
+    {
+        if (refs.Count == 0)
+        {
+            sb.AppendLine("    // none");
+            return;
+        }
+
+        for (var i = 0; i < refs.Count; i++)
+        {
+            var item = refs[i];
+            sb.Append("    { ");
+            AppendInlineProperty(sb, "ref", item.Ref);
+            AppendOptionalInlineProperty(sb, "role", item.Role);
+            AppendOptionalInlineProperty(sb, "tag", item.Tag);
+            AppendOptionalInlineProperty(sb, "type", item.Type);
+            AppendOptionalInlineProperty(sb, "name", item.Name);
+            AppendOptionalInlineProperty(sb, "placeholder", item.Placeholder);
+            AppendOptionalInlineProperty(sb, "text", item.Text);
+            AppendOptionalInlineProperty(sb, "value", item.Value);
+            sb.Append(" }");
+            if (i < refs.Count - 1)
+                sb.Append(',');
+            sb.AppendLine();
+        }
+    }
+
+    private static void AppendProperty(StringBuilder sb, string name, string value, bool trailingComma, int indent)
+    {
+        sb.Append(' ', indent);
+        sb.Append(name);
+        sb.Append(": ");
+        AppendQuoted(sb, value);
+        if (trailingComma)
+            sb.Append(',');
+        sb.AppendLine();
+    }
+
+    private static void AppendInlineProperty(StringBuilder sb, string name, string value)
+    {
+        sb.Append(name);
+        sb.Append(": ");
+        AppendQuoted(sb, value);
+    }
+
+    private static void AppendOptionalInlineProperty(StringBuilder sb, string name, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return;
+
+        sb.Append(", ");
+        AppendInlineProperty(sb, name, value);
+    }
+
+    private static void AppendQuoted(StringBuilder sb, string? value)
+    {
+        sb.Append(JsonSerializer.Serialize(Compact(value ?? ""), QuoteOptions));
+    }
+
+    private static string Compact(string value)
+    {
+        var compact = Regex.Replace(value, @"\s+", " ").Trim();
+        return compact.Length <= 160 ? compact : compact[..157] + "...";
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        NumberHandling = JsonNumberHandling.AllowReadingFromString
+    };
+
+    private static readonly JsonSerializerOptions QuoteOptions = new()
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
+    private const string BrowserStateScript =
+        """
+        () => {
+          const compact = (value, max = 120) => String(value || '').replace(/\s+/g, ' ').trim().slice(0, max);
+          const escapeAttr = value => String(value || '').replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+          const cssEscape = value => {
+            if (window.CSS && CSS.escape) return CSS.escape(String(value));
+            return String(value).replace(/[^a-zA-Z0-9_-]/g, match => `\\${match}`);
+          };
+          const isVisible = el => {
+            const rect = el.getBoundingClientRect();
+            const style = window.getComputedStyle(el);
+            return rect.width > 0 &&
+              rect.height > 0 &&
+              rect.bottom >= 0 &&
+              rect.right >= 0 &&
+              rect.top <= window.innerHeight &&
+              rect.left <= window.innerWidth &&
+              style.visibility !== 'hidden' &&
+              style.display !== 'none' &&
+              style.pointerEvents !== 'none';
+          };
+          const selectorFor = el => {
+            const tag = el.tagName.toLowerCase();
+            if (el.id) return `#${cssEscape(el.id)}`;
+            for (const attr of ['data-testid', 'data-test', 'name', 'aria-label', 'placeholder', 'title']) {
+              const value = el.getAttribute(attr);
+              if (value) return `${tag}[${attr}="${escapeAttr(value)}"]`;
+            }
+
+            const parts = [];
+            let node = el;
+            while (node && node.nodeType === Node.ELEMENT_NODE && parts.length < 5) {
+              const nodeTag = node.tagName.toLowerCase();
+              if (node.id) {
+                parts.unshift(`#${cssEscape(node.id)}`);
+                break;
+              }
+
+              let part = nodeTag;
+              const parent = node.parentElement;
+              if (parent) {
+                const sameTag = Array.from(parent.children).filter(child => child.tagName === node.tagName);
+                if (sameTag.length > 1) {
+                  part += `:nth-of-type(${sameTag.indexOf(node) + 1})`;
+                }
+              }
+              parts.unshift(part);
+              node = parent;
+            }
+
+            return parts.join(' > ');
+          };
+          const describe = el => ({
+            ref: selectorFor(el),
+            role: compact(el.getAttribute('role')),
+            tag: el.tagName.toLowerCase(),
+            type: compact(el.getAttribute('type')),
+            name: compact(el.getAttribute('name')),
+            placeholder: compact(el.getAttribute('placeholder')),
+            text: compact(el.innerText || el.getAttribute('aria-label') || el.getAttribute('title') || el.value || el.textContent),
+            value: compact(el.matches('input, textarea, select, [contenteditable="true"]') ? (el.value || el.innerText) : '')
+          });
+          const uniqueVisible = selector => {
+            const seen = new Set();
+            return Array.from(document.querySelectorAll(selector))
+              .filter(isVisible)
+              .map(describe)
+              .filter(item => {
+                if (!item.ref || seen.has(item.ref)) return false;
+                seen.add(item.ref);
+                return true;
+              })
+              .slice(0, 50);
+          };
+
+          return JSON.stringify({
+            viewport: {
+              width: Math.round(window.innerWidth),
+              height: Math.round(window.innerHeight)
+            },
+            scroll: {
+              x: Math.round(window.scrollX),
+              y: Math.round(window.scrollY),
+              maxX: Math.max(0, Math.round(document.documentElement.scrollWidth - window.innerWidth)),
+              maxY: Math.max(0, Math.round(document.documentElement.scrollHeight - window.innerHeight))
+            },
+            clickableRefs: uniqueVisible('a[href], button, [role="button"], [role="link"], input[type="button"], input[type="submit"], input[type="reset"], summary, [onclick], [tabindex]:not([tabindex="-1"])'),
+            inputRefs: uniqueVisible('input:not([type="hidden"]):not([type="button"]):not([type="submit"]):not([type="reset"]):not([type="image"]), textarea, select, [contenteditable="true"], [role="textbox"], [role="combobox"], [role="searchbox"], [role="spinbutton"]')
+          });
+        }
+        """;
+
     private static void RenderAccessibilityNode(
         AccessibilitySnapshotResult node, StringBuilder sb, int depth)
     {
@@ -269,6 +486,36 @@ public sealed class AccessibilitySnapshotResult
     public string? Name { get; set; }
     public string? Value { get; set; }
     public IReadOnlyList<AccessibilitySnapshotResult>? Children { get; set; }
+}
+
+public sealed record BrowserStateSnapshot(
+    string Url,
+    string Title,
+    BrowserViewport Viewport,
+    BrowserScrollPosition Scroll,
+    IReadOnlyList<BrowserElementRef> ClickableRefs,
+    IReadOnlyList<BrowserElementRef> InputRefs);
+
+public sealed record BrowserViewport(int Width, int Height);
+
+public sealed record BrowserScrollPosition(int X, int Y, int MaxX, int MaxY);
+
+public sealed record BrowserElementRef(
+    string Ref,
+    string? Role = null,
+    string? Tag = null,
+    string? Type = null,
+    string? Name = null,
+    string? Placeholder = null,
+    string? Text = null,
+    string? Value = null);
+
+public sealed class BrowserStateDomSnapshot
+{
+    public BrowserViewport? Viewport { get; set; }
+    public BrowserScrollPosition? Scroll { get; set; }
+    public IReadOnlyList<BrowserElementRef>? ClickableRefs { get; set; }
+    public IReadOnlyList<BrowserElementRef>? InputRefs { get; set; }
 }
 
 public sealed class BrowserParameters

--- a/src/Tools/LargeToolOutputRouter.cs
+++ b/src/Tools/LargeToolOutputRouter.cs
@@ -1,0 +1,123 @@
+namespace Hermes.Agent.Tools;
+
+using Hermes.Agent.Core;
+using Hermes.Agent.Security;
+using System.Security;
+using System.Security.Cryptography;
+using System.Text;
+
+/// <summary>
+/// Routes oversized tool output into artifacts before it pollutes the model context.
+/// Adapted from DeepSeek-TUI's large-output router, with deterministic local
+/// summarization so every tool benefits without an extra model call.
+/// </summary>
+public sealed class LargeToolOutputRouter
+{
+    public const int DefaultThresholdTokens = 4096;
+    private const int CharsPerTokenEstimate = 3;
+    private const int SummaryHeadChars = 2200;
+    private const int SummaryTailChars = 2200;
+
+    private readonly string _artifactDir;
+    private readonly int _thresholdTokens;
+    private readonly Dictionary<string, int> _perToolThresholds;
+
+    public LargeToolOutputRouter(
+        string? artifactDir = null,
+        int thresholdTokens = DefaultThresholdTokens,
+        IReadOnlyDictionary<string, int>? perToolThresholds = null)
+    {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        _artifactDir = artifactDir ?? Path.Combine(localAppData, "hermes", "tool_outputs");
+        _thresholdTokens = Math.Max(1, thresholdTokens);
+        _perToolThresholds = perToolThresholds is null
+            ? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, int>(perToolThresholds, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public ToolResult Route(string toolName, ToolResult result)
+    {
+        if (!result.Success || string.IsNullOrEmpty(result.Content))
+            return result;
+
+        var content = SecretScanner.ContainsSecrets(result.Content)
+            ? SecretScanner.RedactSecrets(result.Content)
+            : result.Content;
+
+        var threshold = ThresholdFor(toolName);
+        var estimatedTokens = EstimateTokens(content);
+        if (estimatedTokens <= threshold)
+            return ReferenceEquals(content, result.Content) ? result : ToolResult.Ok(content);
+
+        try
+        {
+            Directory.CreateDirectory(_artifactDir);
+            var artifactPath = WriteArtifact(toolName, content);
+            var summary = Summarize(toolName, content, estimatedTokens, threshold, artifactPath);
+            return ToolResult.Ok(summary);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException)
+        {
+            return ToolResult.Ok(SummarizeWithoutArtifact(toolName, content, estimatedTokens, threshold, ex.Message));
+        }
+    }
+
+    public int ThresholdFor(string toolName) =>
+        _perToolThresholds.TryGetValue(toolName, out var value) ? value : _thresholdTokens;
+
+    public static int EstimateTokens(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return 0;
+
+        return (text.Length + CharsPerTokenEstimate - 1) / CharsPerTokenEstimate;
+    }
+
+    private string WriteArtifact(string toolName, string content)
+    {
+        var safeTool = string.Concat(toolName.Select(c => char.IsLetterOrDigit(c) || c is '_' or '-' ? c : '_'));
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(content)))[..12].ToLowerInvariant();
+        var path = Path.Combine(_artifactDir, $"{DateTime.UtcNow:yyyyMMdd_HHmmss}_{safeTool}_{hash}.txt");
+        File.WriteAllText(path, content, Encoding.UTF8);
+        return path;
+    }
+
+    private static string Summarize(string toolName, string content, int estimatedTokens, int threshold, string artifactPath)
+    {
+        var headLength = Math.Min(SummaryHeadChars, content.Length);
+        var tailLength = Math.Min(SummaryTailChars, Math.Max(0, content.Length - headLength));
+        var head = content[..headLength];
+        var tail = tailLength > 0 ? content[^tailLength..] : "";
+
+        var omittedChars = Math.Max(0, content.Length - headLength - tailLength);
+        var sb = new StringBuilder();
+        sb.AppendLine($"[large-tool-output: tool={toolName}, estimated_tokens={estimatedTokens}, threshold={threshold}]");
+        sb.AppendLine($"Raw output saved to: {artifactPath}");
+        sb.AppendLine();
+        sb.AppendLine("<head>");
+        sb.AppendLine(head.TrimEnd());
+        sb.AppendLine("</head>");
+        if (omittedChars > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine($"... omitted {omittedChars} chars from middle ...");
+            sb.AppendLine();
+            sb.AppendLine("<tail>");
+            sb.AppendLine(tail.TrimStart());
+            sb.AppendLine("</tail>");
+        }
+
+        return sb.ToString();
+    }
+
+    private static string SummarizeWithoutArtifact(
+        string toolName,
+        string content,
+        int estimatedTokens,
+        int threshold,
+        string artifactError)
+    {
+        var summary = Summarize(toolName, content, estimatedTokens, threshold, "<artifact write failed>");
+        return summary + $"\nArtifact write failed: {artifactError}";
+    }
+}

--- a/src/Tools/PlanningTool.cs
+++ b/src/Tools/PlanningTool.cs
@@ -1,0 +1,326 @@
+namespace Hermes.Agent.Tools;
+
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Hermes.Agent.Core;
+
+/// <summary>
+/// In-memory planning tool for tracking multi-step work within a tool instance.
+/// </summary>
+public sealed class PlanningTool : ITool, IToolSchemaProvider
+{
+    private static readonly JsonSerializerOptions SchemaJsonOptions = new(JsonSerializerDefaults.Web);
+    private static readonly HashSet<string> ValidStatuses = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "not_started",
+        "in_progress",
+        "completed",
+        "blocked"
+    };
+
+    private readonly object _gate = new();
+    private readonly Dictionary<string, PlanState> _plans = new(StringComparer.OrdinalIgnoreCase);
+    private string? _activePlanId;
+
+    public string Name => "planning";
+
+    public string Description =>
+        "Create, inspect, list, update step status, and delete in-memory execution plans.";
+
+    public Type ParametersType => typeof(PlanningParameters);
+
+    public Task<ToolResult> ExecuteAsync(object parameters, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        if (parameters is not PlanningParameters p)
+            return Task.FromResult(ToolResult.Fail("Invalid parameters for planning tool."));
+
+        try
+        {
+            var command = (p.Command ?? p.Action)?.Trim().ToLowerInvariant();
+            var result = command switch
+            {
+                "create" => CreatePlan(p.PlanId, p.Title, p.Steps),
+                "get" => GetPlan(p.PlanId),
+                "list" => ListPlans(),
+                "mark_step" => MarkStep(p.PlanId, p.StepIndex, p.StepStatus, p.StepNotes),
+                "delete" => DeletePlan(p.PlanId),
+                _ => ToolResult.Fail(
+                    $"Unknown command: {p.Command ?? p.Action}. Use create, get, list, mark_step, or delete.")
+            };
+
+            return Task.FromResult(result);
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ToolResult.Fail($"Planning tool failed: {ex.Message}", ex));
+        }
+    }
+
+    public JsonElement? GetParameterSchema()
+    {
+        var schema = new
+        {
+            type = "object",
+            properties = new Dictionary<string, object>
+            {
+                ["command"] = new
+                {
+                    type = "string",
+                    description = "Operation to perform.",
+                    @enum = new[] { "create", "get", "list", "mark_step", "delete" }
+                },
+                ["action"] = new
+                {
+                    type = "string",
+                    description = "Alias for command.",
+                    @enum = new[] { "create", "get", "list", "mark_step", "delete" }
+                },
+                ["plan_id"] = new
+                {
+                    type = "string",
+                    description = "Plan identifier. Required for delete; required for get/mark_step when no active plan exists."
+                },
+                ["title"] = new
+                {
+                    type = "string",
+                    description = "Plan title. Required for create."
+                },
+                ["steps"] = new
+                {
+                    type = "array",
+                    description = "Non-empty list of step descriptions. Required for create.",
+                    items = new { type = "string" }
+                },
+                ["step_index"] = new
+                {
+                    type = "integer",
+                    description = "0-based step index. Required for mark_step."
+                },
+                ["step_status"] = new
+                {
+                    type = "string",
+                    description = "Status to apply to a step.",
+                    @enum = new[] { "not_started", "in_progress", "completed", "blocked" }
+                },
+                ["step_notes"] = new
+                {
+                    type = "string",
+                    description = "Optional notes to attach to the step."
+                }
+            },
+            additionalProperties = false
+        };
+
+        return JsonSerializer.SerializeToElement(schema, SchemaJsonOptions);
+    }
+
+    private ToolResult CreatePlan(string? planId, string? title, IReadOnlyList<string>? steps)
+    {
+        if (string.IsNullOrWhiteSpace(planId))
+            return ToolResult.Fail("plan_id is required for create.");
+
+        if (string.IsNullOrWhiteSpace(title))
+            return ToolResult.Fail("title is required for create.");
+
+        if (steps is null || steps.Count == 0 || steps.Any(string.IsNullOrWhiteSpace))
+            return ToolResult.Fail("steps must be a non-empty list of step descriptions.");
+
+        lock (_gate)
+        {
+            if (_plans.ContainsKey(planId))
+                return ToolResult.Fail($"A plan with ID '{planId}' already exists.");
+
+            var plan = new PlanState(
+                planId,
+                title.Trim(),
+                steps.Select(step => new PlanStep(step.Trim())).ToList());
+
+            _plans[planId] = plan;
+            _activePlanId = planId;
+
+            return ToolResult.Ok($"Plan created: {planId}\n\n{FormatPlan(plan)}");
+        }
+    }
+
+    private ToolResult GetPlan(string? planId)
+    {
+        lock (_gate)
+        {
+            if (!TryGetPlan(planId, out var plan, out var error))
+                return ToolResult.Fail(error);
+
+            return ToolResult.Ok(FormatPlan(plan));
+        }
+    }
+
+    private ToolResult ListPlans()
+    {
+        lock (_gate)
+        {
+            if (_plans.Count == 0)
+                return ToolResult.Ok("No plans available.");
+
+            var sb = new StringBuilder();
+            sb.AppendLine("Available plans:");
+
+            foreach (var plan in _plans.Values.OrderBy(p => p.PlanId, StringComparer.OrdinalIgnoreCase))
+            {
+                var active = string.Equals(plan.PlanId, _activePlanId, StringComparison.OrdinalIgnoreCase)
+                    ? " (active)"
+                    : "";
+                var completed = plan.Steps.Count(s => s.Status == "completed");
+                sb.AppendLine($"- {plan.PlanId}{active}: {plan.Title} - {completed}/{plan.Steps.Count} completed");
+            }
+
+            return ToolResult.Ok(sb.ToString().TrimEnd());
+        }
+    }
+
+    private ToolResult MarkStep(string? planId, int? stepIndex, string? stepStatus, string? stepNotes)
+    {
+        if (stepIndex is null)
+            return ToolResult.Fail("step_index is required for mark_step.");
+
+        if (string.IsNullOrWhiteSpace(stepStatus))
+            return ToolResult.Fail("step_status is required for mark_step.");
+
+        if (!ValidStatuses.Contains(stepStatus))
+            return ToolResult.Fail("Invalid step_status. Use not_started, in_progress, completed, or blocked.");
+
+        var index = stepIndex.Value;
+
+        lock (_gate)
+        {
+            if (!TryGetPlan(planId, out var plan, out var error))
+                return ToolResult.Fail(error);
+
+            if (index < 0 || index >= plan.Steps.Count)
+                return ToolResult.Fail($"Invalid step_index: {index}. Valid range is 0 to {plan.Steps.Count - 1}.");
+
+            var step = plan.Steps[index];
+            step.Status = stepStatus.ToLowerInvariant();
+            if (stepNotes is not null)
+                step.Notes = stepNotes;
+
+            _activePlanId = plan.PlanId;
+
+            return ToolResult.Ok($"Step {index} updated in plan '{plan.PlanId}'.\n\n{FormatPlan(plan)}");
+        }
+    }
+
+    private ToolResult DeletePlan(string? planId)
+    {
+        if (string.IsNullOrWhiteSpace(planId))
+            return ToolResult.Fail("plan_id is required for delete.");
+
+        lock (_gate)
+        {
+            if (!_plans.Remove(planId))
+                return ToolResult.Fail($"No plan found with ID: {planId}");
+
+            if (string.Equals(_activePlanId, planId, StringComparison.OrdinalIgnoreCase))
+                _activePlanId = null;
+
+            return ToolResult.Ok($"Plan '{planId}' deleted.");
+        }
+    }
+
+    private bool TryGetPlan(string? planId, out PlanState plan, out string error)
+    {
+        var resolvedPlanId = string.IsNullOrWhiteSpace(planId) ? _activePlanId : planId;
+        if (string.IsNullOrWhiteSpace(resolvedPlanId))
+        {
+            plan = null!;
+            error = "No active plan. Provide plan_id.";
+            return false;
+        }
+
+        if (!_plans.TryGetValue(resolvedPlanId, out plan!))
+        {
+            error = $"No plan found with ID: {resolvedPlanId}";
+            return false;
+        }
+
+        error = "";
+        return true;
+    }
+
+    private static string FormatPlan(PlanState plan)
+    {
+        var total = plan.Steps.Count;
+        var completed = plan.Steps.Count(step => step.Status == "completed");
+        var inProgress = plan.Steps.Count(step => step.Status == "in_progress");
+        var blocked = plan.Steps.Count(step => step.Status == "blocked");
+        var notStarted = plan.Steps.Count(step => step.Status == "not_started");
+        var percent = total == 0 ? 0 : completed * 100.0 / total;
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"Plan: {plan.Title} (ID: {plan.PlanId})");
+        sb.AppendLine($"Progress: {completed}/{total} completed ({percent:0.0}%)");
+        sb.AppendLine($"Status: {completed} completed, {inProgress} in progress, {blocked} blocked, {notStarted} not started");
+        sb.AppendLine();
+        sb.AppendLine("Steps:");
+
+        for (var i = 0; i < plan.Steps.Count; i++)
+        {
+            var step = plan.Steps[i];
+            sb.AppendLine($"{i}. [{StatusMarker(step.Status)}] {step.Description}");
+            if (!string.IsNullOrWhiteSpace(step.Notes))
+                sb.AppendLine($"   Notes: {step.Notes}");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string StatusMarker(string status) => status switch
+    {
+        "completed" => "x",
+        "in_progress" => "~",
+        "blocked" => "!",
+        _ => " "
+    };
+
+    private sealed record PlanState(string PlanId, string Title, List<PlanStep> Steps);
+
+    private sealed class PlanStep
+    {
+        public PlanStep(string description)
+        {
+            Description = description;
+        }
+
+        public string Description { get; }
+        public string Status { get; set; } = "not_started";
+        public string? Notes { get; set; }
+    }
+}
+
+public sealed class PlanningParameters
+{
+    [JsonPropertyName("command")]
+    public string? Command { get; init; }
+
+    [JsonPropertyName("action")]
+    public string? Action { get; init; }
+
+    [JsonPropertyName("plan_id")]
+    public string? PlanId { get; init; }
+
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    [JsonPropertyName("steps")]
+    public IReadOnlyList<string>? Steps { get; init; }
+
+    [JsonPropertyName("step_index")]
+    public int? StepIndex { get; init; }
+
+    [JsonPropertyName("step_status")]
+    public string? StepStatus { get; init; }
+
+    [JsonPropertyName("step_notes")]
+    public string? StepNotes { get; init; }
+}

--- a/src/UI/StreamingTextAccumulator.cs
+++ b/src/UI/StreamingTextAccumulator.cs
@@ -1,0 +1,78 @@
+namespace Hermes.Agent.UI;
+
+using System.Text;
+
+/// <summary>
+/// Batches streaming text deltas before they are committed to a UI-bound string.
+/// Adapted from DeepSeek-TUI's streaming chunk/commit-tick model for WinUI.
+/// </summary>
+public sealed class StreamingTextAccumulator
+{
+    private readonly StringBuilder _pending = new();
+    private readonly TimeProvider _clock;
+    private DateTimeOffset _lastFlush;
+
+    public StreamingTextAccumulator(
+        TimeProvider? clock = null,
+        TimeSpan? minFlushInterval = null,
+        int maxBufferedChars = 256)
+    {
+        _clock = clock ?? TimeProvider.System;
+        MinFlushInterval = minFlushInterval ?? TimeSpan.FromMilliseconds(33);
+        MaxBufferedChars = Math.Max(1, maxBufferedChars);
+        _lastFlush = _clock.GetUtcNow();
+    }
+
+    public TimeSpan MinFlushInterval { get; }
+    public int MaxBufferedChars { get; }
+    public bool HasPending => _pending.Length > 0;
+
+    public void Append(string? delta)
+    {
+        if (!string.IsNullOrEmpty(delta))
+            _pending.Append(delta);
+    }
+
+    public string FlushIfDue(bool force = false)
+    {
+        if (_pending.Length == 0)
+            return string.Empty;
+
+        var now = _clock.GetUtcNow();
+        if (!force &&
+            _pending.Length < MaxBufferedChars &&
+            now - _lastFlush < MinFlushInterval)
+        {
+            return string.Empty;
+        }
+
+        var flushLength = SafeFlushLength(force);
+        if (flushLength == 0)
+            return string.Empty;
+
+        var text = _pending.ToString(0, flushLength);
+        _pending.Remove(0, flushLength);
+        _lastFlush = now;
+        return text;
+    }
+
+    public string Flush() => FlushIfDue(force: true);
+
+    public void Clear()
+    {
+        _pending.Clear();
+        _lastFlush = _clock.GetUtcNow();
+    }
+
+    private int SafeFlushLength(bool force)
+    {
+        var length = _pending.Length;
+
+        // Do not split a UTF-16 surrogate pair during ordinary timed flushes.
+        // The final forced flush is allowed to release whatever the provider sent.
+        if (!force && length > 0 && char.IsHighSurrogate(_pending[length - 1]))
+            length--;
+
+        return length;
+    }
+}

--- a/src/transcript/TimelineRecords.cs
+++ b/src/transcript/TimelineRecords.cs
@@ -1,0 +1,96 @@
+namespace Hermes.Agent.Transcript;
+
+public sealed record ThreadRecord
+{
+    public required int SchemaVersion { get; init; }
+    public required string ThreadId { get; init; }
+    public required string SessionId { get; init; }
+    public required DateTime CreatedAt { get; init; }
+    public required DateTime UpdatedAt { get; init; }
+    public string Platform { get; init; } = "desktop";
+    public string? WorkspaceRoot { get; init; }
+    public string? Provider { get; init; }
+    public string? Model { get; init; }
+    public string? Title { get; init; }
+    public bool Archived { get; init; }
+    public string? ParentThreadId { get; init; }
+    public string? LatestTurnId { get; init; }
+}
+
+public sealed record TurnRecord
+{
+    public required int SchemaVersion { get; init; }
+    public required string TurnId { get; init; }
+    public required string ThreadId { get; init; }
+    public required int Sequence { get; init; }
+    public required TurnStatus Status { get; init; }
+    public required DateTime StartedAt { get; init; }
+    public DateTime? CompletedAt { get; init; }
+    public long? DurationMs { get; init; }
+    public required string InputSummary { get; init; }
+    public string? Error { get; init; }
+    public IReadOnlyDictionary<string, long> Usage { get; init; } = new Dictionary<string, long>();
+    public IReadOnlyList<string> ItemIds { get; init; } = Array.Empty<string>();
+}
+
+public sealed record TurnItemRecord
+{
+    public required int SchemaVersion { get; init; }
+    public required string ItemId { get; init; }
+    public required string TurnId { get; init; }
+    public required string ThreadId { get; init; }
+    public required int Sequence { get; init; }
+    public required TurnItemKind Kind { get; init; }
+    public string? Role { get; init; }
+    public required string ContentSummary { get; init; }
+    public int? MessageIndex { get; init; }
+    public string? MessageRef { get; init; }
+    public string? ToolCallId { get; init; }
+    public string? ToolName { get; init; }
+    public required TurnItemStatus Status { get; init; }
+    public string? ArtifactPath { get; init; }
+    public IReadOnlyDictionary<string, string> Metadata { get; init; } = new Dictionary<string, string>();
+    public required DateTime CreatedAt { get; init; }
+}
+
+public sealed record RuntimeEventRecord
+{
+    public required int SchemaVersion { get; init; }
+    public required long EventSequence { get; init; }
+    public required string ThreadId { get; init; }
+    public string? TurnId { get; init; }
+    public string? ItemId { get; init; }
+    public required string EventType { get; init; }
+    public required DateTime Timestamp { get; init; }
+    public IReadOnlyDictionary<string, string> Payload { get; init; } = new Dictionary<string, string>();
+}
+
+public enum TurnStatus
+{
+    Queued,
+    InProgress,
+    Completed,
+    Failed,
+    Interrupted,
+    Canceled
+}
+
+public enum TurnItemKind
+{
+    UserMessage,
+    AssistantMessage,
+    AgentReasoning,
+    ToolCall,
+    ToolResult,
+    Status,
+    Error
+}
+
+public enum TurnItemStatus
+{
+    Pending,
+    Running,
+    Completed,
+    Failed,
+    Canceled
+}

--- a/src/transcript/TimelineStore.cs
+++ b/src/transcript/TimelineStore.cs
@@ -1,0 +1,447 @@
+namespace Hermes.Agent.Transcript;
+
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Durable runtime timeline for threads, turns, turn items, and replay events.
+/// Kept separate from transcript JSONL so existing session listing stays clean.
+/// </summary>
+public sealed class TimelineStore
+{
+    private const int CurrentSchemaVersion = 1;
+
+    private readonly string _threadsDir;
+    private readonly string _turnsDir;
+    private readonly string _itemsDir;
+    private readonly string _eventsDir;
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+
+    public TimelineStore(string timelineRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(timelineRoot);
+
+        _threadsDir = Path.Combine(timelineRoot, "threads");
+        _turnsDir = Path.Combine(timelineRoot, "turns");
+        _itemsDir = Path.Combine(timelineRoot, "items");
+        _eventsDir = Path.Combine(timelineRoot, "events");
+
+        Directory.CreateDirectory(_threadsDir);
+        Directory.CreateDirectory(_turnsDir);
+        Directory.CreateDirectory(_itemsDir);
+        Directory.CreateDirectory(_eventsDir);
+    }
+
+    public async Task<ThreadRecord> GetOrCreateThreadAsync(
+        string sessionId,
+        string platform,
+        string? workspaceRoot,
+        string? provider,
+        string? model,
+        string? title,
+        CancellationToken ct)
+    {
+        await _writeLock.WaitAsync(ct);
+        try
+        {
+            return await GetOrCreateThreadNoLockAsync(sessionId, platform, workspaceRoot, provider, model, title, ct);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    public async Task<TurnRecord> StartTurnAsync(
+        string sessionId,
+        string platform,
+        string inputSummary,
+        string? workspaceRoot,
+        string? provider,
+        string? model,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(inputSummary);
+
+        await _writeLock.WaitAsync(ct);
+        try
+        {
+            var thread = await GetOrCreateThreadNoLockAsync(sessionId, platform, workspaceRoot, provider, model, inputSummary, ct);
+            var now = DateTime.UtcNow;
+            var turn = new TurnRecord
+            {
+                SchemaVersion = CurrentSchemaVersion,
+                TurnId = NewId("turn"),
+                ThreadId = thread.ThreadId,
+                Sequence = NextTurnSequenceNoLock(thread.ThreadId),
+                Status = TurnStatus.InProgress,
+                StartedAt = now,
+                InputSummary = Summarize(inputSummary)
+            };
+
+            await WriteJsonAtomicAsync(GetTurnPath(turn.TurnId), turn, ct);
+            await WriteJsonAtomicAsync(GetThreadPath(thread.ThreadId), thread with
+            {
+                UpdatedAt = now,
+                LatestTurnId = turn.TurnId,
+                Title = string.IsNullOrWhiteSpace(thread.Title) ? turn.InputSummary : thread.Title
+            }, ct);
+            await AppendEventNoLockAsync(thread.ThreadId, turn.TurnId, null, "turn_started", null, ct);
+            return turn;
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    public async Task<TurnItemRecord> AppendItemAsync(
+        string threadId,
+        string turnId,
+        TurnItemKind kind,
+        TurnItemStatus status,
+        string contentSummary,
+        string? role = null,
+        int? messageIndex = null,
+        string? messageRef = null,
+        string? toolCallId = null,
+        string? toolName = null,
+        string? artifactPath = null,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken ct = default)
+    {
+        await _writeLock.WaitAsync(ct);
+        try
+        {
+            var turn = await ReadJsonAsync<TurnRecord>(GetTurnPath(turnId), ct)
+                ?? throw new InvalidOperationException($"Turn '{turnId}' does not exist.");
+
+            var item = new TurnItemRecord
+            {
+                SchemaVersion = CurrentSchemaVersion,
+                ItemId = NewId("item"),
+                TurnId = turnId,
+                ThreadId = threadId,
+                Sequence = turn.ItemIds.Count + 1,
+                Kind = kind,
+                Role = role,
+                ContentSummary = Summarize(contentSummary),
+                MessageIndex = messageIndex,
+                MessageRef = messageRef,
+                ToolCallId = toolCallId,
+                ToolName = toolName,
+                Status = status,
+                ArtifactPath = artifactPath,
+                Metadata = metadata is null ? new Dictionary<string, string>() : new Dictionary<string, string>(metadata),
+                CreatedAt = DateTime.UtcNow
+            };
+
+            var itemIds = turn.ItemIds.ToList();
+            itemIds.Add(item.ItemId);
+
+            await WriteJsonAtomicAsync(GetItemPath(item.ItemId), item, ct);
+            await WriteJsonAtomicAsync(GetTurnPath(turnId), turn with { ItemIds = itemIds }, ct);
+            await TouchThreadNoLockAsync(threadId, ct);
+            await AppendEventNoLockAsync(threadId, turnId, item.ItemId, "item_appended", new Dictionary<string, string>
+            {
+                ["kind"] = kind.ToString(),
+                ["status"] = status.ToString()
+            }, ct);
+
+            return item;
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    public async Task CompleteTurnAsync(string threadId, string turnId, TurnStatus status, string? error, CancellationToken ct)
+    {
+        await _writeLock.WaitAsync(ct);
+        try
+        {
+            var path = GetTurnPath(turnId);
+            var turn = await ReadJsonAsync<TurnRecord>(path, ct);
+            if (turn is null)
+                return;
+
+            var completedAt = DateTime.UtcNow;
+            await WriteJsonAtomicAsync(path, turn with
+            {
+                Status = status,
+                CompletedAt = completedAt,
+                DurationMs = (long)(completedAt - turn.StartedAt).TotalMilliseconds,
+                Error = string.IsNullOrWhiteSpace(error) ? null : error
+            }, ct);
+
+            await TouchThreadNoLockAsync(threadId, ct, turnId);
+            await AppendEventNoLockAsync(threadId, turnId, null, "turn_completed", new Dictionary<string, string>
+            {
+                ["status"] = status.ToString()
+            }, ct);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    public async Task<ThreadRecord?> LoadThreadAsync(string threadId, CancellationToken ct) =>
+        await ReadJsonAsync<ThreadRecord>(GetThreadPath(threadId), ct);
+
+    public async Task<TurnRecord?> LoadTurnAsync(string turnId, CancellationToken ct) =>
+        await ReadJsonAsync<TurnRecord>(GetTurnPath(turnId), ct);
+
+    public async Task<TurnRecord?> LoadLatestTurnForThreadAsync(string threadId, CancellationToken ct)
+    {
+        var thread = await LoadThreadAsync(threadId, ct);
+        if (thread?.LatestTurnId is null)
+            return null;
+
+        return await LoadTurnAsync(thread.LatestTurnId, ct);
+    }
+
+    public async Task<IReadOnlyList<TurnItemRecord>> LoadTurnItemsAsync(string turnId, CancellationToken ct)
+    {
+        var turn = await LoadTurnAsync(turnId, ct);
+        if (turn is null)
+            return Array.Empty<TurnItemRecord>();
+
+        var items = new List<TurnItemRecord>();
+        foreach (var itemId in turn.ItemIds)
+        {
+            var item = await ReadJsonAsync<TurnItemRecord>(GetItemPath(itemId), ct);
+            if (item is not null)
+                items.Add(item);
+        }
+
+        return items;
+    }
+
+    public async Task<IReadOnlyList<ThreadRecord>> ListThreadsAsync(CancellationToken ct)
+    {
+        var threads = new List<ThreadRecord>();
+        foreach (var path in Directory.EnumerateFiles(_threadsDir, "*.json"))
+        {
+            ct.ThrowIfCancellationRequested();
+            var thread = await ReadJsonAsync<ThreadRecord>(path, ct);
+            if (thread is not null)
+                threads.Add(thread);
+        }
+
+        return threads.OrderByDescending(thread => thread.UpdatedAt).ToList();
+    }
+
+    public async Task<IReadOnlyList<RuntimeEventRecord>> LoadEventsAsync(string threadId, CancellationToken ct)
+    {
+        var path = GetEventPath(threadId);
+        if (!File.Exists(path))
+            return Array.Empty<RuntimeEventRecord>();
+
+        var events = new List<RuntimeEventRecord>();
+        var lines = await File.ReadAllLinesAsync(path, ct);
+        foreach (var line in lines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            try
+            {
+                var evt = JsonSerializer.Deserialize<RuntimeEventRecord>(line, JsonOptions);
+                if (evt is not null)
+                    events.Add(evt);
+            }
+            catch (JsonException)
+            {
+                // A corrupt event line should not make the whole timeline unreadable.
+            }
+        }
+
+        return events.OrderBy(evt => evt.EventSequence).ToList();
+    }
+
+    private async Task<ThreadRecord> GetOrCreateThreadNoLockAsync(
+        string sessionId,
+        string platform,
+        string? workspaceRoot,
+        string? provider,
+        string? model,
+        string? title,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(platform);
+
+        var path = GetThreadPath(sessionId);
+        var existing = await ReadJsonAsync<ThreadRecord>(path, ct);
+        if (existing is not null)
+            return existing;
+
+        var now = DateTime.UtcNow;
+        var thread = new ThreadRecord
+        {
+            SchemaVersion = CurrentSchemaVersion,
+            ThreadId = sessionId,
+            SessionId = sessionId,
+            Platform = platform,
+            WorkspaceRoot = workspaceRoot,
+            Provider = provider,
+            Model = model,
+            Title = Summarize(title),
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        await WriteJsonAtomicAsync(path, thread, ct);
+        await AppendEventNoLockAsync(thread.ThreadId, null, null, "thread_created", null, ct);
+        return thread;
+    }
+
+    private async Task TouchThreadNoLockAsync(string threadId, CancellationToken ct, string? latestTurnId = null)
+    {
+        var path = GetThreadPath(threadId);
+        var thread = await ReadJsonAsync<ThreadRecord>(path, ct);
+        if (thread is null)
+            return;
+
+        await WriteJsonAtomicAsync(path, thread with
+        {
+            UpdatedAt = DateTime.UtcNow,
+            LatestTurnId = latestTurnId ?? thread.LatestTurnId
+        }, ct);
+    }
+
+    private int NextTurnSequenceNoLock(string threadId)
+    {
+        var count = 0;
+        foreach (var path in Directory.EnumerateFiles(_turnsDir, "*.json"))
+        {
+            try
+            {
+                var json = File.ReadAllText(path);
+                using var doc = JsonDocument.Parse(json);
+                if (doc.RootElement.TryGetProperty("threadId", out var value) &&
+                    string.Equals(value.GetString(), threadId, StringComparison.Ordinal))
+                {
+                    count++;
+                }
+            }
+            catch (JsonException)
+            {
+            }
+        }
+
+        return count + 1;
+    }
+
+    private async Task AppendEventNoLockAsync(
+        string threadId,
+        string? turnId,
+        string? itemId,
+        string eventType,
+        IReadOnlyDictionary<string, string>? payload,
+        CancellationToken ct)
+    {
+        var path = GetEventPath(threadId);
+        var evt = new RuntimeEventRecord
+        {
+            SchemaVersion = CurrentSchemaVersion,
+            EventSequence = NextEventSequenceNoLock(path),
+            ThreadId = threadId,
+            TurnId = turnId,
+            ItemId = itemId,
+            EventType = eventType,
+            Timestamp = DateTime.UtcNow,
+            Payload = payload is null ? new Dictionary<string, string>() : new Dictionary<string, string>(payload)
+        };
+
+        var json = JsonSerializer.Serialize(evt, JsonOptions);
+        var bytes = Encoding.UTF8.GetBytes(json + "\n");
+        using var fs = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read, 4096, FileOptions.WriteThrough | FileOptions.SequentialScan);
+        await fs.WriteAsync(bytes, ct);
+        await fs.FlushAsync(ct);
+    }
+
+    private static long NextEventSequenceNoLock(string path)
+    {
+        if (!File.Exists(path))
+            return 1;
+
+        var count = 0L;
+        foreach (var line in File.ReadLines(path))
+        {
+            if (!string.IsNullOrWhiteSpace(line))
+                count++;
+        }
+
+        return count + 1;
+    }
+
+    private static async Task<T?> ReadJsonAsync<T>(string path, CancellationToken ct)
+    {
+        if (!File.Exists(path))
+            return default;
+
+        await using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        return await JsonSerializer.DeserializeAsync<T>(fs, JsonOptions, ct);
+    }
+
+    private static async Task WriteJsonAtomicAsync<T>(string path, T value, CancellationToken ct)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var temp = $"{path}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            await using (var fs = new FileStream(temp, FileMode.CreateNew, FileAccess.Write, FileShare.None, 4096, FileOptions.WriteThrough))
+            {
+                await JsonSerializer.SerializeAsync(fs, value, JsonOptions, ct);
+                await fs.FlushAsync(ct);
+            }
+
+            File.Move(temp, path, overwrite: true);
+        }
+        finally
+        {
+            if (File.Exists(temp))
+                File.Delete(temp);
+        }
+    }
+
+    private string GetThreadPath(string threadId) => Path.Combine(_threadsDir, $"{SafeFileName(threadId)}.json");
+    private string GetTurnPath(string turnId) => Path.Combine(_turnsDir, $"{SafeFileName(turnId)}.json");
+    private string GetItemPath(string itemId) => Path.Combine(_itemsDir, $"{SafeFileName(itemId)}.json");
+    private string GetEventPath(string threadId) => Path.Combine(_eventsDir, $"{SafeFileName(threadId)}.jsonl");
+
+    private static string NewId(string prefix)
+    {
+        var id = $"{prefix}_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}_{Guid.NewGuid():N}";
+        return id.Length <= 48 ? id : id[..48];
+    }
+
+    private static string Summarize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return string.Empty;
+
+        var normalized = value.Replace('\r', ' ').Replace('\n', ' ').Trim();
+        return normalized.Length <= 240 ? normalized : normalized[..237] + "...";
+    }
+
+    private static string SafeFileName(string value)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var builder = new StringBuilder(value.Length);
+        foreach (var ch in value)
+            builder.Append(invalid.Contains(ch) ? '_' : ch);
+        return builder.ToString();
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+        Converters = { new JsonStringEnumConverter() }
+    };
+}


### PR DESCRIPTION
## Summary
- add OpenManus/DeepSeek-TUI reference notes and concrete runtime improvements
- add planning tool, command registry, streaming accumulator, browser state reporting, large output routing, and post-edit diagnostics
- add durable timeline records for chat turns and tool lifecycle execution

## Verification
- dotnet test Desktop/HermesDesktop.Tests/HermesDesktop.Tests.csproj --no-restore
- dotnet build Desktop/HermesDesktop/HermesDesktop.csproj --no-restore -c Debug -p:Platform=x64

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `Agent` tool-execution flow and desktop streaming/rendering while introducing new durable timeline writes and output routing, so regressions could affect turn execution and message/tool ordering. Changes are mostly additive with tests covering key invariants, reducing but not eliminating risk.
> 
> **Overview**
> Introduces a **durable runtime timeline** (`TimelineStore` + `ThreadRecord`/`TurnRecord`/`TurnItemRecord`/events) and wires it into Desktop DI and `HermesChatService` so each send/stream creates a turn, appends user/assistant/error items, and completes the turn with status.
> 
> Refactors desktop streaming to a typed `ChatRuntimeEvent` stream (token/thinking/tool-status/error/completed), adapts `ChatPage` to consume it, and reduces UI churn by batching token updates via `StreamingTextAccumulator` (flushed on timers and stream end).
> 
> Extends the core `Agent` tool loop to (1) record tool-call lifecycle into the timeline (pending/running/result/denied), (2) route oversized *successful* tool outputs to on-disk artifacts with redacted head/tail summaries (`LargeToolOutputRouter`), and (3) optionally append post-edit diagnostics reports after file-mutating tools (`PostEditDiagnosticsHook`).
> 
> Adds new capabilities: a metadata-driven slash `CommandRegistry` for `/help`/`/new` handling, a `planning` tool for in-memory step tracking, and a `browser_state/state` action on `BrowserTool` to return compact URL/title/viewport/scroll and visible element refs. Includes extensive unit tests covering timeline persistence, tool lifecycle recording, output routing/redaction, diagnostics hook behavior, browser state formatting, and planning/command parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87a29b31505fb2f271e66fe9340aa81ff9d599e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->